### PR TITLE
Stack search tags below search row

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -58,6 +58,7 @@ a:hover {
 /* Layout for form inside search bar */
 .search-bar form {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 0.5em;
   width: 100%;
@@ -67,11 +68,11 @@ a:hover {
 .search-bar input[type="text"] {
   font-size: 1.2em;
   padding: 6px 10px;
-  width: 100%;
   border-radius: 5px;
   border: 1px solid #e7e7c0;
   background: #fffbe4;
-  flex: 1;
+  flex: 2;
+  min-width: 0;
 }
 
 /* Buttons inside search bar */


### PR DESCRIPTION
## Summary
- keep search form controls in a single row
- enlarge search input so it's twice the width of the buttons
- keep quick search buttons on a new row under the form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68494057e7b483329aa6b7fc24bb1e4d