### PR TITLE
Add styling classes for form elements

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -64,3 +64,36 @@
 .fw-bold { font-weight: bold; }
 .version-text { font-size: 0.7em; color: #666; }
 .ml-01 { margin-left: 0.1em; }
+
+/* Generic form styles */
+.retrorecon-root .btn {
+  border: 1px solid var(--fg-color);
+  background: var(--fg-color);
+  color: var(--bg-color);
+  padding: 2px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.retrorecon-root .btn:hover {
+  opacity: 0.85;
+}
+
+.retrorecon-root .form-input,
+.retrorecon-root .form-file,
+.retrorecon-root .form-select {
+  border: 1px solid var(--fg-color);
+  border-radius: 5px;
+  background: var(--bg-color);
+  color: var(--fg-color);
+  padding: 2px 6px;
+}
+
+.retrorecon-root .form-label {
+  margin-right: 0.3em;
+  font-size: 0.96em;
+}
+
+.retrorecon-root .form-checkbox {
+  accent-color: var(--fg-color);
+}

--- a/templates/_webpack_exploder_form.html
+++ b/templates/_webpack_exploder_form.html
@@ -10,13 +10,14 @@
     action="{{ url_for('webpack_zip') }}"
     class="d-flex"
   >
-    <label for="mapUrlInput">.js.map URL:</label>
+    <label for="mapUrlInput" class="form-label">.js.map URL:</label>
     <input
       type="text"
       id="mapUrlInput"
       name="map_url"
       placeholder="https://example.com/static/js/app.js.map"
       required
+      class="form-input"
     />
 
     <!-- Explode (client-side listing) -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,8 +55,8 @@
     <form class="d-inline ml-1" onsubmit="return gotoPage(this);">
       <input type="hidden" name="q" value="{{ q }}" />
       <input type="hidden" name="tag" value="{{ tag }}" />
-      <input type="text" name="page" size="2" placeholder="Page" />
-      <button type="submit">Go</button>
+      <input type="text" name="page" size="2" placeholder="Page" class="form-input" />
+      <button type="submit" class="btn">Go</button>
     </form>
     <span class="total-count">Total: {{ total_count }}</span>
   </div>
@@ -73,37 +73,37 @@
             <div class="import-controls">
               <div class="fw-bold">Import Options</div>
               <form class="import-row" method="POST" action="/fetch_cdx">
-                <label>⏳ Import from CDX API:
-                  <input type="text" name="domain" placeholder="example.com" required />
+                <label class="form-label">⏳ Import from CDX API:
+                  <input type="text" name="domain" placeholder="example.com" required class="form-input" />
                 </label>
-                <button type="submit">Fetch</button>
+                <button type="submit" class="btn">Fetch</button>
               </form>
               <form class="import-row" method="POST" action="/import_json" enctype="multipart/form-data" id="import-form">
-                <label>📄 Import from JSON:
-                  <input type="file" name="json_file" required />
+                <label class="form-label">📄 Import from JSON:
+                  <input type="file" name="json_file" required class="form-file" />
                 </label>
-                <button type="submit">Import</button>
+                <button type="submit" class="btn">Import</button>
               </form>
               <form class="import-row" method="POST" action="/load_db" enctype="multipart/form-data">
-                <label>📂 SQLite DB:
-                  <input type="file" name="db_file" required />
+                <label class="form-label">📂 SQLite DB:
+                  <input type="file" name="db_file" required class="form-file" />
                 </label>
-                <button type="submit">Import</button>
+                <button type="submit" class="btn">Import</button>
               </form>
               <div class="mt-05">
                 <form method="GET" action="/save_db" id="save-db-form" class="d-inline">
-                  <button type="submit">💾 Save As</button>
+                  <button type="submit" class="btn">💾 Save As</button>
                 </form>
                 <form method="POST" action="/new_db" class="d-inline ml-4px">
-                  <button type="submit">🆕 New DB</button>
+                  <button type="submit" class="btn">🆕 New DB</button>
                 </form>
               </div>
             </div>
             <hr class="my-8px">
             <div>
               <form method="POST" action="/tools/webpack-zip" class="import-row">
-                <label>🔍 Explode .js.map URL:
-                  <input type="text" name="map_url" id="map-url-input" placeholder="https://example.com/file.js.map" required />
+                <label class="form-label">🔍 Explode .js.map URL:
+                  <input type="text" name="map_url" id="map-url-input" placeholder="https://example.com/file.js.map" required class="form-input" />
                 </label>
                 <button type="submit" class="explode-btn">Explode &amp; Download ZIP</button>
               </form>
@@ -114,14 +114,14 @@
                 <button type="submit" form="bulk-form" name="action" value="add_tag" class="bulk-action-btn">➕🏷️ Add Tag All Selected</button>
                 <button type="submit" form="bulk-form" name="action" value="remove_tag" class="bulk-action-btn">➖🏷️ Remove Tag Selected</button>
                 <button type="submit" form="bulk-form" name="action" value="delete" class="bulk-action-btn">✂🗑️ Delete Selected</button>
-                <input type="text" name="tag" id="bulk-tag-input" form="bulk-form" placeholder="Tag" />
+                <input type="text" name="tag" id="bulk-tag-input" form="bulk-form" placeholder="Tag" class="form-input" />
                 <div class="checkbox-row">
-                  <label class="select-all-label ml-1">
-                    <input type="checkbox" id="select-all-page" onclick="toggleSelectAllPage(this)">
+                  <label class="select-all-label ml-1 form-label">
+                    <input type="checkbox" id="select-all-page" onclick="toggleSelectAllPage(this)" class="form-checkbox">
                     Select all visible
                   </label>
-                  <label class="select-all-label">
-                    <input type="checkbox" id="select-all-matching" onclick="toggleSelectAllMatching(this)">
+                  <label class="select-all-label form-label">
+                    <input type="checkbox" id="select-all-matching" onclick="toggleSelectAllMatching(this)" class="form-checkbox">
                     Select all matching
                   </label>
                 </div>
@@ -129,7 +129,7 @@
               <hr class="my-8px">
               <div class="fw-bold">Themes</div>
               <form method="POST" action="/set_theme" class="theme-row mb-4px d-inline-block">
-                <select name="theme">
+                <select name="theme" class="form-select">
                   {% for t in themes %}
                   {% set cols = theme_swatches.get(t) %}
                   <option id="theme-opt-{{ loop.index }}" value="{{ t }}" {% if t == current_theme %}selected{% endif %}>
@@ -137,15 +137,15 @@
                   </option>
                   {% endfor %}
                 </select>
-                <button type="submit">Apply</button>
+                <button type="submit" class="btn">Apply</button>
               </form>
-              <select id="background-select" class="ml-4px">
+              <select id="background-select" class="ml-4px form-select">
                 {% for bg in backgrounds %}
                 <option value="{{ bg }}" {% if bg == current_background %}selected{% endif %}>{{ bg }}</option>
                 {% endfor %}
               </select>
-              <label class="d-block">
-                <input type="checkbox" id="bg-toggle" checked onchange="toggleBackground(this)">
+              <label class="d-block form-label">
+                <input type="checkbox" id="bg-toggle" checked onchange="toggleBackground(this)" class="form-checkbox">
                 Show background image
               </label>
           </div>
@@ -163,16 +163,16 @@
       <table class="w-100">
         <tr>
           <td class="text-center">
-            <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" class="w-95" />
+            <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" class="w-95 form-input" />
           </td>
         </tr>
       </table>
       <div class="search-actions">
         <div id="search-history" class="search-history"></div>
         <div class="search-buttons">
-          <button type="button" id="save-tag-btn">Save Tag</button>
-          <button type="submit">Search</button>
-          <button type="button" onclick="document.getElementById('searchbox').value=''; document.getElementById('search-form').submit();">Clear</button>
+          <button type="button" id="save-tag-btn" class="btn">Save Tag</button>
+          <button type="submit" class="btn">Search</button>
+          <button type="button" class="btn" onclick="document.getElementById('searchbox').value=''; document.getElementById('search-form').submit();">Clear</button>
         </div>
       </div>
     </form>
@@ -214,7 +214,7 @@
               <thead>
                 <tr>
                   <th class="w-2em">
-                    <input type="checkbox" id="select-all-rows" onchange="toggleSelectAllRows(this)" onclick="event.stopPropagation()" />
+                    <input type="checkbox" id="select-all-rows" onchange="toggleSelectAllRows(this)" onclick="event.stopPropagation()" class="form-checkbox" />
                   </th>
                   <th>URL</th>
                   <th>Timestamp</th>
@@ -265,15 +265,15 @@
                           <input type="hidden" name="action" value="remove_tag" />
                           <input type="hidden" name="tag" value="{{ tag }}" />
                           <input type="hidden" name="selected_ids" value="{{ url.id }}" />
-                          <button type="submit" title="Remove tag">&times;</button>
+                          <button type="submit" title="Remove tag" class="btn">&times;</button>
                         </form>
                       </span>
                       {% endfor %}
                       <form method="POST" action="/bulk_action" class="d-inline ml-05">
                         <input type="hidden" name="action" value="add_tag" />
                         <input type="hidden" name="selected_ids" value="{{ url.id }}" />
-                        <input type="text" name="tag" placeholder="Tag" size="8" required/>
-                        <button type="submit" title="Add tag">+</button>
+                        <input type="text" name="tag" placeholder="Tag" size="8" required class="form-input" />
+                        <button type="submit" title="Add tag" class="btn">+</button>
                       </form>
                     </div>
                   </td>

--- a/templates/indexBack.html
+++ b/templates/indexBack.html
@@ -198,8 +198,8 @@
     <!-- Search bar -->
     <div class="search-bar">
       <form method="GET" action="/">
-        <input type="text" name="q" placeholder="Search..." value="{{ q }}" />
-        <button type="submit">Search</button>
+        <input type="text" name="q" placeholder="Search..." value="{{ q }}" class="form-input" />
+        <button type="submit" class="btn">Search</button>
       </form>
     </div>
 
@@ -209,26 +209,26 @@
       <div class="dropdown-content" id="main-dropdown-content">
         <div>
           <form method="POST" action="/fetch_cdx" style="margin-bottom: 8px;">
-            <label>🌐 Domain:
-              <input type="text" name="domain" placeholder="example.com" required style="width:120px;"/>
+            <label class="form-label">🌐 Domain:
+              <input type="text" name="domain" placeholder="example.com" required style="width:120px;" class="form-input" />
             </label>
-            <button type="submit">Fetch</button>
+            <button type="submit" class="btn">Fetch</button>
           </form>
           <form method="POST" action="/import_json" enctype="multipart/form-data">
-            <label>📄 NDJSON:
-              <input type="file" name="json_file" required />
+            <label class="form-label">📄 NDJSON:
+              <input type="file" name="json_file" required class="form-file" />
             </label>
-            <button type="submit">Import</button>
+            <button type="submit" class="btn">Import</button>
           </form>
         </div>
         <hr style="margin:8px 0;">
         <!-- Webpack Exploder Form inside Dropdown -->
         <div>
           <form method="POST" action="/webpack_exploder" enctype="multipart/form-data">
-            <label>🔍 Explode JS/MSP URL:
-              <input type="text" name="js_url" placeholder="https://example.com/file.js.msp" required style="width:160px;" />
+            <label class="form-label">🔍 Explode JS/MSP URL:
+              <input type="text" name="js_url" placeholder="https://example.com/file.js.msp" required style="width:160px;" class="form-input" />
             </label>
-            <button type="submit">Explode &amp; Download ZIP</button>
+            <button type="submit" class="btn">Explode &amp; Download ZIP</button>
           </form>
         </div>
       </div>
@@ -262,17 +262,18 @@
 
   <form method="POST" action="/bulk_action">
     <div class="bulk-controls" style="margin-bottom: 1em;">
-      <select name="action">
+      <select name="action" class="form-select">
         <option value="add_tag" selected>Add Tag</option>
         <option value="remove_tag">Remove Tag</option>
         <option value="delete">Delete</option>
       </select>
-      <input type="text" name="tag" placeholder="Tag" />
-      <button type="submit">Apply</button>
-      <label>
+      <input type="text" name="tag" placeholder="Tag" class="form-input" />
+      <button type="submit" class="btn">Apply</button>
+      <label class="form-label">
         <input
           type="checkbox"
           onchange="toggleSelectAllMatching(this)"
+          class="form-checkbox"
         />Select all matching
       </label>
       <input type="hidden" name="q" value="{{ q }}" />
@@ -289,6 +290,7 @@
               type="checkbox"
               name="selected_ids"
               value="{{ url.id }}"
+              class="form-checkbox"
             />
             {% if url.url %}
             <a href="{{ url.url }}" target="_blank"


### PR DESCRIPTION
## Summary
- define reusable form classes in `static/base.css`
- apply styling classes to inputs, buttons, labels and selects in templates

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684a4a726cdc8332881abf4866c5dd2a