### PR TITLE
Fix background height

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -9,6 +9,7 @@
   color: var(--fg-color);
   font-family: "Segoe UI", Arial, sans-serif;
   margin: 0;
+  min-height: 100vh;
   padding: 0;
   line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
- fill the viewport by giving `.retrorecon-root` a `min-height`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a734bfa448332a7491d3f7ccb4547