### PR TITLE
Improve layout and pagination

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -34,12 +34,11 @@ a:hover {
 
 /* Controls section - aligned and spaced */
 .controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5em;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1em;
   align-items: flex-start;
-  justify-content: center;
-  margin-bottom: 1em;
+  margin: 1em;
 }
 
 /* Search bar container */
@@ -95,9 +94,15 @@ a:hover {
 }
 
 .search-history-box {
+  min-width: 270px;
+  padding: 0.7em;
+  background: #f8f8e0;
+  border-radius: 8px;
+  box-shadow: 0 1px 6px #eaeab0;
   display: flex;
   flex-direction: column;
-  gap: 0.3em;
+  align-items: flex-start;
+  gap: 0.5em;
 }
 
 .history-title {
@@ -174,13 +179,18 @@ a:hover {
 
 /* Header bar layout */
 .header-bar {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   align-items: center;
   gap: 1em;
   margin: 1em;
 }
+.header-bar .menu-dropdown {
+  justify-self: start;
+}
 
 .header-bar h1 {
+  justify-self: start;
   margin: 0;
   font-size: 1.8em;
   text-align: left;

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,16 +54,6 @@
         </form>
       </div>
       <hr style="margin:8px 0;">
-      <!-- Explode JS Map -->
-      <div>
-        <form method="POST" action="/tools/webpack-zip">
-          <label>🔍 Explode .js.map URL:
-            <input type="text" name="map_url" placeholder="https://example.com/file.js.map" required style="width:160px;" />
-          </label>
-          <button type="submit">Explode &amp; Download ZIP</button>
-        </form>
-      </div>
-      <hr style="margin:8px 0;">
       <!-- Bulk Actions -->
       <div style="font-weight:bold;">Bulk Actions</div>
       <div class="bulk-controls">
@@ -112,85 +102,6 @@
       <div class="history-title">Search history</div>
       <div id="search-history" class="search-history"></div>
     </div>
-    <!-- Menu Dropdown -->
-    <div class="dropdown" style="position: relative;">
-      <button class="dropbtn" id="main-dropdown-btn">Menu ▼</button>
-      <div class="dropdown-content" id="main-dropdown-content">
-        <!-- Fetch Domain Form -->
-        <div>
-          <form method="POST" action="/fetch_cdx" style="margin-bottom:8px;">
-            <label>🌐 Domain:
-              <input type="text" name="domain" placeholder="example.com" required style="width:120px;"/>
-            </label>
-            <button type="submit">Fetch</button>
-          </form>
-          <!-- Import JSON -->
-          <form method="POST" action="/import_json" enctype="multipart/form-data" id="import-form">
-            <label>📄 NDJSON:
-              <input type="file" name="json_file" required />
-            </label>
-            <button type="submit">Import</button>
-          </form>
-          <!-- Load DB -->
-          <form method="POST" action="/load_db" enctype="multipart/form-data" style="margin-top:8px;">
-            <label>📂 Load DB:
-              <input type="file" name="db_file" required />
-            </label>
-            <button type="submit">Load</button>
-          </form>
-          <div class="db-buttons">
-            <!-- Save DB -->
-            <form method="GET" action="/save_db" id="save-db-form">
-              <button type="submit">💾 Save As</button>
-            </form>
-            <!-- New DB -->
-            <form method="POST" action="/new_db">
-              <button type="submit">🆕 New DB</button>
-            </form>
-          </div>
-        </div>
-        <hr style="margin:8px 0;">
-        <!-- Explode JS Map -->
-        <div>
-          <form method="POST" action="/tools/webpack-zip">
-            <label>🔍 Explode .js.map URL:
-              <input type="text" name="map_url" placeholder="https://example.com/file.js.map" required style="width:160px;" />
-            </label>
-            <button type="submit">Explode &amp; Download ZIP</button>
-          </form>
-        </div>
-        <hr style="margin:8px 0;">
-        <!-- Explode JS Map -->
-        <div>
-          <form method="POST" action="/tools/webpack-zip">
-            <label>🔍 Explode .js.map URL:
-              <input type="text" name="map_url" placeholder="https://example.com/file.js.map" required style="width:160px;" />
-            </label>
-            <button type="submit">Explode &amp; Download ZIP</button>
-          </form>
-        </div>
-        <hr style="margin:8px 0;">
-        <!-- Bulk Actions -->
-        <div style="font-weight:bold;">Bulk Actions</div>
-        <div class="bulk-controls">
-          <select id="bulk-action-selector" name="action" form="bulk-form" onchange="adjustBulkAction();">
-            <option value="add_tag">➕🏷️ Add Tag Selected</option>
-            <option value="remove_tag">➖🏷️ Remove Tag Selected</option>
-            <option value="delete">✂🗑️ Delete Selected</option>
-          </select>
-          <input type="text" name="tag" id="bulk-tag-input" form="bulk-form" placeholder="Tag" />
-          <button type="submit" form="bulk-form">Apply</button>
-          <label class="select-all-label" style="margin-left:1em;">
-            <input type="checkbox" id="select-all-page" onclick="toggleSelectAllPage(this)">
-            Select all visible
-          </label>
-          <label class="select-all-label">
-            <input type="checkbox" id="select-all-matching" onclick="toggleSelectAllMatching(this)">
-            Select all matching
-          </label>
-        </div>
-      </div>
-    </div>
   </div>
 
   <!-- Bulk Actions & Pagination -->
@@ -205,10 +116,9 @@
       {% if page > 1 %}
         <a href="?page=1&q={{ q }}&tag={{ tag }}">⏮ First</a>
         <a href="?page={{ page - 1 }}&q={{ q }}&tag={{ tag }}">◀ Prev</a>
+        <a href="?page={{ page - 5 if page - 5 > 1 else 1 }}&q={{ q }}&tag={{ tag }}">« Prev 5</a>
       {% endif %}
-      {% set start = page - 3 if page - 3 >= 1 else 1 %}
-      {% set end = page + 3 if page + 3 <= total_pages else total_pages %}
-      {% for p in range(start, end + 1) %}
+      {% for p in range(1, total_pages + 1) %}
         {% if p == page %}
           <strong>{{ p }}</strong>
         {% else %}
@@ -217,6 +127,8 @@
       {% endfor %}
       {% if page < total_pages %}
         <a href="?page={{ page + 1 }}&q={{ q }}&tag={{ tag }}">Next ▶</a>
+        <a href="?page={{ page + 5 if page + 5 <= total_pages else total_pages }}&q={{ q }}&tag={{ tag }}">Next 5 »</a>
+        <a href="?page={{ total_pages - 4 if total_pages - 4 > 1 else 1 }}&q={{ q }}&tag={{ tag }}">Last 5</a>
         <a href="?page={{ total_pages }}&q={{ q }}&tag={{ tag }}">Last ⏭</a>
       {% endif %}
       <!-- Jump to page form -->
@@ -310,10 +222,9 @@
     {% if page > 1 %}
       <a href="?page=1&q={{ q }}&tag={{ tag }}">⏮ First</a>
       <a href="?page={{ page - 1 }}&q={{ q }}&tag={{ tag }}">◀ Prev</a>
+      <a href="?page={{ page - 5 if page - 5 > 1 else 1 }}&q={{ q }}&tag={{ tag }}">« Prev 5</a>
     {% endif %}
-    {% set start = page - 3 if page - 3 >= 1 else 1 %}
-    {% set end = page + 3 if page + 3 <= total_pages else total_pages %}
-    {% for p in range(start, end + 1) %}
+    {% for p in range(1, total_pages + 1) %}
       {% if p == page %}
         <strong>{{ p }}</strong>
       {% else %}
@@ -322,6 +233,8 @@
     {% endfor %}
     {% if page < total_pages %}
       <a href="?page={{ page + 1 }}&q={{ q }}&tag={{ tag }}">Next ▶</a>
+      <a href="?page={{ page + 5 if page + 5 <= total_pages else total_pages }}&q={{ q }}&tag={{ tag }}">Next 5 »</a>
+      <a href="?page={{ total_pages - 4 if total_pages - 4 > 1 else 1 }}&q={{ q }}&tag={{ tag }}">Last 5</a>
       <a href="?page={{ total_pages }}&q={{ q }}&tag={{ tag }}">Last ⏭</a>
     {% endif %}
     <!-- Jump to page form -->
@@ -488,7 +401,7 @@
     }
 
     function loadHistory(){
-      const defaults = ['.js.map','.php','.env'];
+      const defaults = ['.js.map','.php','.env','.zip','.rar','.svg','.docx'];
       let saved = [];
       try { saved = JSON.parse(localStorage.getItem('searchHistory') || '[]'); } catch(e){}
       const all = Array.from(new Set(defaults.concat(saved)));


### PR DESCRIPTION
## Summary
- clean up index.html to only use one menu dropdown
- lay out header and controls in a grid
- add extra quick-search buttons
- expand pagination links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684951edb048833289a67e58ded3a7ad