### PR TITLE
Align title next to menu dropdown

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -147,10 +147,21 @@ a:hover {
 
 /* Fixed menu placement */
 .menu-dropdown {
-  position: fixed;
-  top: 1em;
-  left: 1em;
-  z-index: 1000;
+  position: relative;
+}
+
+/* Header bar layout */
+.header-bar {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin: 1em;
+}
+
+.header-bar h1 {
+  margin: 0;
+  font-size: 1.8em;
+  text-align: left;
 }
 
 /* Bulk controls section with flex layout */

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,26 +6,15 @@
   <link rel="stylesheet" href="/static/wabax.css" />
 </head>
 <body>
-  <h1>hindsite <span style="font-size:0.7em; color:#666;">v1.0.0</span></h1>
-  <!-- Import Status Block -->
   <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
-  <div id="import-status-block" style="display:none;">
-    <strong>Import status:</strong>
-    <span id="import-status-text"></span>
-    <div id="import-progress-bar-container">
-      <div id="import-progress-bar"></div>
-    </div>
-    <div id="import-progress-numbers" style="margin-top:0.5em;">
-      <span id="import-progress-numbers-span"></span>
-    </div>
-  </div>
-  <!-- Menu Dropdown -->
-  <div class="dropdown menu-dropdown">
-    <button class="dropbtn" id="main-dropdown-btn">Menu ▼</button>
-    <div class="dropdown-content" id="main-dropdown-content">
-      <!-- Fetch Domain Form -->
-      <div>
-        <form method="POST" action="/fetch_cdx" style="margin-bottom:8px;">
+  <div class="header-bar">
+    <!-- Menu Dropdown -->
+    <div class="dropdown menu-dropdown">
+      <button class="dropbtn" id="main-dropdown-btn">Menu ▼</button>
+      <div class="dropdown-content" id="main-dropdown-content">
+        <!-- Fetch Domain Form -->
+        <div>
+          <form method="POST" action="/fetch_cdx" style="margin-bottom:8px;">
           <label>🌐 Domain:
             <input type="text" name="domain" placeholder="example.com" required style="width:120px;"/>
           </label>
@@ -94,6 +83,18 @@
           Select all matching
         </label>
       </div>
+    </div>
+    <h1>hindsite <span style="font-size:0.7em; color:#666;">v1.0.0</span></h1>
+  </div>
+  <!-- Import Status Block -->
+  <div id="import-status-block" style="display:none;">
+    <strong>Import status:</strong>
+    <span id="import-status-text"></span>
+    <div id="import-progress-bar-container">
+      <div id="import-progress-bar"></div>
+    </div>
+    <div id="import-progress-numbers" style="margin-top:0.5em;">
+      <span id="import-progress-numbers-span"></span>
     </div>
   </div>
   <!-- Control Section -->


### PR DESCRIPTION
## Summary
- place menu button and page title in a new flex `.header-bar`
- remove fixed positioning from the menu and style new header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849477ed2648332b71f6d287e6bca00