### PR TITLE
Add status metadata to CDX import

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,10 @@ def init_db():
     CREATE TABLE IF NOT EXISTS urls (
         id   INTEGER PRIMARY KEY AUTOINCREMENT,
         url  TEXT UNIQUE NOT NULL,
+        domain TEXT,
+        timestamp TEXT,
+        status_code INTEGER,
+        mime_type TEXT,
         tags TEXT
     );
     """
@@ -120,7 +124,7 @@ def index():
 
     offset = (page - 1) * ITEMS_PER_PAGE
     select_sql = f"""
-        SELECT id, url, tags
+        SELECT id, url, timestamp, status_code, mime_type, tags
         FROM urls
         {where_sql}
         ORDER BY id DESC
@@ -151,7 +155,7 @@ def fetch_cdx():
 
     cdx_api = (
         'http://web.archive.org/cdx/search/cdx'
-        '?url={domain}/*&output=json&fl=original&collapse=urlkey'
+        '?url={domain}/*&output=json&fl=original,timestamp,statuscode,mimetype&collapse=urlkey'
     ).format(domain=domain)
 
     try:
@@ -167,6 +171,9 @@ def fetch_cdx():
         if idx == 0:
             continue
         original_url = row[0]
+        timestamp = row[1] if len(row) > 1 else None
+        status_code = int(row[2]) if len(row) > 2 and row[2] else None
+        mime_type = row[3] if len(row) > 3 else None
         existing = query_db(
             "SELECT id FROM urls WHERE url = ?",
             [original_url],
@@ -175,8 +182,8 @@ def fetch_cdx():
         if existing:
             continue
         execute_db(
-            "INSERT INTO urls (url, tags) VALUES (?, ?)",
-            [original_url, ""]
+            "INSERT INTO urls (url, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?)",
+            [original_url, timestamp, status_code, mime_type, ""]
         )
         inserted += 1
 
@@ -195,7 +202,13 @@ def _background_import(file_content):
                 records = [{"url": url, "tags": ""} for url in data]
             elif isinstance(data, list) and all(isinstance(item, dict) for item in data):
                 records = [
-                    {"url": rec.get('url', '').strip(), "tags": rec.get('tags', '').strip()}
+                    {
+                        "url": rec.get('url', '').strip(),
+                        "timestamp": rec.get('timestamp'),
+                        "status_code": rec.get('status_code'),
+                        "mime_type": rec.get('mime_type'),
+                        "tags": rec.get('tags', '').strip()
+                    }
                     for rec in data if rec.get('url', '').strip()
                 ]
         except Exception:
@@ -206,9 +219,14 @@ def _background_import(file_content):
                 try:
                     rec = json.loads(line)
                     url = rec.get('url', '').strip()
-                    tags = rec.get('tags', '').strip()
                     if url:
-                        records.append({"url": url, "tags": tags})
+                        records.append({
+                            "url": url,
+                            "timestamp": rec.get('timestamp'),
+                            "status_code": rec.get('status_code'),
+                            "mime_type": rec.get('mime_type'),
+                            "tags": rec.get('tags', '').strip()
+                        })
                 except Exception:
                     continue
 
@@ -219,7 +237,16 @@ def _background_import(file_content):
         inserted = 0
         for idx, rec in enumerate(records):
             try:
-                c.execute("INSERT OR IGNORE INTO urls (url, tags) VALUES (?, ?)", (rec['url'], rec['tags']))
+                c.execute(
+                    "INSERT OR IGNORE INTO urls (url, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?)",
+                    (
+                        rec['url'],
+                        rec.get('timestamp'),
+                        rec.get('status_code'),
+                        rec.get('mime_type'),
+                        rec['tags']
+                    )
+                )
             except Exception:
                 continue
             inserted += 1

--- a/init_db.py
+++ b/init_db.py
@@ -15,6 +15,9 @@ c.execute("""
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         url TEXT UNIQUE NOT NULL,
         domain TEXT,
+        timestamp TEXT,
+        status_code INTEGER,
+        mime_type TEXT,
         tags TEXT DEFAULT ''
     )
 """)

--- a/schema.sql
+++ b/schema.sql
@@ -2,6 +2,9 @@ CREATE TABLE IF NOT EXISTS urls (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     url TEXT UNIQUE NOT NULL,
     domain TEXT,
+    timestamp TEXT,
+    status_code INTEGER,
+    mime_type TEXT,
     tags TEXT DEFAULT ''
 );
 

--- a/static/wabax.css
+++ b/static/wabax.css
@@ -349,4 +349,10 @@ a:hover {
   background-color: #eaeaea;
 }
 
+/* Status code colors */
+.status-2 { color: blue; }
+.status-3 { color: green; }
+.status-4 { color: orange; }
+.status-5 { color: red; }
+
 /* --- End of update --- */

--- a/templates/index.html
+++ b/templates/index.html
@@ -137,6 +137,9 @@
             <input type="checkbox" id="select-all-rows" onchange="toggleSelectAllRows(this)" onclick="event.stopPropagation()" />
           </th>
           <th>URL</th>
+          <th>Timestamp</th>
+          <th>HTTP</th>
+          <th>MIME</th>
         </tr>
       </thead>
       <tbody>
@@ -146,12 +149,15 @@
             <input type="checkbox" class="row-checkbox" name="selected_ids" value="{{ url.id }}" onclick="event.stopPropagation()" />
           </td>
           <td>{{ url.url }}</td>
+          <td>{{ url.timestamp or '-' }}</td>
+          <td class="status {% if url.status_code %}status-{{ (url.status_code|string)[:1] }}{% endif %}">{{ url.status_code if url.status_code else '-' }}</td>
+          <td>{{ url.mime_type or '-' }}</td>
         </tr>
-        
+
         <!-- Buttons row: stay fixed -->
         <tr class="url-row-buttons">
           <td></td>
-          <td>
+          <td colspan="4">
             <div class="url-tools-row" style="white-space: nowrap;">
               <button class="explode-btn" type="button" title="Wayback" onclick="window.open('https://web.archive.org/web/*/{{ url.url }}','_blank')">⏳</button>
               <button class="explode-btn" type="button" title="Shodan" onclick="window.open('https://www.shodan.io/search?query={{ url.url|urlencode }}','_blank')">🤖</button>

--- a/tests/test_fetch_cdx.py
+++ b/tests/test_fetch_cdx.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+
+def test_fetch_cdx_inserts_status(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(app.app, 'config', {**app.app.config, 'DATABASE': str(db_path)})
+    app.init_db()
+
+    sample = [
+        ["original", "timestamp", "statuscode", "mimetype"],
+        ["http://example.com/", "20250101010101", "200", "text/html"]
+    ]
+    monkeypatch.setattr(app.requests, 'get', lambda *a, **k: FakeResponse(sample))
+
+    client = app.app.test_client()
+    client.post('/fetch_cdx', data={'domain': 'example.com'})
+
+    with app.app.app_context():
+        rows = app.query_db('SELECT url, timestamp, status_code, mime_type FROM urls')
+    assert len(rows) == 1
+    row = rows[0]
+    assert row['url'] == "http://example.com/"
+    assert row['timestamp'] == "20250101010101"
+    assert row['status_code'] == 200
+    assert row['mime_type'] == "text/html"


### PR DESCRIPTION
## Summary
- track timestamp, HTTP status, and MIME type in the database
- color HTTP status codes in results
- show new metadata columns in the UI
- extend CDX fetch and import logic to record new fields
- test CDX fetch with mocked API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492f6dd9bc8332ae52706384086b9c