### PR TITLE
Fix bulk action CSS scope and labels

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -89,6 +89,15 @@
   padding: 2px 6px;
 }
 
+/* Ensure file inputs inherit base form styling */
+.retrorecon-root input[type="file"] {
+  border: 1px solid var(--fg-color);
+  border-radius: 5px;
+  background: var(--bg-color);
+  color: var(--fg-color);
+  padding: 2px 6px;
+}
+
 .retrorecon-root .form-label {
   margin-right: 0.3em;
   font-size: 0.96em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,9 +111,9 @@
             <hr class="my-8px">
               <div class="fw-bold">Bulk Actions</div>
               <div class="bulk-controls">
-                <button type="submit" form="bulk-form" name="action" value="add_tag" class="bulk-action-btn">➕🏷️ Add Tag All Selected</button>
-                <button type="submit" form="bulk-form" name="action" value="remove_tag" class="bulk-action-btn">➖🏷️ Remove Tag Selected</button>
-                <button type="submit" form="bulk-form" name="action" value="delete" class="bulk-action-btn">✂🗑️ Delete Selected</button>
+                <button type="submit" form="bulk-form" name="action" value="add_tag" class="bulk-action-btn">➕🏷️ Tag URLs</button>
+                <button type="submit" form="bulk-form" name="action" value="remove_tag" class="bulk-action-btn">➖🏷️ Rem Tags</button>
+                <button type="submit" form="bulk-form" name="action" value="delete" class="bulk-action-btn">✂🗑️ Del URLs</button>
                 <input type="text" name="tag" id="bulk-tag-input" form="bulk-form" placeholder="Tag" class="form-input" />
                 <div class="checkbox-row">
                   <label class="select-all-label ml-1 form-label">


### PR DESCRIPTION
## Summary
- scope file inputs in `base.css`
- shorten text on bulk action buttons

## Testing
- `pytest -q`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a5f7953d88332b4dd3dd7126070ad