### PR TITLE
Add retrorecon-root container

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -4,7 +4,7 @@
   --accent-color: #1b51a1;
 }
 
-.app {
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: "Segoe UI", Arial, sans-serif;
@@ -12,24 +12,20 @@
   padding: 0;
   line-height: 1.5;
 }
-
-.app h1,
-.app h2 {
+.retrorecon-root h1,
+.retrorecon-root h2 {
   margin: 1em 0;
   text-align: center;
   font-weight: bold;
 }
-
-.app a {
+.retrorecon-root a {
   color: var(--accent-color);
   text-decoration: none;
 }
-
-.app a:hover {
+.retrorecon-root a:hover {
   text-decoration: underline;
 }
-
-.app button {
+.retrorecon-root button {
   cursor: pointer;
 }
 

--- a/static/tools.css
+++ b/static/tools.css
@@ -1,5 +1,5 @@
 /* File: static/tools.css */
-.webpack-exploder-panel {
+.retrorecon-root .webpack-exploder-panel {
   padding: 1em;
   background: #fafafa;
   border: 1px solid #ccc;
@@ -7,20 +7,20 @@
   border-radius: 6px;
 }
 
-.webpack-exploder-panel h2 {
+.retrorecon-root .webpack-exploder-panel h2 {
   margin-top: 0;
   font-size: 1.2em;
   color: #333;
 }
 
-.webpack-exploder-panel form {
+.retrorecon-root .webpack-exploder-panel form {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5em;
   align-items: center;
 }
 
-.webpack-exploder-panel input[type="text"] {
+.retrorecon-root .webpack-exploder-panel input[type="text"] {
   flex: 1;
   padding: 0.5em;
   font-size: 1em;
@@ -28,7 +28,7 @@
   border-radius: 4px;
 }
 
-.webpack-exploder-panel button {
+.retrorecon-root .webpack-exploder-panel button {
   padding: 0.5em 1em;
   font-size: 1em;
   background-color: #f3f3f3;
@@ -36,11 +36,11 @@
   border-radius: 4px;
   cursor: pointer;
 }
-.webpack-exploder-panel button:hover {
+.retrorecon-root .webpack-exploder-panel button:hover {
   background-color: #e0e0e0;
 }
 
-#exploder-results {
+.retrorecon-root #exploder-results {
   margin-top: 1em;
   white-space: pre-wrap;
   font-family: monospace;

--- a/templates/fetching.html
+++ b/templates/fetching.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
 </head>
 <body class="app">
+  <div class="retrorecon-root">
   <h2>Fetching CDX Data...</h2>
   <img src="{{ url_for('static', filename='hourglass.gif') }}" class="spinner" width="64" height="64" />
   <p id="status">Working...</p>
@@ -26,5 +27,6 @@
     }
     poll();
   </script>
+  </div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
   </style>
 </head>
 <body class="app">
+  <div class="retrorecon-root">
   {% macro render_pagination(page, total_pages, q, tag, total_count) %}
   <div class="pagination mt-1">
     <span class="page-info">Displaying page {{ page }} of {{ total_pages }}</span>
@@ -499,5 +500,6 @@
       });
     }
   </script>
+  </div>
 </body>
 </html>

--- a/templates/indexBack.html
+++ b/templates/indexBack.html
@@ -190,6 +190,7 @@
   </style>
 </head>
 <body class="app">
+  <div class="retrorecon-root">
   <h1>🔎⏳📁 WABAX: Wayback Archive eXplorer 📁⏳🔎</h1>
 
   <!-- ===== CONTROLS ROW ===== -->
@@ -492,5 +493,6 @@
       WAYBAX: a yolosint production by thesavant42. Some rights reserved 2025.
     </a>
   </footer>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- scope markup under `.retrorecon-root`
- apply `.retrorecon-root` prefix in base and tools styles

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a3e5706088332950b13d855070b96