### PR TITLE
Add neon dark theme

### DIFF
--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -1,0 +1,72 @@
+/* Neon midnight dark theme */
+:root {
+  --bg-main: #18192e;
+  --bg-panel: rgba(20, 18, 34, 0.92);
+  --font-main: #e1e9ff;
+  --font-accent: #8be9fd;
+  --border-color: rgba(139, 233, 253, 0.4);
+  --input-bg: rgba(34, 39, 50, 0.9);
+  --input-border: #8be9fd;
+
+  /* compatibility with base styles */
+  --bg-color: var(--bg-main);
+  --fg-color: var(--font-main);
+  --accent-color: var(--font-accent);
+}
+
+.retrorecon-root {
+  background: linear-gradient(180deg, #18192e 0%, #232344 100%);
+  color: var(--font-main);
+  font-family: 'Share Tech Mono', 'Consolas', monospace;
+}
+
+body.bg-hidden {
+  background-image: none !important;
+}
+
+.retrorecon-root .panel,
+.retrorecon-root .card,
+.retrorecon-root .table-container,
+.retrorecon-root .search-bar {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
+  box-shadow: 0 0 12px 2px rgba(139, 233, 253, 0.12);
+}
+
+.retrorecon-root .url-table th,
+.retrorecon-root .url-table td {
+  background: rgba(20, 18, 34, 0.80);
+  color: var(--font-main);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.retrorecon-root input,
+.retrorecon-root button,
+.retrorecon-root select,
+.retrorecon-root textarea {
+  background: var(--input-bg);
+  color: var(--font-main);
+  border: 1px solid var(--input-border);
+  border-radius: 4px;
+}
+
+.retrorecon-root input:focus,
+.retrorecon-root button:focus {
+  border-color: #fff;
+}
+
+.retrorecon-root a,
+.retrorecon-root .accent,
+.retrorecon-root .button {
+  color: var(--font-accent);
+  text-shadow: 0 0 8px var(--font-accent);
+}
+
+.retrorecon-root h1,
+.retrorecon-root h2,
+.retrorecon-root h3,
+.retrorecon-root .glow {
+  color: var(--font-accent);
+  text-shadow: 0 0 12px var(--font-accent), 0 0 24px #222;
+}


### PR DESCRIPTION
## Summary
- create `theme-neon.css` implementing a new dark color scheme with retro accents

## Testing
- `python audit_css.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8111498c83329020733b2bc2ea5d