### PR TITLE
Improve theme support for tag pills

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -53,6 +53,7 @@ a:hover {
   align-items: flex-start;
   gap: 0.5em;
   color: var(--fg-color);
+  margin: 1em;
 }
 
 /* Layout for form inside search bar */
@@ -91,8 +92,8 @@ a:hover {
 
 /* Buttons inside search bar */
 .search-bar button {
-  font-size: 1.1em;
-  padding: 6px 12px;
+  font-size: 1.05em;
+  padding: 5px 10px;
   border-radius: 5px;
   border: 1px solid var(--fg-color);
   background: var(--fg-color);
@@ -131,15 +132,17 @@ a:hover {
   gap: 0.3em;
 }
 .search-history button {
-  background: #f3f3b3;
-  border: 1px solid #e0c600;
+  background: var(--fg-color);
+  border: 1px solid var(--fg-color);
+  color: var(--bg-color);
   border-radius: 12px;
   font-size: 0.95em;
   padding: 2px 12px;
   cursor: pointer;
+  transition: opacity 0.2s;
 }
 .search-history button:hover {
-  background: #e0e0b3;
+  opacity: 0.8;
 }
 
 .db-buttons {
@@ -159,8 +162,8 @@ a:hover {
 .dropbtn {
   background-color: var(--fg-color);
   color: var(--bg-color);
-  padding: 8px 16px;
-  font-size: 1.4em;
+  padding: 5px 10px;
+  font-size: 1.05em;
   border: 1px solid var(--fg-color);
   border-radius: 7px;
   cursor: pointer;
@@ -177,7 +180,7 @@ a:hover {
   min-width: 220px;
   box-shadow: 0px 8px 20px #00000033;
   z-index: 1;
-  padding: 11px 17px;
+  padding: 8px 12px;
   border-radius: 9px;
   border: 1px solid var(--fg-color);
   margin-top: 8px;
@@ -320,7 +323,7 @@ a:hover {
   border-collapse: collapse;
   background: var(--bg-color);
   margin-bottom: 0.7em;
-  box-shadow: 0 1px 8px #f3f3b3;
+  box-shadow: 0 1px 8px var(--fg-color);
   font-family: "Segoe UI", "Arial", sans-serif;
 }
 


### PR DESCRIPTION
## Summary
- allow theme colors for search history pills
- tweak dropdown and search button sizes
- align search bar width with results
- replace hard-coded yellow from CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0c143e048332ab8b09c962bd196c