### PR TITLE
Tweak dropdown and bulk actions layout

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -14,7 +14,7 @@ body {
 h1 {
   margin: 1.4em 0;
   text-align: center;
-  font-size: 2.1em;
+  font-size: 1.6em;
   letter-spacing: 0.04em;
   font-weight: bold;
   /* Add a subtle text-shadow for depth (optional) */
@@ -158,7 +158,7 @@ a:hover {
   background-color: #f8d970;
   color: #443300;
   padding: 8px 16px;
-  font-size: 2.1em;
+  font-size: 1.4em;
   border: 1px solid #e7e7c0;
   border-radius: 7px;
   cursor: pointer;
@@ -187,6 +187,24 @@ a:hover {
 /* Fixed menu placement */
 .menu-dropdown {
   position: relative;
+}
+
+/* Import controls layout */
+.import-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5em;
+}
+.import-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+.import-row input[type="text"],
+.import-row input[type="file"] {
+  flex: 1;
+  max-width: 160px;
 }
 
 /* Layout grid for header and search */
@@ -276,6 +294,13 @@ a:hover {
 }
 .bulk-controls button:hover {
   background: #ffed93;
+}
+
+/* Row for bulk action checkboxes */
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
 }
 
 /* Checkbox label */

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,20 +52,21 @@
         <div class="dropdown menu-dropdown">
           <button class="dropbtn" id="main-dropdown-btn">Menu ▼</button>
           <div class="dropdown-content" id="main-dropdown-content">
-            <div>
-              <form method="POST" action="/fetch_cdx" style="margin-bottom:8px;">
+            <div class="import-controls">
+              <div style="font-weight:bold;">Import Options</div>
+              <form class="import-row" method="POST" action="/fetch_cdx">
                 <label>⏳ Import from CDX API:
-                  <input type="text" name="domain" placeholder="example.com" required style="width:120px;" />
+                  <input type="text" name="domain" placeholder="example.com" required />
                 </label>
                 <button type="submit">Fetch</button>
               </form>
-              <form method="POST" action="/import_json" enctype="multipart/form-data" id="import-form">
+              <form class="import-row" method="POST" action="/import_json" enctype="multipart/form-data" id="import-form">
                 <label>📄 Import from JSON:
                   <input type="file" name="json_file" required />
                 </label>
                 <button type="submit">Import</button>
               </form>
-              <form method="POST" action="/load_db" enctype="multipart/form-data" style="margin-top:8px;">
+              <form class="import-row" method="POST" action="/load_db" enctype="multipart/form-data">
                 <label>📂 SQLite DB:
                   <input type="file" name="db_file" required />
                 </label>
@@ -96,14 +97,16 @@
                 <button type="submit" form="bulk-form" name="action" value="remove_tag" class="bulk-action-btn">➖🏷️ Remove Tag Selected</button>
                 <button type="submit" form="bulk-form" name="action" value="delete" class="bulk-action-btn">✂🗑️ Delete Selected</button>
                 <input type="text" name="tag" id="bulk-tag-input" form="bulk-form" placeholder="Tag" />
-                <label class="select-all-label" style="margin-left:1em;">
-                  <input type="checkbox" id="select-all-page" onclick="toggleSelectAllPage(this)">
-                  Select all visible
-                </label>
-                <label class="select-all-label">
-                  <input type="checkbox" id="select-all-matching" onclick="toggleSelectAllMatching(this)">
-                  Select all matching
-                </label>
+                <div class="checkbox-row">
+                  <label class="select-all-label" style="margin-left:1em;">
+                    <input type="checkbox" id="select-all-page" onclick="toggleSelectAllPage(this)">
+                    Select all visible
+                  </label>
+                  <label class="select-all-label">
+                    <input type="checkbox" id="select-all-matching" onclick="toggleSelectAllMatching(this)">
+                    Select all matching
+                  </label>
+                </div>
               </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reduce heading and dropdown button sizes
- add "Import Options" heading and align import forms
- rearrange bulk action checkboxes into their own row

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849dd5f04a48332a30d6e78e08b6d26