### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ index.html displays:
 Import + fetch CDX forms
 Search/filter inputs
 Select all visible checks all results on the page
-Clear button unchecks all buttons and empties searh and tab boxes
+Clear button unchecks all buttons and empties search and tag boxes
 Pagination both top and bottom
 
 
@@ -92,7 +92,7 @@ Pagination both top and bottom
 
 ```bash
 pip install flask
-pythin init_db.py
+python init_db.py
 python app.py
 ```
 Then visit: http://127.0.0.1:5000


### PR DESCRIPTION
## Summary
- fix typos in the Known Good State and Running Local sections of README
- verify spelling via grep

## Testing
- `python -m py_compile app.py init_db.py`

------
https://chatgpt.com/codex/tasks/task_e_684917018e448332a59cdacc39dfd2cf