### PR TITLE
Style url tool buttons

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -494,14 +494,14 @@
 }
 
 /* Buttons in row actions */
-.copy-btn,
-.delete-btn,
-.explode-btn,
-.btn-wayback,
-.shodan-btn,
-.vt-btn,
-.github-btn,
-.google-btn,
+.retrorecon-root .copy-btn,
+.retrorecon-root .delete-btn,
+.retrorecon-root .explode-btn,
+.retrorecon-root .btn-wayback,
+.retrorecon-root .shodan-btn,
+.retrorecon-root .vt-btn,
+.retrorecon-root .github-btn,
+.retrorecon-root .google-btn,
 .retrorecon-root .crtsh-btn {
   background: var(--fg-color);
   border: 1px solid var(--fg-color);
@@ -515,25 +515,25 @@
   cursor: pointer;
   transition: opacity 0.2s;
 }
-.copy-btn:hover,
-.delete-btn:hover,
-.explode-btn:hover,
-.btn-wayback:hover,
-.shodan-btn:hover,
-.vt-btn:hover,
-.github-btn:hover,
-.google-btn:hover,
+.retrorecon-root .copy-btn:hover,
+.retrorecon-root .delete-btn:hover,
+.retrorecon-root .explode-btn:hover,
+.retrorecon-root .btn-wayback:hover,
+.retrorecon-root .shodan-btn:hover,
+.retrorecon-root .vt-btn:hover,
+.retrorecon-root .github-btn:hover,
+.retrorecon-root .google-btn:hover,
 .retrorecon-root .crtsh-btn:hover {
   opacity: 0.8;
 }
-.copy-btn:active,
-.delete-btn:active,
+.retrorecon-root .copy-btn:active,
+.retrorecon-root .delete-btn:active,
 .retrorecon-root .explode-btn:active {
   opacity: 0.6;
 }
 
 /* Disabled state for explode buttons */
-.disabled-btn,
+.retrorecon-root .disabled-btn,
 .retrorecon-root .explode-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/templates/_webpack_exploder_form.html
+++ b/templates/_webpack_exploder_form.html
@@ -20,9 +20,9 @@
     />
 
     <!-- Explode (client-side listing) -->
-    <button type="button" id="explodeBtn" class="explode-btn">Explode</button>
+    <button type="button" id="explodeBtn" class="btn explode-btn">Explode</button>
     <!-- Download ZIP (server-side bundling) -->
-    <button type="submit" class="explode-btn">Download ZIP</button>
+    <button type="submit" class="btn explode-btn">Download ZIP</button>
   </form>
   <div id="exploder-results"></div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -105,7 +105,7 @@
                 <label class="form-label">🔍 Explode .js.map URL:
                   <input type="text" name="map_url" id="map-url-input" placeholder="https://example.com/file.js.map" required class="form-input" />
                 </label>
-                <button type="submit" class="explode-btn">Explode &amp; Download ZIP</button>
+                <button type="submit" class="btn explode-btn">Explode &amp; Download ZIP</button>
               </form>
             </div>
             <hr class="my-8px">
@@ -237,27 +237,27 @@
                   <td></td>
                   <td colspan="4">
                     <div class="url-tools-row nowrap">
-                      <button class="explode-btn" type="button" title="Wayback" onclick="window.open('https://web.archive.org/web/*/{{ url.url }}','_blank')">⏳</button>
-                      <button class="explode-btn" type="button" title="Shodan" onclick="window.open('https://www.shodan.io/search?query={{ url.url|urlencode }}','_blank')">🤖</button>
-                      <button class="explode-btn" type="button" title="VirusTotal" onclick="window.open('https://www.virustotal.com/gui/search/{{ url.url|urlencode }}','_blank')">🦠</button>
-                      <button class="explode-btn" type="button" title="GitHub" onclick="window.open('https://github.com/search?q={{ url.url|urlencode }}','_blank')">🐙</button>
-                      <button class="explode-btn" type="button" title="Google" onclick="window.open('https://www.google.com/search?q=site:{{ url.url|urlencode }}','_blank')">🔍</button>
-                      <button class="explode-btn" type="button" title="crt.sh" onclick="window.open('https://crt.sh/?q={{ url.url|urlencode }}','_blank')">🔏</button>
-                      <button class="explode-btn copy-btn" type="button" data-url="{{ url.url }}" title="Copy">📋</button>
+                      <button class="btn explode-btn" type="button" title="Wayback" onclick="window.open('https://web.archive.org/web/*/{{ url.url }}','_blank')">⏳</button>
+                      <button class="btn explode-btn" type="button" title="Shodan" onclick="window.open('https://www.shodan.io/search?query={{ url.url|urlencode }}','_blank')">🤖</button>
+                      <button class="btn explode-btn" type="button" title="VirusTotal" onclick="window.open('https://www.virustotal.com/gui/search/{{ url.url|urlencode }}','_blank')">🦠</button>
+                      <button class="btn explode-btn" type="button" title="GitHub" onclick="window.open('https://github.com/search?q={{ url.url|urlencode }}','_blank')">🐙</button>
+                      <button class="btn explode-btn" type="button" title="Google" onclick="window.open('https://www.google.com/search?q=site:{{ url.url|urlencode }}','_blank')">🔍</button>
+                      <button class="btn explode-btn" type="button" title="crt.sh" onclick="window.open('https://crt.sh/?q={{ url.url|urlencode }}','_blank')">🔏</button>
+                      <button class="btn explode-btn copy-btn" type="button" data-url="{{ url.url }}" title="Copy">📋</button>
                       <form method="POST" action="/bulk_action" class="d-inline mr-03">
                         <input type="hidden" name="action" value="delete" />
                         <input type="hidden" name="selected_ids" value="{{ url.id }}" />
                         <input type="hidden" name="q" value="{{ q }}" />
                         <input type="hidden" name="tag" value="{{ tag }}" />
-                        <button type="submit" class="delete-btn" title="Delete">🗑️</button>
+                        <button type="submit" class="btn delete-btn" title="Delete">🗑️</button>
                       </form>
                       {% if ".js.map" in url.url %}
                       <form method="POST" action="/tools/webpack-zip" class="d-inline ml-01">
                         <input type="hidden" name="map_url" value="{{ url.url }}" />
-                        <button type="submit" class="explode-btn" title="Explode .js.map">💥 Explode!</button>
+                        <button type="submit" class="btn explode-btn" title="Explode .js.map">💥 Explode!</button>
                       </form>
                       {% else %}
-                      <button type="button" class="explode-btn disabled-btn" title="Not a .js.map" disabled>💥 Explode!</button>
+                      <button type="button" class="btn explode-btn disabled-btn" title="Not a .js.map" disabled>💥 Explode!</button>
                       {% endif %}
                       {% for tag in (url.tags or '').split(',') if tag %}
                       <span class="tag-pill">{{ tag }}


### PR DESCRIPTION
## Summary
- apply `.btn` style to action buttons under each URL
- scope action button selectors in CSS
- update Webpack exploder form buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684a56d8a5b4833289c74ad3755bc63e