### PR TITLE
Add DB management endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.zip
 *.sqlite
 *.json
+!demo_data.json
 uploads/

--- a/demo_data.json
+++ b/demo_data.json
@@ -1,0 +1,5 @@
+[
+  {"url": "https://example.com", "tags": "demo"},
+  {"url": "https://example.org/about", "tags": "demo"},
+  {"url": "https://test.com/home", "tags": ""}
+]

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,6 +53,21 @@
             </label>
             <button type="submit">Import</button>
           </form>
+          <!-- Load DB -->
+          <form method="POST" action="/load_db" enctype="multipart/form-data" style="margin-top:8px;">
+            <label>📂 Load DB:
+              <input type="file" name="db_file" required />
+            </label>
+            <button type="submit">Load</button>
+          </form>
+          <!-- Save DB -->
+          <form method="GET" action="/save_db" style="margin-top:8px;">
+            <button type="submit">💾 Save As</button>
+          </form>
+          <!-- New DB -->
+          <form method="POST" action="/new_db" style="margin-top:8px;">
+            <button type="submit">🆕 New DB</button>
+          </form>
         </div>
         <hr style="margin:8px 0;">
         <!-- Explode JS Map -->


### PR DESCRIPTION
## Summary
- add demo dataset and unignore it
- load demo DB on first run
- export/load/create new DB endpoints
- expose DB management forms in the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492df73bbc8332a11400351098b12c