### PR TITLE
Fix bulk action filter persistence

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -71,6 +71,8 @@
   <!-- Bulk Actions & Pagination -->
   {% if urls %}
   <form method="POST" action="/bulk_action" id="bulk-form">
+    <input type="hidden" name="q" value="{{ q }}" />
+    <input type="hidden" name="tag" value="{{ tag }}" />
     <!-- Bulk Actions Label -->
     <div style="margin-top:10px; font-weight:bold;">Bulk Actions</div>
     


### PR DESCRIPTION
## Summary
- persist query and tag filters when submitting bulk actions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684914bc49a0833280cea4d26e2b077e