### PR TITLE
Restore per-item delete and larger search UI

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -50,15 +50,24 @@ a:hover {
   border-radius: 8px;
   box-shadow: 0 1px 6px #eaeab0;
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5em;
+}
+
+/* Layout for form inside search bar */
+.search-bar form {
+  display: flex;
   align-items: center;
   gap: 0.5em;
+  width: 100%;
 }
 
 /* Search input */
 .search-bar input[type="text"] {
-  font-size: 1.05em;
-  padding: 3px 7px;
-  width: 180px;
+  font-size: 1.2em;
+  padding: 6px 10px;
+  width: 100%;
   border-radius: 5px;
   border: 1px solid #e7e7c0;
   background: #fffbe4;
@@ -67,8 +76,8 @@ a:hover {
 
 /* Buttons inside search bar */
 .search-bar button {
-  font-size: 1em;
-  padding: 3px 8px;
+  font-size: 1.1em;
+  padding: 6px 12px;
   border-radius: 5px;
   border: 1px solid #e7e7c0;
   background: #f8d970;
@@ -80,12 +89,17 @@ a:hover {
   background: #ffed93;
 }
 
+#quick-searches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+}
+
 /* Quick search buttons */
 #quick-searches button {
   background: #f3f3b3;
   border: 1px solid #e0c600;
   border-radius: 6px;
-  margin-right: 0.2em;
   font-size: 0.95em;
   padding: 2px 11px;
   margin-top: 0.2em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,11 +24,11 @@
     <!-- Search Bar -->
     <div class="search-bar">
       <form method="GET" action="/">
-        <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox"/>
+        <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" />
         <button type="submit">Search</button>
         <button type="button" onclick="document.getElementById('searchbox').value=''; this.form.submit();">Clear</button>
       </form>
-      <div id="quick-searches" style="margin-top:0.5em;">
+      <div id="quick-searches">
         <button type="button" onclick="quickSearch('.js.map')">.js.map</button>
         <button type="button" onclick="quickSearch('.php')">.php</button>
         <button type="button" onclick="quickSearch('.env')">.env</button>
@@ -166,6 +166,13 @@
               </form>
               {% endif %}
               <button class="explode-btn copy-btn" type="button" data-url="{{ url.url }}" title="Copy">📋</button>
+              <form method="POST" action="/bulk_action" style="display:inline;margin-right:0.3em;">
+                <input type="hidden" name="action" value="delete" />
+                <input type="hidden" name="selected_ids" value="{{ url.id }}" />
+                <input type="hidden" name="q" value="{{ q }}" />
+                <input type="hidden" name="tag" value="{{ tag }}" />
+                <button type="submit" class="delete-btn" title="Delete">🗑️</button>
+              </form>
               {% for tag in (url.tags or '').split(',') if tag %}
               <span class="tag-pill">{{ tag }}
                 <form method="POST" action="/bulk_action" style="display:inline;">


### PR DESCRIPTION
## Summary
- restore the `Delete` button to each result row
- enlarge search input and buttons and separate quick-search row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492c52c7f08332b56122a700c2bc97