### PR TITLE
Fix background not filling viewport

### DIFF
--- a/static/wabax.css
+++ b/static/wabax.css
@@ -14,6 +14,7 @@
   background-size: cover;
   font-family: "Segoe UI", "Arial", sans-serif; /* Use system UI fonts for modern look */
   margin: 0;
+  min-height: 100vh;
   padding: 0 0 4em 0;
   color: #23230a; /* Slightly softer text color for readability */
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- ensure the root container always fills the viewport so the background image covers the full page

## Testing
- `pytest -q`
- `wkhtmltoimage http://127.0.0.1:5000/ /tmp/page.png`


------
https://chatgpt.com/codex/tasks/task_e_684a6d57a7c88332be0a3c9e8fd30f7b