### PR TITLE
Add themed UI styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,24 @@ if os.path.isdir(THEMES_DIR):
 else:
     AVAILABLE_THEMES = []
 
+def _parse_theme_colors(filename):
+    bg = '#000000'
+    fg = '#ffffff'
+    try:
+        with open(os.path.join(THEMES_DIR, filename)) as fh:
+            for line in fh:
+                if '--bg-color' in line:
+                    bg = line.split(':')[1].strip().rstrip(';')
+                elif '--fg-color' in line:
+                    fg = line.split(':')[1].strip().rstrip(';')
+                if 'font-family' in line:
+                    break
+    except OSError:
+        pass
+    return bg, fg
+
+THEME_SWATCHES = {t: _parse_theme_colors(t) for t in AVAILABLE_THEMES}
+
 BACKGROUNDS_DIR = os.path.join(app.root_path, 'static', 'img')
 if os.path.isdir(BACKGROUNDS_DIR):
     AVAILABLE_BACKGROUNDS = sorted([
@@ -203,6 +221,7 @@ def index():
         q=q,
         tag=tag_filter,
         themes=AVAILABLE_THEMES,
+        theme_swatches=THEME_SWATCHES,
         current_theme=current_theme,
         backgrounds=AVAILABLE_BACKGROUNDS,
         current_background=current_background,

--- a/static/themes/theme-001.css
+++ b/static/themes/theme-001.css
@@ -1,6 +1,8 @@
 body {
-  background: #0d011e;
-  color: #ebebeb;
+  --bg-color: #0d011e;
+  --fg-color: #ebebeb;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-002.css
+++ b/static/themes/theme-002.css
@@ -1,6 +1,8 @@
 body {
-  background: #0d011e;
-  color: #cdcfd2;
+  --bg-color: #0d011e;
+  --fg-color: #cdcfd2;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-003.css
+++ b/static/themes/theme-003.css
@@ -1,6 +1,8 @@
 body {
-  background: #0d011e;
-  color: #b3ecff;
+  --bg-color: #0d011e;
+  --fg-color: #b3ecff;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-004.css
+++ b/static/themes/theme-004.css
@@ -1,6 +1,8 @@
 body {
-  background: #0d011e;
-  color: #ffffd8;
+  --bg-color: #0d011e;
+  --fg-color: #ffffd8;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-005.css
+++ b/static/themes/theme-005.css
@@ -1,6 +1,8 @@
 body {
-  background: #0d011e;
-  color: #ffffd8;
+  --bg-color: #0d011e;
+  --fg-color: #ffffd8;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-006.css
+++ b/static/themes/theme-006.css
@@ -1,6 +1,8 @@
 body {
-  background: #0d011e;
-  color: #8be9fd;
+  --bg-color: #0d011e;
+  --fg-color: #8be9fd;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-007.css
+++ b/static/themes/theme-007.css
@@ -1,6 +1,8 @@
 body {
-  background: #0d011e;
-  color: #62b9e5;
+  --bg-color: #0d011e;
+  --fg-color: #62b9e5;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-008.css
+++ b/static/themes/theme-008.css
@@ -1,6 +1,8 @@
 body {
-  background: #21222c;
-  color: #ffffff;
+  --bg-color: #21222c;
+  --fg-color: #ffffff;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-009.css
+++ b/static/themes/theme-009.css
@@ -1,6 +1,8 @@
 body {
-  background: #21222c;
-  color: #f8f8f2;
+  --bg-color: #21222c;
+  --fg-color: #f8f8f2;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-010.css
+++ b/static/themes/theme-010.css
@@ -1,6 +1,8 @@
 body {
-  background: #21222c;
-  color: #ebebeb;
+  --bg-color: #21222c;
+  --fg-color: #ebebeb;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-011.css
+++ b/static/themes/theme-011.css
@@ -1,6 +1,8 @@
 body {
-  background: #21222c;
-  color: #cdcfd2;
+  --bg-color: #21222c;
+  --fg-color: #cdcfd2;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-012.css
+++ b/static/themes/theme-012.css
@@ -1,6 +1,8 @@
 body {
-  background: #21222c;
-  color: #b3ecff;
+  --bg-color: #21222c;
+  --fg-color: #b3ecff;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-013.css
+++ b/static/themes/theme-013.css
@@ -1,6 +1,8 @@
 body {
-  background: #21222c;
-  color: #ffffd8;
+  --bg-color: #21222c;
+  --fg-color: #ffffd8;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-014.css
+++ b/static/themes/theme-014.css
@@ -1,6 +1,8 @@
 body {
-  background: #21222c;
-  color: #8be9fd;
+  --bg-color: #21222c;
+  --fg-color: #8be9fd;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-openai.css
+++ b/static/themes/theme-openai.css
@@ -1,7 +1,9 @@
 /* OpenAI-inspired light theme */
 body {
-  background: #f7f7f8;
-  color: #303030;
+  --bg-color: #f7f7f8;
+  --fg-color: #303030;
+  background: var(--bg-color);
+  color: var(--fg-color);
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
@@ -14,27 +16,30 @@ a {
 }
 
 .search-bar {
-  background: #ffffff;
-  border: 1px solid #dcdcdc;
+  background: var(--bg-color);
+  border: 1px solid var(--fg-color);
 }
 
 .search-bar input[type="text"] {
-  background: #ffffff;
-  border: 1px solid #cccccc;
+  background: var(--bg-color);
+  border: 1px solid var(--fg-color);
+  color: var(--fg-color);
 }
 
 .search-bar button {
-  background: #10a37f;
+  background: var(--fg-color);
   border: none;
-  color: #ffffff;
+  color: var(--bg-color);
 }
 .search-bar button:hover {
-  background: #0e8c6a;
+  opacity: 0.8;
 }
 
 .url-table th {
-  background: #ebebeb;
+  background: var(--fg-color);
+  color: var(--bg-color);
 }
 .url-table td {
-  background: #ffffff;
+  background: var(--bg-color);
+  color: var(--fg-color);
 }

--- a/static/wabax.css
+++ b/static/wabax.css
@@ -45,13 +45,14 @@ a:hover {
 .search-bar {
   min-width: 270px;
   padding: 0.7em;
-  background: #f8f8e0;
+  background: var(--bg-color);
   border-radius: 8px;
   box-shadow: 0 1px 6px #eaeab0;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 0.5em;
+  color: var(--fg-color);
 }
 
 /* Layout for form inside search bar */
@@ -81,8 +82,9 @@ a:hover {
   font-size: 1.2em;
   padding: 6px 10px;
   border-radius: 5px;
-  border: 1px solid #e7e7c0;
-  background: #fffbe4;
+  border: 1px solid var(--fg-color);
+  background: var(--bg-color);
+  color: var(--fg-color);
   flex: 2;
   min-width: 0;
 }
@@ -92,14 +94,14 @@ a:hover {
   font-size: 1.1em;
   padding: 6px 12px;
   border-radius: 5px;
-  border: 1px solid #e7e7c0;
-  background: #f8d970;
-  color: #443300;
+  border: 1px solid var(--fg-color);
+  background: var(--fg-color);
+  color: var(--bg-color);
   cursor: pointer;
-  transition: background 0.2s;
+  transition: opacity 0.2s;
 }
 .search-bar button:hover {
-  background: #ffed93;
+  opacity: 0.8;
 }
 
 #quick-searches {
@@ -155,30 +157,31 @@ a:hover {
   min-width: 225px;
 }
 .dropbtn {
-  background-color: #f8d970;
-  color: #443300;
+  background-color: var(--fg-color);
+  color: var(--bg-color);
   padding: 8px 16px;
   font-size: 1.4em;
-  border: 1px solid #e7e7c0;
+  border: 1px solid var(--fg-color);
   border-radius: 7px;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: opacity 0.2s;
 }
 .dropbtn:hover,
 .dropbtn:focus {
-  background-color: #fffbe4;
+  opacity: 0.8;
 }
 .dropdown-content {
   display: none;
   position: absolute;
-  background-color: #fffbe4;
+  background-color: var(--bg-color);
   min-width: 220px;
-  box-shadow: 0px 8px 20px #dac737;
+  box-shadow: 0px 8px 20px #00000033;
   z-index: 1;
   padding: 11px 17px;
   border-radius: 9px;
-  border: 1px solid #e7e7c0;
+  border: 1px solid var(--fg-color);
   margin-top: 8px;
+  color: var(--fg-color);
 }
 .dropdown.show .dropdown-content {
   display: block;
@@ -315,7 +318,7 @@ a:hover {
 .url-table {
   width: 100%;
   border-collapse: collapse;
-  background: #fff;
+  background: var(--bg-color);
   margin-bottom: 0.7em;
   box-shadow: 0 1px 8px #f3f3b3;
   font-family: "Segoe UI", "Arial", sans-serif;
@@ -323,7 +326,8 @@ a:hover {
 
 /* Table header style */
 .url-table thead {
-  background: #f3f3b3;
+  background: var(--fg-color);
+  color: var(--bg-color);
 }
 .url-table th {
   font-weight: bold;
@@ -336,11 +340,11 @@ a:hover {
 /* Alternating row backgrounds for readability */
 .url-row-main:nth-child(4n),
 .url-row-buttons:nth-child(4n + 1) {
-  background: #f8f8ff;
+  background: var(--bg-color);
 }
 .url-row-main:nth-child(4n + 2),
 .url-row-buttons:nth-child(4n + 3) {
-  background: #f4f4e0;
+  background: var(--bg-color);
 }
 
 /* Main row: cursor pointer for entire row */
@@ -353,7 +357,7 @@ a:hover {
 }
 .url-row-buttons td {
   padding: 0.43em 0.7em;
-  border-bottom: 1px solid #e7e7c0;
+  border-bottom: 1px solid var(--fg-color);
 }
 .url-row-main input[type="checkbox"] {
   cursor: pointer;
@@ -370,12 +374,13 @@ a:hover {
 .tag-pill {
   display: inline-block;
   padding: 2px 8px;
-  background: #f3f3b3;
+  background: var(--fg-color);
   border-radius: 10px;
-  border: 1px solid #e0c600;
+  border: 1px solid var(--fg-color);
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
+  color: var(--bg-color);
 }
 .tag-pill form {
   display: inline;
@@ -383,14 +388,14 @@ a:hover {
 .tag-pill button {
   background: none;
   border: none;
-  color: #c80;
+  color: inherit;
   font-size: 1em;
   margin-left: 2px;
   cursor: pointer;
-  transition: color 0.2s;
+  transition: opacity 0.2s;
 }
 .tag-pill button:hover {
-  color: #a00;
+  opacity: 0.8;
 }
 
 /* Buttons in row actions */
@@ -403,17 +408,17 @@ a:hover {
 .github-btn,
 .google-btn,
 .crtsh-btn {
-  background: #fffbe4;
-  border: 1px solid #e7e7c0;
+  background: var(--fg-color);
+  border: 1px solid var(--fg-color);
   border-radius: 7px;
-  color: #222;
+  color: var(--bg-color);
   font-size: 1em;
   line-height: 1.15em;
   padding: 2px 11px;
   margin-left: 0.1em;
   margin-right: 0.1em;
   cursor: pointer;
-  transition: background 0.2s, color 0.2s, border-color 0.2s;
+  transition: opacity 0.2s;
 }
 .copy-btn:hover,
 .delete-btn:hover,
@@ -424,14 +429,12 @@ a:hover {
 .github-btn:hover,
 .google-btn:hover,
 .crtsh-btn:hover {
-  background: #fff1a3;
-  border-color: #dac737;
-  color: #222;
+  opacity: 0.8;
 }
 .copy-btn:active,
 .delete-btn:active,
 .explode-btn:active {
-  background: #ffe270;
+  opacity: 0.6;
 }
 
 /* Pagination styling */
@@ -501,7 +504,8 @@ a:hover {
 #layout-a td,
 #layout-c td,
 #layout-d td {
-  background: #fffbe4;
+  background: var(--bg-color);
+  color: var(--fg-color);
 }
 
 /* --- End of update --- */

--- a/templates/index.html
+++ b/templates/index.html
@@ -121,7 +121,10 @@
               <form method="POST" action="/set_theme" class="theme-row" style="margin-bottom:4px; display:inline-block;">
                 <select name="theme">
                   {% for t in themes %}
-                  <option value="{{ t }}" {% if t == current_theme %}selected{% endif %}>{{ t.replace('theme-','').replace('.css','') }}</option>
+                  {% set cols = theme_swatches.get(t) %}
+                  <option value="{{ t }}" style="background: {{ cols[0] }}; color: {{ cols[1] }};" {% if t == current_theme %}selected{% endif %}>
+                    {{ t.replace('theme-','').replace('.css','') }}
+                  </option>
                   {% endfor %}
                 </select>
                 <button type="submit">Apply</button>
@@ -447,9 +450,10 @@
       });
     }
 
-    // Apply solid background and alignments on the URL results table
+    // Apply theme colors on the URL results table
     document.querySelectorAll('.url-table tr').forEach(tr => {
-      tr.style.backgroundColor = '#ffffff';
+      tr.style.backgroundColor = 'var(--bg-color)';
+      tr.style.color = 'var(--fg-color)';
     });
     document.querySelectorAll('.url-table tbody tr').forEach(tr => {
       const cells = tr.querySelectorAll('td');


### PR DESCRIPTION
## Summary
- theme CSS now exposes `--bg-color` and `--fg-color` variables
- calculate theme swatch colors server-side and show in theme picker
- use theme variables in UI styles so menu, search bar and tables follow the selected theme
- adjust javascript to apply themed colors to the results table

## Testing
- `pip install flask requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a08aa58cc83329b29a21d1d2358a7