### PR TITLE
Stack search controls vertically

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -58,7 +58,8 @@ a:hover {
 /* Layout for form inside search bar */
 .search-bar form {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 0.5em;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- tweak search form layout so search input, search and clear buttons each appear on their own line

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68494057e7b483329aa6b7fc24bb1e4d