### PR TITLE
Fix pagination layout and divider

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -208,6 +208,9 @@ a:hover {
 .url-row-main td {
   font-size: 1.08em;
   padding: 0.43em 0.7em;
+}
+.url-row-buttons td {
+  padding: 0.43em 0.7em;
   border-bottom: 1px solid #e7e7c0;
 }
 .url-row-main input[type="checkbox"] {

--- a/templates/index.html
+++ b/templates/index.html
@@ -211,6 +211,14 @@
       <a href="?page={{ page + 1 }}&q={{ q }}&tag={{ tag }}">Next ▶</a>
       <a href="?page={{ total_pages }}&q={{ q }}&tag={{ tag }}">Last ⏭</a>
     {% endif %}
+    <!-- Jump to page form -->
+    <form style="display:inline; margin-left:1em;" onsubmit="return gotoPage(this);">
+      <input type="hidden" name="q" value="{{ q }}" />
+      <input type="hidden" name="tag" value="{{ tag }}" />
+      <input type="text" name="page" size="2" placeholder="Page" />
+      <button type="submit">Go</button>
+    </form>
+    <span class="total-count">Total: {{ total_count }}</span>
   </div>
   {% else %}
     <div style="margin:2em; color:#888; text-align:center;">No URLs found for this query.</div>


### PR DESCRIPTION
## Summary
- ensure pagination widgets match at top and bottom of the index page
- move table row divider to below the action buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849299bbefc8332960a4282f6f45898