### PR TITLE
Fix import progress refresh loop

### DIFF
--- a/app.py
+++ b/app.py
@@ -321,6 +321,8 @@ def import_json():
 @app.route('/import_progress', methods=['GET'])
 def import_progress():
     prog = get_import_progress()
+    if request.args.get('clear') == '1' and prog.get('status') in ('done', 'failed'):
+        clear_import_progress()
     # Always supply progress and total, and message for UI
     return jsonify({
         'status': prog.get('status', 'idle'),

--- a/templates/index.html
+++ b/templates/index.html
@@ -372,7 +372,9 @@
               document.getElementById('import-progress-numbers-span').textContent = data.progress + '/' + data.total;
             }
             if (['done', 'failed'].includes(data.status)) {
-              setTimeout(() => { window.location.reload(); }, 1000);
+              fetch('/import_progress?clear=1').then(() => {
+                setTimeout(() => { window.location.reload(); }, 1000);
+              });
               return;
             }
           }


### PR DESCRIPTION
## Summary
- prevent infinite page refresh while polling import progress
- clear progress in `/import_progress` once the status is finished

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493ce294ac8332a4220785e755f227