### PR TITLE
Add selectable background images

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,15 @@ if os.path.isdir(THEMES_DIR):
 else:
     AVAILABLE_THEMES = []
 
+BACKGROUNDS_DIR = os.path.join(app.root_path, 'static', 'img')
+if os.path.isdir(BACKGROUNDS_DIR):
+    AVAILABLE_BACKGROUNDS = sorted([
+        f for f in os.listdir(BACKGROUNDS_DIR)
+        if f.lower().endswith(('.png', '.jpg', '.jpeg'))
+    ])
+else:
+    AVAILABLE_BACKGROUNDS = []
+
 IMPORT_PROGRESS_FILE = os.path.join(app.root_path, 'import_progress.json')
 IMPORT_LOCK = threading.Lock()
 DEMO_DATA_FILE = os.path.join(app.root_path, 'demo_data.json')
@@ -176,6 +185,9 @@ def index():
     default_theme = 'theme-openai.css' if 'theme-openai.css' in AVAILABLE_THEMES else (AVAILABLE_THEMES[0] if AVAILABLE_THEMES else '')
     current_theme = session.get('theme', default_theme)
 
+    default_background = 'background.jpg' if 'background.jpg' in AVAILABLE_BACKGROUNDS else (AVAILABLE_BACKGROUNDS[0] if AVAILABLE_BACKGROUNDS else '')
+    current_background = session.get('background', default_background)
+
     search_history = session.get('search_history', [])
     if q:
         if q in search_history:
@@ -192,6 +204,8 @@ def index():
         tag=tag_filter,
         themes=AVAILABLE_THEMES,
         current_theme=current_theme,
+        backgrounds=AVAILABLE_BACKGROUNDS,
+        current_background=current_background,
         total_count=total_count,
         db_name=db_name,
         search_history=search_history
@@ -448,6 +462,15 @@ def set_theme():
     else:
         flash("Invalid theme selection.", "error")
     return redirect(url_for('index'))
+
+
+@app.route('/set_background', methods=['POST'])
+def set_background():
+    bg = request.form.get('background', '')
+    if bg in AVAILABLE_BACKGROUNDS:
+        session['background'] = bg
+        return ('', 204)
+    return ('Invalid background', 400)
 
 @app.route('/tools/webpack-zip', methods=['POST'])
 def webpack_zip():

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,11 @@
   {% if current_theme %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
   {% endif %}
+  {% if current_background %}
+  <style>
+    body { background-image: url('{{ url_for('static', filename='img/' + current_background) }}'); }
+  </style>
+  {% endif %}
 </head>
 <body>
   {% macro render_pagination(page, total_pages, q, tag, total_count) %}
@@ -113,7 +118,7 @@
               </div>
               <hr style="margin:8px 0;">
               <div style="font-weight:bold;">Themes</div>
-              <form method="POST" action="/set_theme" class="theme-row" style="margin-bottom:4px;">
+              <form method="POST" action="/set_theme" class="theme-row" style="margin-bottom:4px; display:inline-block;">
                 <select name="theme">
                   {% for t in themes %}
                   <option value="{{ t }}" {% if t == current_theme %}selected{% endif %}>{{ t.replace('theme-','').replace('.css','') }}</option>
@@ -121,6 +126,11 @@
                 </select>
                 <button type="submit">Apply</button>
               </form>
+              <select id="background-select" style="margin-left:4px;">
+                {% for bg in backgrounds %}
+                <option value="{{ bg }}" {% if bg == current_background %}selected{% endif %}>{{ bg }}</option>
+                {% endfor %}
+              </select>
               <label style="display:block;">
                 <input type="checkbox" id="bg-toggle" checked onchange="toggleBackground(this)">
                 Show background image
@@ -459,6 +469,19 @@
       } else {
         document.body.classList.add('bg-hidden');
       }
+    }
+
+    const bgSelect = document.getElementById('background-select');
+    if(bgSelect){
+      bgSelect.addEventListener('change', function(){
+        const bg = this.value;
+        document.body.style.backgroundImage = "url('/static/img/" + bg + "')";
+        fetch('/set_background', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'background=' + encodeURIComponent(bg)
+        });
+      });
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- allow choosing from local background images
- persist background choice in session and update dynamically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a002d4e308332846f6fbfb4a516c7