### PR TITLE
Align title next to menu dropdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -175,6 +175,13 @@ def index():
 
     current_theme = session.get('theme', AVAILABLE_THEMES[0] if AVAILABLE_THEMES else '')
 
+    search_history = session.get('search_history', [])
+    if q:
+        if q in search_history:
+            search_history.remove(q)
+        search_history.insert(0, q)
+        session['search_history'] = search_history[:10]
+
     return render_template(
         'index.html',
         urls=rows,
@@ -185,7 +192,8 @@ def index():
         themes=AVAILABLE_THEMES,
         current_theme=current_theme,
         total_count=total_count,
-        db_name=db_name
+        db_name=db_name,
+        search_history=search_history
     )
 
 @app.route('/fetch_cdx', methods=['POST'])

--- a/static/wabax.css
+++ b/static/wabax.css
@@ -147,10 +147,40 @@ a:hover {
 
 /* Fixed menu placement */
 .menu-dropdown {
-  position: fixed;
-  top: 1em;
-  left: 1em;
-  z-index: 1000;
+  position: relative;
+}
+
+/* Layout grid for header and search */
+.page-grid {
+  display: grid;
+  grid-template-columns: 270px 1fr;
+  gap: 1em;
+  align-items: start;
+  margin: 1em;
+}
+
+.page-grid h1 {
+  margin: 0;
+  font-size: 1.8em;
+  align-self: center;
+}
+
+.search-history table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 1px 6px #eaeab0;
+}
+
+.search-history th,
+.search-history td {
+  padding: 0.4em 0.6em;
+  border-bottom: 1px solid #e7e7c0;
+  text-align: left;
+}
+
+.search-history tbody tr:nth-child(even) {
+  background: #f8f8ff;
 }
 
 /* Bulk controls section with flex layout */

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,26 +6,14 @@
   <link rel="stylesheet" href="/static/wabax.css" />
 </head>
 <body>
-  <h1>hindsite <span style="font-size:0.7em; color:#666;">v1.0.0</span></h1>
-  <!-- Import Status Block -->
   <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
-  <div id="import-status-block" style="display:none;">
-    <strong>Import status:</strong>
-    <span id="import-status-text"></span>
-    <div id="import-progress-bar-container">
-      <div id="import-progress-bar"></div>
-    </div>
-    <div id="import-progress-numbers" style="margin-top:0.5em;">
-      <span id="import-progress-numbers-span"></span>
-    </div>
-  </div>
-  <!-- Menu Dropdown -->
-  <div class="dropdown menu-dropdown">
-    <button class="dropbtn" id="main-dropdown-btn">Menu ▼</button>
-    <div class="dropdown-content" id="main-dropdown-content">
-      <!-- Fetch Domain Form -->
-      <div>
-        <form method="POST" action="/fetch_cdx" style="margin-bottom:8px;">
+  <div class="page-grid">
+    <div class="dropdown menu-dropdown">
+      <button class="dropbtn" id="main-dropdown-btn">Menu ▼</button>
+      <div class="dropdown-content" id="main-dropdown-content">
+        <!-- Fetch Domain Form -->
+        <div>
+          <form method="POST" action="/fetch_cdx" style="margin-bottom:8px;">
           <label>🌐 Domain:
             <input type="text" name="domain" placeholder="example.com" required style="width:120px;"/>
           </label>
@@ -95,10 +83,7 @@
         </label>
       </div>
     </div>
-  </div>
-  <!-- Control Section -->
-  <div class="controls">
-    <!-- Search Bar -->
+    <h1>hindsite <span style="font-size:0.7em; color:#666;">v1.0.0</span></h1>
     <div class="search-bar">
       <form method="GET" action="/">
         <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" />
@@ -111,7 +96,31 @@
         <button type="button" onclick="quickSearch('.env')">.env</button>
       </div>
     </div>
+    <div class="search-history">
+      <table class="history-table">
+        <thead><tr><th>Search History</th></tr></thead>
+        <tbody>
+          {% for term in search_history %}
+          <tr><td><a href="?q={{ term|urlencode }}">{{ term }}</a></td></tr>
+          {% else %}
+          <tr><td style="color:#888;">No history</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
+  <!-- Import Status Block -->
+  <div id="import-status-block" style="display:none;">
+    <strong>Import status:</strong>
+    <span id="import-status-text"></span>
+    <div id="import-progress-bar-container">
+      <div id="import-progress-bar"></div>
+    </div>
+    <div id="import-progress-numbers" style="margin-top:0.5em;">
+      <span id="import-progress-numbers-span"></span>
+    </div>
+  </div>
+  <!-- Control Section removed: search bar now in page grid -->
 
   <!-- Bulk Actions & Pagination -->
   {% if urls %}


### PR DESCRIPTION
## Summary
- add two-column grid for menu/title and search/history
- keep search bar and new history table in shared layout
- persist recent search terms in session

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849477ed2648332b71f6d287e6bca00