### PR TITLE
Fix CSS scopes for bulk controls

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -372,7 +372,7 @@
   color: var(--fg-color);
 }
 /* Action buttons */
-.retrorecon-root .bulk-controls button {
+.retrorecon-root .bulk-action-btn {
   font-size: 1em;
   padding: 2px 11px;
   border-radius: 6px;
@@ -382,7 +382,7 @@
   cursor: pointer;
   transition: opacity 0.2s;
 }
-.retrorecon-root .bulk-controls button:hover {
+.retrorecon-root .bulk-action-btn:hover {
   opacity: 0.85;
 }
 
@@ -560,8 +560,8 @@
 }
 
 /* Generic theming for inputs and selects */
-input[type="text"],
-input[type="file"],
+.retrorecon-root input[type="text"],
+.retrorecon-root input[type="file"],
 .retrorecon-root select {
   border: 1px solid var(--fg-color);
   border-radius: 5px;

--- a/templates/indexBack.html
+++ b/templates/indexBack.html
@@ -139,8 +139,8 @@
       font-size: 0.96em;
       margin-right: 0.5em;
     }
-    .dropdown-content input[type="text"],
-    .dropdown-content input[type="file"] {
+    .retrorecon-root .dropdown-content input[type="text"],
+    .retrorecon-root .dropdown-content input[type="file"] {
       font-size: 0.96em;
       margin-left: 0.3em;
     }


### PR DESCRIPTION
## Summary
- scope bulk action button styles under `.retrorecon-root`
- scope generic `input[type="file"]` rule
- prefix dropdown file input rule in `indexBack.html`

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a5a97bc188332a4a9856645fbf44c