### PR TITLE
Align CSS with style guide

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -29,41 +29,41 @@
   cursor: pointer;
 }
 
-.hidden { display: none; }
+.retrorecon-root .hidden { display: none; }
 
-.spinner {
+.retrorecon-root .spinner {
   animation: spin 2s linear infinite;
 }
 
 @keyframes spin { 100% { transform: rotate(360deg); } }
 
-.mt-1 { margin-top: 1em; }
-.mt-05 { margin-top: 0.5em; }
-.ml-1 { margin-left: 1em; }
-.ml-05 { margin-left: 0.5em; }
-.ml-4px { margin-left: 4px; }
-.mr-03 { margin-right: 0.3em; }
-.mb-4px { margin-bottom: 4px; }
-.m-2em { margin: 2em; }
-.my-8px { margin: 8px 0; }
-.w-100 { width: 100%; }
-.w-95 { width: 95%; }
-.w-2em { width: 2em; }
-.text-left { text-align: left; }
-.text-center { text-align: center; }
-.text-muted { color: #888; }
-.no-underline { text-decoration: none; }
-.d-inline { display: inline; }
-.d-inline-block { display: inline-block; }
-.d-block { display: block; }
-.d-flex { display: flex; }
-.flex-between { display: flex; justify-content: space-between; align-items: center; }
-.nowrap { white-space: nowrap; }
-.d-none { display: none; }
-.cursor-pointer { cursor: pointer; }
-.fw-bold { font-weight: bold; }
-.version-text { font-size: 0.7em; color: #666; }
-.ml-01 { margin-left: 0.1em; }
+.retrorecon-root .mt-1 { margin-top: 1em; }
+.retrorecon-root .mt-05 { margin-top: 0.5em; }
+.retrorecon-root .ml-1 { margin-left: 1em; }
+.retrorecon-root .ml-05 { margin-left: 0.5em; }
+.retrorecon-root .ml-4px { margin-left: 4px; }
+.retrorecon-root .mr-03 { margin-right: 0.3em; }
+.retrorecon-root .mb-4px { margin-bottom: 4px; }
+.retrorecon-root .m-2em { margin: 2em; }
+.retrorecon-root .my-8px { margin: 8px 0; }
+.retrorecon-root .w-100 { width: 100%; }
+.retrorecon-root .w-95 { width: 95%; }
+.retrorecon-root .w-2em { width: 2em; }
+.retrorecon-root .text-left { text-align: left; }
+.retrorecon-root .text-center { text-align: center; }
+.retrorecon-root .text-muted { color: #888; }
+.retrorecon-root .no-underline { text-decoration: none; }
+.retrorecon-root .d-inline { display: inline; }
+.retrorecon-root .d-inline-block { display: inline-block; }
+.retrorecon-root .d-block { display: block; }
+.retrorecon-root .d-flex { display: flex; }
+.retrorecon-root .flex-between { display: flex; justify-content: space-between; align-items: center; }
+.retrorecon-root .nowrap { white-space: nowrap; }
+.retrorecon-root .d-none { display: none; }
+.retrorecon-root .cursor-pointer { cursor: pointer; }
+.retrorecon-root .fw-bold { font-weight: bold; }
+.retrorecon-root .version-text { font-size: 0.7em; color: #666; }
+.retrorecon-root .ml-01 { margin-left: 0.1em; }
 
 /* Generic form styles */
 .retrorecon-root .btn {

--- a/static/themes/theme-001.css
+++ b/static/themes/theme-001.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #0d011e;
   --fg-color: #ebebeb;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-002.css
+++ b/static/themes/theme-002.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #0d011e;
   --fg-color: #cdcfd2;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-003.css
+++ b/static/themes/theme-003.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #0d011e;
   --fg-color: #b3ecff;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-004.css
+++ b/static/themes/theme-004.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #0d011e;
   --fg-color: #ffffd8;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-005.css
+++ b/static/themes/theme-005.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #0d011e;
   --fg-color: #ffffd8;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-006.css
+++ b/static/themes/theme-006.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #0d011e;
   --fg-color: #8be9fd;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-007.css
+++ b/static/themes/theme-007.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #0d011e;
   --fg-color: #62b9e5;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-008.css
+++ b/static/themes/theme-008.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #21222c;
   --fg-color: #ffffff;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-009.css
+++ b/static/themes/theme-009.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #21222c;
   --fg-color: #f8f8f2;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-010.css
+++ b/static/themes/theme-010.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #21222c;
   --fg-color: #ebebeb;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-011.css
+++ b/static/themes/theme-011.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #21222c;
   --fg-color: #cdcfd2;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-012.css
+++ b/static/themes/theme-012.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #21222c;
   --fg-color: #b3ecff;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-013.css
+++ b/static/themes/theme-013.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #21222c;
   --fg-color: #ffffd8;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-014.css
+++ b/static/themes/theme-014.css
@@ -1,8 +1,12 @@
-body {
+:root {
   --bg-color: #21222c;
   --fg-color: #8be9fd;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, sans-serif;
 }
+
 body.bg-hidden { background-image: none !important; }

--- a/static/themes/theme-openai.css
+++ b/static/themes/theme-openai.css
@@ -1,7 +1,10 @@
 /* OpenAI-inspired light theme */
-body {
+:root {
   --bg-color: #f7f7f8;
   --fg-color: #303030;
+}
+
+.retrorecon-root {
   background: var(--bg-color);
   color: var(--fg-color);
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;

--- a/static/wabax.css
+++ b/static/wabax.css
@@ -9,7 +9,7 @@
 
 /* --- Updated CSS to emulate Fandom Map Room style --- */
 
-.retrorecon-root body{
+.retrorecon-root {
   background: #f5f5ef url("/static/img/background.jpg") no-repeat center center fixed;
   background-size: cover;
   font-family: "Segoe UI", "Arial", sans-serif; /* Use system UI fonts for modern look */


### PR DESCRIPTION
## Summary
- scope generic utility classes under `.retrorecon-root`
- scope wabax layout styles to `.retrorecon-root`
- move theme colors into `:root` variables for override
- keep existing tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a661269008332b6dbce3bb72abfe7