### PR TITLE
Add CSS auditing script with HTML report

### DIFF
--- a/generate_style_report.py
+++ b/generate_style_report.py
@@ -1,0 +1,101 @@
+import os
+import cssutils
+from bs4 import BeautifulSoup
+
+# Silence cssutils warnings for cleaner output
+cssutils.log.setLevel('FATAL')
+
+# Collect :root variables from CSS
+
+def parse_root_vars(path):
+    vars = {}
+    sheet = cssutils.parseFile(path)
+    for rule in sheet:
+        if rule.type == rule.STYLE_RULE and rule.selectorText.strip() == ':root':
+            for prop in rule.style:
+                if prop.name.startswith('--'):
+                    vars[prop.name] = prop.value
+    return vars
+
+# Collect selectors with color-related properties
+
+def collect_color_rules(path):
+    results = []
+    sheet = cssutils.parseFile(path)
+    for rule in sheet:
+        if rule.type == rule.STYLE_RULE:
+            colors = {}
+            for prop in rule.style:
+                if prop.name in ('color', 'background', 'background-color'):
+                    colors[prop.name] = prop.value
+            if colors:
+                results.append({'file': path, 'selector': rule.selectorText, 'props': colors})
+    return results
+
+# Parse HTML to gather used tags
+
+def collect_tags(directory='templates'):
+    tags = {}
+    for root, _, files in os.walk(directory):
+        for f in files:
+            if f.endswith('.html'):
+                with open(os.path.join(root, f), 'r', encoding='utf-8') as fh:
+                    soup = BeautifulSoup(fh, 'html.parser')
+                for el in soup.find_all(True):
+                    tags[el.name] = tags.get(el.name, 0) + 1
+    return tags
+
+# Generate HTML report
+
+def main():
+    base_vars = parse_root_vars(os.path.join('static', 'base.css'))
+    theme_vars = {}
+    theme_dir = os.path.join('static', 'themes')
+    if os.path.isdir(theme_dir):
+        for f in sorted(os.listdir(theme_dir)):
+            if f.endswith('.css'):
+                theme_vars[f] = parse_root_vars(os.path.join(theme_dir, f))
+
+    color_rules = []
+    for root, _, files in os.walk('static'):
+        for f in files:
+            if f.endswith('.css'):
+                color_rules.extend(collect_color_rules(os.path.join(root, f)))
+
+    tags = collect_tags()
+
+    html = ["<html><head><meta charset='utf-8'>",
+            "<title>Style Report</title>",
+            "<style>table{border-collapse:collapse;}td,th{border:1px solid #ccc;padding:4px;} .swatch{width:40px;height:20px;display:inline-block;border:1px solid #000;}</style>",
+            "</head><body>"]
+
+    html.append("<h1>Base Variables</h1><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>")
+    for k,v in base_vars.items():
+        html.append(f"<tr><td>{k}</td><td>{v}</td><td><span class='swatch' style='background:{v}'></span></td></tr>")
+    html.append("</table>")
+
+    html.append("<h1>Theme Variables</h1>")
+    for theme, vars in theme_vars.items():
+        html.append(f"<h2>{theme}</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>")
+        for k,v in vars.items():
+            html.append(f"<tr><td>{k}</td><td>{v}</td><td><span class='swatch' style='background:{v}'></span></td></tr>")
+        html.append("</table>")
+
+    html.append("<h1>Used HTML Tags</h1><table><tr><th>Tag</th><th>Count</th></tr>")
+    for tag,count in sorted(tags.items()):
+        html.append(f"<tr><td>{tag}</td><td>{count}</td></tr>")
+    html.append("</table>")
+
+    html.append("<h1>Color Rules</h1><table><tr><th>File</th><th>Selector</th><th>Property</th><th>Value</th><th>Swatch</th></tr>")
+    for rule in color_rules:
+        for prop,val in rule['props'].items():
+            html.append(f"<tr><td>{rule['file']}</td><td>{rule['selector']}</td><td>{prop}</td><td>{val}</td><td><span class='swatch' style='{prop}:{val}'></span></td></tr>")
+    html.append("</table>")
+
+    html.append("</body></html>")
+
+    with open('style_report.html', 'w', encoding='utf-8') as fh:
+        fh.write('\n'.join(html))
+
+if __name__ == '__main__':
+    main()

