### PR TITLE
Enable import auto refresh and custom db naming

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import sqlite3
 import zipfile
 import threading
 import requests
+import urllib.parse
 from flask import (
     Flask, g, render_template, request,
     redirect, url_for, flash, send_file, session, jsonify
@@ -480,10 +481,17 @@ def load_db_route():
 
 @app.route('/save_db', methods=['GET'])
 def save_db():
+    name = request.args.get('name', '').strip()
+    if name:
+        safe_name = urllib.parse.quote(name, safe='')
+        if not safe_name.lower().endswith('.db'):
+            safe_name += '.db'
+    else:
+        safe_name = os.path.basename(app.config['DATABASE'])
     return send_file(
         app.config['DATABASE'],
         as_attachment=True,
-        download_name=os.path.basename(app.config['DATABASE'])
+        download_name=safe_name
     )
 
 if __name__ == '__main__':

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,7 +61,7 @@
             <button type="submit">Load</button>
           </form>
           <!-- Save DB -->
-          <form method="GET" action="/save_db" style="margin-top:8px;">
+          <form method="GET" action="/save_db" style="margin-top:8px;" id="save-db-form">
             <button type="submit">💾 Save As</button>
           </form>
           <!-- New DB -->
@@ -351,6 +351,45 @@
         }
       });
     });
+
+    // Poll import progress and refresh when done
+    function pollImport() {
+      fetch('/import_progress')
+        .then(r => r.json())
+        .then(data => {
+          if (data.status && data.status !== 'idle') {
+            document.getElementById('import-status-block').style.display = 'block';
+            document.getElementById('import-status-text').textContent = data.detail || data.status;
+            if (data.total) {
+              const pct = Math.floor(data.progress / data.total * 100);
+              document.getElementById('import-progress-bar').style.width = pct + '%';
+              document.getElementById('import-progress-numbers-span').textContent = data.progress + '/' + data.total;
+            }
+            if (['done', 'failed'].includes(data.status)) {
+              setTimeout(() => { window.location.reload(); }, 1000);
+              return;
+            }
+          }
+          setTimeout(pollImport, 2000);
+        })
+        .catch(() => setTimeout(pollImport, 5000));
+    }
+    pollImport();
+
+    // Prompt for DB name on save
+    const saveForm = document.getElementById('save-db-form');
+    if (saveForm) {
+      saveForm.addEventListener('submit', function(e) {
+        if (!/name=/.test(this.action)) {
+          e.preventDefault();
+          const nm = prompt('Enter database name:', 'wabax');
+          if (nm) {
+            const enc = encodeURIComponent(nm.trim());
+            window.location = '/save_db?name=' + enc;
+          }
+        }
+      });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow user-specified download name for database
- poll import progress and auto-refresh when finished
- prompt for DB name when saving

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684931919d5c8332907b098693f98b57