### PR TITLE
Fix layout readability and menu sizing

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -63,6 +63,19 @@ a:hover {
   width: 100%;
 }
 
+/* Row below search input containing history pills and buttons */
+.search-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.search-buttons {
+  display: flex;
+  gap: 0.5em;
+}
+
 /* Search input */
 .search-bar input[type="text"] {
   font-size: 1.2em;
@@ -118,10 +131,9 @@ a:hover {
 .search-history button {
   background: #f3f3b3;
   border: 1px solid #e0c600;
-  border-radius: 6px;
+  border-radius: 12px;
   font-size: 0.95em;
-  padding: 2px 11px;
-  margin-top: 0.2em;
+  padding: 2px 12px;
   cursor: pointer;
 }
 .search-history button:hover {
@@ -146,7 +158,7 @@ a:hover {
   background-color: #f8d970;
   color: #443300;
   padding: 8px 16px;
-  font-size: 1em;
+  font-size: 2.1em;
   border: 1px solid #e7e7c0;
   border-radius: 7px;
   cursor: pointer;
@@ -459,5 +471,12 @@ a:hover {
 .status-3 { color: green; }
 .status-4 { color: orange; }
 .status-5 { color: red; }
+
+/* Solid background for layout tables */
+#layout-a td,
+#layout-c td,
+#layout-d td {
+  background: #fffbe4;
+}
 
 /* --- End of update --- */

--- a/templates/index.html
+++ b/templates/index.html
@@ -124,28 +124,20 @@
             <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" style="width:95%;" />
           </td>
         </tr>
-        <tr>
-          <td style="text-align:right;">
-            <button type="button" id="save-tag-btn">Save Tag</button>
-            <button type="submit">Search</button>
-            <button type="button" onclick="document.getElementById('searchbox').value=''; document.getElementById('search-form').submit();">Clear</button>
-          </td>
-        </tr>
       </table>
+      <div class="search-actions">
+        <div id="search-history" class="search-history"></div>
+        <div class="search-buttons">
+          <button type="button" id="save-tag-btn">Save Tag</button>
+          <button type="submit">Search</button>
+          <button type="button" onclick="document.getElementById('searchbox').value=''; document.getElementById('search-form').submit();">Clear</button>
+        </div>
+      </div>
     </form>
   </div>
 
   <!-- Table C : Pagination and saved tags -->
   <table id="layout-c" style="width:100%; margin-top:1em;">
-    <tr>
-      <td style="width:50%;"></td>
-      <td rowspan="2" style="width:50%; vertical-align:top;">
-        <div class="search-history-box">
-          <div class="history-title">Search history</div>
-          <div id="search-history" class="search-history"></div>
-        </div>
-      </td>
-    </tr>
     <tr>
       <td style="text-align:left;">
         {{ render_pagination(page, total_pages, q, tag, total_count) }}


### PR DESCRIPTION
## Summary
- enlarge dropdown menu text to match header
- move search history pills below search box and style them like pills
- shift search action buttons into their own row
- add solid background for layout tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cea0d2d48332ab76cbfa3c34b5aa