--- a/style_report.html
+++ b/style_report.html
@@ -1,0 +1,229 @@
+<html><head><meta charset='utf-8'>
+<title>Style Report</title>
+<style>table{border-collapse:collapse;}td,th{border:1px solid #ccc;padding:4px;} .swatch{width:40px;height:20px;display:inline-block;border:1px solid #000;}</style>
+</head><body>
+<h1>Base Variables</h1><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#f5f5ef</td><td><span class='swatch' style='background:#f5f5ef'></span></td></tr>
+<tr><td>--fg-color</td><td>#23230a</td><td><span class='swatch' style='background:#23230a'></span></td></tr>
+<tr><td>--accent-color</td><td>#1b51a1</td><td><span class='swatch' style='background:#1b51a1'></span></td></tr>
+</table>
+<h1>Theme Variables</h1>
+<h2>theme-001.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#0d011e</td><td><span class='swatch' style='background:#0d011e'></span></td></tr>
+<tr><td>--fg-color</td><td>#ebebeb</td><td><span class='swatch' style='background:#ebebeb'></span></td></tr>
+</table>
+<h2>theme-002.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#0d011e</td><td><span class='swatch' style='background:#0d011e'></span></td></tr>
+<tr><td>--fg-color</td><td>#cdcfd2</td><td><span class='swatch' style='background:#cdcfd2'></span></td></tr>
+</table>
+<h2>theme-003.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#0d011e</td><td><span class='swatch' style='background:#0d011e'></span></td></tr>
+<tr><td>--fg-color</td><td>#b3ecff</td><td><span class='swatch' style='background:#b3ecff'></span></td></tr>
+</table>
+<h2>theme-006.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#0d011e</td><td><span class='swatch' style='background:#0d011e'></span></td></tr>
+<tr><td>--fg-color</td><td>#8be9fd</td><td><span class='swatch' style='background:#8be9fd'></span></td></tr>
+</table>
+<h2>theme-007.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#0d011e</td><td><span class='swatch' style='background:#0d011e'></span></td></tr>
+<tr><td>--fg-color</td><td>#62b9e5</td><td><span class='swatch' style='background:#62b9e5'></span></td></tr>
+</table>
+<h2>theme-008.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#21222c</td><td><span class='swatch' style='background:#21222c'></span></td></tr>
+<tr><td>--fg-color</td><td>#fff</td><td><span class='swatch' style='background:#fff'></span></td></tr>
+</table>
+<h2>theme-009.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#21222c</td><td><span class='swatch' style='background:#21222c'></span></td></tr>
+<tr><td>--fg-color</td><td>#f8f8f2</td><td><span class='swatch' style='background:#f8f8f2'></span></td></tr>
+</table>
+<h2>theme-010.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#21222c</td><td><span class='swatch' style='background:#21222c'></span></td></tr>
+<tr><td>--fg-color</td><td>#ebebeb</td><td><span class='swatch' style='background:#ebebeb'></span></td></tr>
+</table>
+<h2>theme-011.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#21222c</td><td><span class='swatch' style='background:#21222c'></span></td></tr>
+<tr><td>--fg-color</td><td>#cdcfd2</td><td><span class='swatch' style='background:#cdcfd2'></span></td></tr>
+</table>
+<h2>theme-012.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#21222c</td><td><span class='swatch' style='background:#21222c'></span></td></tr>
+<tr><td>--fg-color</td><td>#b3ecff</td><td><span class='swatch' style='background:#b3ecff'></span></td></tr>
+</table>
+<h2>theme-014.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#21222c</td><td><span class='swatch' style='background:#21222c'></span></td></tr>
+<tr><td>--fg-color</td><td>#8be9fd</td><td><span class='swatch' style='background:#8be9fd'></span></td></tr>
+</table>
+<h2>theme-neon.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-main</td><td>#18192e</td><td><span class='swatch' style='background:#18192e'></span></td></tr>
+<tr><td>--bg-panel</td><td>rgba(20, 18, 34, 0.92)</td><td><span class='swatch' style='background:rgba(20, 18, 34, 0.92)'></span></td></tr>
+<tr><td>--font-main</td><td>#e1e9ff</td><td><span class='swatch' style='background:#e1e9ff'></span></td></tr>
+<tr><td>--font-accent</td><td>#8be9fd</td><td><span class='swatch' style='background:#8be9fd'></span></td></tr>
+<tr><td>--border-color</td><td>rgba(139, 233, 253, 0.4)</td><td><span class='swatch' style='background:rgba(139, 233, 253, 0.4)'></span></td></tr>
+<tr><td>--input-bg</td><td>rgba(34, 39, 50, 0.9)</td><td><span class='swatch' style='background:rgba(34, 39, 50, 0.9)'></span></td></tr>
+<tr><td>--input-border</td><td>#8be9fd</td><td><span class='swatch' style='background:#8be9fd'></span></td></tr>
+<tr><td>--bg-color</td><td>var(--bg-main)</td><td><span class='swatch' style='background:var(--bg-main)'></span></td></tr>
+<tr><td>--fg-color</td><td>var(--font-main)</td><td><span class='swatch' style='background:var(--font-main)'></span></td></tr>
+<tr><td>--accent-color</td><td>var(--font-accent)</td><td><span class='swatch' style='background:var(--font-accent)'></span></td></tr>
+</table>
+<h2>theme-openai.css</h2><table><tr><th>Variable</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>--bg-color</td><td>#f7f7f8</td><td><span class='swatch' style='background:#f7f7f8'></span></td></tr>
+<tr><td>--fg-color</td><td>#303030</td><td><span class='swatch' style='background:#303030'></span></td></tr>
+</table>
+<h1>Used HTML Tags</h1><table><tr><th>Tag</th><th>Count</th></tr>
+<tr><td>a</td><td>8</td></tr>
+<tr><td>body</td><td>2</td></tr>
+<tr><td>button</td><td>29</td></tr>
+<tr><td>div</td><td>29</td></tr>
+<tr><td>form</td><td>15</td></tr>
+<tr><td>h1</td><td>1</td></tr>
+<tr><td>h2</td><td>2</td></tr>
+<tr><td>head</td><td>2</td></tr>
+<tr><td>hr</td><td>3</td></tr>
+<tr><td>html</td><td>2</td></tr>
+<tr><td>img</td><td>1</td></tr>
+<tr><td>input</td><td>29</td></tr>
+<tr><td>label</td><td>8</td></tr>
+<tr><td>link</td><td>5</td></tr>
+<tr><td>meta</td><td>1</td></tr>
+<tr><td>option</td><td>2</td></tr>
+<tr><td>p</td><td>1</td></tr>
+<tr><td>script</td><td>3</td></tr>
+<tr><td>select</td><td>2</td></tr>
+<tr><td>span</td><td>8</td></tr>
+<tr><td>strong</td><td>2</td></tr>
+<tr><td>style</td><td>2</td></tr>
+<tr><td>table</td><td>5</td></tr>
+<tr><td>tbody</td><td>1</td></tr>
+<tr><td>td</td><td>13</td></tr>
+<tr><td>th</td><td>5</td></tr>
+<tr><td>thead</td><td>1</td></tr>
+<tr><td>title</td><td>2</td></tr>
+<tr><td>tr</td><td>8</td></tr>
+</table>
+<h1>Color Rules</h1><table><tr><th>File</th><th>Selector</th><th>Property</th><th>Value</th><th>Swatch</th></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root a</td><td>color</td><td>var(--accent-color)</td><td><span class='swatch' style='color:var(--accent-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root .text-muted</td><td>color</td><td>#888</td><td><span class='swatch' style='color:#888'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root .version-text</td><td>color</td><td>#666</td><td><span class='swatch' style='color:#666'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root .btn</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root .btn</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root .form-input, .retrorecon-root .form-file, .retrorecon-root .form-select</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root .form-input, .retrorecon-root .form-file, .retrorecon-root .form-select</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root input[type="file"]</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/base.css</td><td>.retrorecon-root input[type="file"]</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root</td><td>background</td><td>#f5f5ef url(/static/img/background.jpg) no-repeat center center fixed</td><td><span class='swatch' style='background:#f5f5ef url(/static/img/background.jpg) no-repeat center center fixed'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root</td><td>color</td><td>#23230a</td><td><span class='swatch' style='color:#23230a'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root a</td><td>color</td><td>#1b51a1</td><td><span class='swatch' style='color:#1b51a1'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root a:hover</td><td>color</td><td>#0d3d80</td><td><span class='swatch' style='color:#0d3d80'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-bar</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-bar</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-bar input[type="text"]</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-bar input[type="text"]</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-bar button</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-bar button</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-history-box</td><td>background</td><td>#f8f8e0</td><td><span class='swatch' style='background:#f8f8e0'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-history button</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .search-history button</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .db-buttons button</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .db-buttons button</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .dropbtn</td><td>background-color</td><td>var(--fg-color)</td><td><span class='swatch' style='background-color:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .dropbtn</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .dropdown-content</td><td>background-color</td><td>var(--bg-color)</td><td><span class='swatch' style='background-color:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .dropdown-content</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .import-row input[type="text"], .retrorecon-root .import-row input[type="file"]</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .import-row input[type="text"], .retrorecon-root .import-row input[type="file"]</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .import-row button</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/wabax.css</td><td>.retrorecon-root .import-row button</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/tools.css</td><td>.retrorecon-root .webpack-exploder-panel</td><td>background</td><td>#fafafa</td><td><span class='swatch' style='background:#fafafa'></span></td></tr>
+<tr><td>static/tools.css</td><td>.retrorecon-root .webpack-exploder-panel h2</td><td>color</td><td>#333</td><td><span class='swatch' style='color:#333'></span></td></tr>
+<tr><td>static/tools.css</td><td>.retrorecon-root .webpack-exploder-panel button</td><td>background-color</td><td>#f3f3f3</td><td><span class='swatch' style='background-color:#f3f3f3'></span></td></tr>
+<tr><td>static/tools.css</td><td>.retrorecon-root .webpack-exploder-panel button:hover</td><td>background-color</td><td>#e0e0e0</td><td><span class='swatch' style='background-color:#e0e0e0'></span></td></tr>
+<tr><td>static/themes/theme-006.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-006.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-006.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-006.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-006.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-006.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-014.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-014.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-014.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-014.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-014.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-014.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root a</td><td>color</td><td>#10a37f</td><td><span class='swatch' style='color:#10a37f'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .search-bar</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .search-bar input[type="text"]</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .search-bar input[type="text"]</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .search-bar button</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .search-bar button</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .url-table th</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .url-table th</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .url-table td</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-openai.css</td><td>.retrorecon-root .url-table td</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-011.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-011.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-011.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-011.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-011.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-011.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root</td><td>background</td><td>linear-gradient(180deg, #18192e 0%, #232344 100%)</td><td><span class='swatch' style='background:linear-gradient(180deg, #18192e 0%, #232344 100%)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root</td><td>color</td><td>var(--font-main)</td><td><span class='swatch' style='color:var(--font-main)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root .panel, .retrorecon-root .card, .retrorecon-root .table-container, .retrorecon-root .search-bar</td><td>background</td><td>var(--bg-panel)</td><td><span class='swatch' style='background:var(--bg-panel)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root .url-table th, .retrorecon-root .url-table td</td><td>background</td><td>rgba(20, 18, 34, 0.8)</td><td><span class='swatch' style='background:rgba(20, 18, 34, 0.8)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root .url-table th, .retrorecon-root .url-table td</td><td>color</td><td>var(--font-main)</td><td><span class='swatch' style='color:var(--font-main)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root input, .retrorecon-root button, .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--input-bg)</td><td><span class='swatch' style='background:var(--input-bg)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root input, .retrorecon-root button, .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--font-main)</td><td><span class='swatch' style='color:var(--font-main)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root a, .retrorecon-root .accent, .retrorecon-root .button</td><td>color</td><td>var(--font-accent)</td><td><span class='swatch' style='color:var(--font-accent)'></span></td></tr>
+<tr><td>static/themes/theme-neon.css</td><td>.retrorecon-root h1, .retrorecon-root h2, .retrorecon-root h3, .retrorecon-root .glow</td><td>color</td><td>var(--font-accent)</td><td><span class='swatch' style='color:var(--font-accent)'></span></td></tr>
+<tr><td>static/themes/theme-002.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-002.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-002.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-002.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-002.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-002.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-001.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-001.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-001.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-001.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-001.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-001.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-003.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-003.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-003.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-003.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-003.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-003.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-008.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-008.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-008.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-008.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-008.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-008.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-007.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-007.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-007.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-007.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-007.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-007.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-012.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-012.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-012.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-012.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-012.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-012.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-010.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-010.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-010.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-010.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-010.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-010.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-009.css</td><td>.retrorecon-root</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-009.css</td><td>.retrorecon-root</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-009.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>background</td><td>var(--fg-color)</td><td><span class='swatch' style='background:var(--fg-color)'></span></td></tr>
+<tr><td>static/themes/theme-009.css</td><td>.retrorecon-root button, .retrorecon-root input[type="button"], .retrorecon-root input[type="submit"], .retrorecon-root input[type="reset"]</td><td>color</td><td>var(--bg-color)</td><td><span class='swatch' style='color:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-009.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>background</td><td>var(--bg-color)</td><td><span class='swatch' style='background:var(--bg-color)'></span></td></tr>
+<tr><td>static/themes/theme-009.css</td><td>.retrorecon-root input:not([type="button"]):not([type="submit"]):not([type="reset"]), .retrorecon-root select, .retrorecon-root textarea</td><td>color</td><td>var(--fg-color)</td><td><span class='swatch' style='color:var(--fg-color)'></span></td></tr>
+</table>
+</body></html>


### PR DESCRIPTION
## Summary
- create `generate_style_report.py` to scan CSS and HTML for style info
- output `style_report.html` with color swatches for base and themes

## Testing
- `pip install cssutils beautifulsoup4 requests Flask`
- `python generate_style_report.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b16a0e5f48332913755029486d499