### PR TITLE
Fix menu styles for map input and bulk tags

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -217,6 +217,25 @@ a:hover {
   color: var(--fg-color);
   padding: 2px 6px;
 }
+/* Map URL input inside dropdown */
+#map-url-input {
+  max-width: 160px;
+  border: 1px solid var(--fg-color);
+  border-radius: 5px;
+  background: var(--bg-color);
+  color: var(--fg-color);
+  padding: 2px 6px;
+}
+/* Standalone exploder form input */
+#mapUrlInput {
+  flex: 1;
+  font-size: 1em;
+  border: 1px solid var(--fg-color);
+  border-radius: 5px;
+  background: var(--bg-color);
+  color: var(--fg-color);
+  padding: 0.5em;
+}
 
 /* Layout grid for header and search */
 .page-grid {
@@ -286,6 +305,15 @@ a:hover {
 }
 /* Tag input */
 .bulk-controls input[type="text"] {
+  font-size: 0.98em;
+  padding: 2px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--fg-color);
+  background: var(--bg-color);
+  color: var(--fg-color);
+}
+/* Specific bulk tag input */
+#bulk-tag-input {
   font-size: 0.98em;
   padding: 2px 8px;
   border-radius: 5px;

--- a/templates/_webpack_exploder_form.html
+++ b/templates/_webpack_exploder_form.html
@@ -16,13 +16,12 @@
       name="map_url"
       placeholder="https://example.com/static/js/app.js.map"
       required
-      style="flex: 1; padding: 0.5em; font-size: 1em;"
     />
 
     <!-- Explode (client-side listing) -->
-    <button type="button" id="explodeBtn">Explode</button>
+    <button type="button" id="explodeBtn" class="explode-btn">Explode</button>
     <!-- Download ZIP (server-side bundling) -->
-    <button type="submit">Download ZIP</button>
+    <button type="submit" class="explode-btn">Download ZIP</button>
   </form>
   <div id="exploder-results"></div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,11 +91,11 @@
             </div>
             <hr style="margin:8px 0;">
             <div>
-              <form method="POST" action="/tools/webpack-zip">
+              <form method="POST" action="/tools/webpack-zip" class="import-row">
                 <label>🔍 Explode .js.map URL:
-                  <input type="text" name="map_url" placeholder="https://example.com/file.js.map" required style="width:160px;" />
+                  <input type="text" name="map_url" id="map-url-input" placeholder="https://example.com/file.js.map" required />
                 </label>
-                <button type="submit">Explode &amp; Download ZIP</button>
+                <button type="submit" class="explode-btn">Explode &amp; Download ZIP</button>
               </form>
             </div>
             <hr style="margin:8px 0;">


### PR DESCRIPTION
## Summary
- add styling for the map URL input and bulk tag input
- apply same style to webpack exploder form buttons
- ensure dropdown webpack form uses `import-row` styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1dd4d8c08332b73bc17c86e0a8d1