### PR TITLE
Fix bulk action buttons style

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -375,15 +375,6 @@
 .retrorecon-root .bulk-action-btn {
   font-size: 1em;
   padding: 2px 11px;
-  border-radius: 6px;
-  border: 1px solid var(--fg-color);
-  background: var(--fg-color);
-  color: var(--bg-color);
-  cursor: pointer;
-  transition: opacity 0.2s;
-}
-.retrorecon-root .bulk-action-btn:hover {
-  opacity: 0.85;
 }
 
 /* Row for bulk action checkboxes */

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,9 +111,9 @@
             <hr class="my-8px">
               <div class="fw-bold">Bulk Actions</div>
               <div class="bulk-controls">
-                <button type="submit" form="bulk-form" name="action" value="add_tag" class="bulk-action-btn">➕🏷️ Tag URLs</button>
-                <button type="submit" form="bulk-form" name="action" value="remove_tag" class="bulk-action-btn">➖🏷️ Rem Tags</button>
-                <button type="submit" form="bulk-form" name="action" value="delete" class="bulk-action-btn">✂🗑️ Del URLs</button>
+                <button type="submit" form="bulk-form" name="action" value="add_tag" class="btn bulk-action-btn">➕🏷️ Tag URLs</button>
+                <button type="submit" form="bulk-form" name="action" value="remove_tag" class="btn bulk-action-btn">➖🏷️ Rem Tags</button>
+                <button type="submit" form="bulk-form" name="action" value="delete" class="btn bulk-action-btn">✂🗑️ Del URLs</button>
                 <input type="text" name="tag" id="bulk-tag-input" form="bulk-form" placeholder="Tag" class="form-input" />
                 <div class="checkbox-row">
                   <label class="select-all-label ml-1 form-label">


### PR DESCRIPTION
## Summary
- add `.btn` class to bulk action buttons
- rely on global `.btn` rules and keep only custom padding in `bulk-action-btn`

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a6ca04c0c8332a0da5bd1f081b0fd