### PR TITLE
Improve pagination styles and add SVG arrow icons

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -644,11 +644,7 @@
 
 /* Pagination styling */
 .retrorecon-root .pagination {
-    margin: 1em 0;
-    margin-top: 1em;
-    margin-right: 1em;
-    margin-bottom: 1em;
-    margin-left: 1em;
+    margin: 1em;
     border-radius: 4px;
     transition: background 0.2s;
     /* border: 1px solid var(--fg-color); */
@@ -659,6 +655,14 @@
     justify-content: center;
     align-items: center;
     text-align: center;
+    font-size: 1.2em;
+    gap: 0.6em;
+}
+.retrorecon-root .pagination a,
+.retrorecon-root .pagination strong,
+.retrorecon-root .pagination span,
+.retrorecon-root .pagination form {
+  margin: 0 0.2em;
 }
 .retrorecon-root .pagination a:hover {
   background: var(--bg-color);
@@ -670,7 +674,7 @@
   font-weight: bold;
 }
 .retrorecon-root .pagination .page-info {
-  margin-right: 0.5em;
+  margin-right: 1em;
 }
 .retrorecon-root .pagination input[type="text"] {
   width: 40px;
@@ -683,7 +687,18 @@
   color: var(--fg-color);
 }
 .retrorecon-root .pagination button {
-  margin-left: 0.2em;
+  margin-left: 0.5em;
+}
+
+.retrorecon-root .pagination-arrow {
+  display: inline-flex;
+  align-items: center;
+}
+
+.retrorecon-root .pagination .icon {
+  width: 1.4em;
+  height: 1.4em;
+  fill: var(--accent-color);
 }
 
 .retrorecon-root .search-bar button:hover{

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,8 +27,16 @@
   <div class="pagination mt-1">
     <span class="page-info">Displaying page {{ page }} of {{ total_pages }}</span>
     {% if page > 1 %}
-      <a href="?page=1&q={{ q }}&tag={{ tag }}">&#171;&#171;</a>
-      <a href="?page={{ page - 1 }}&q={{ q }}&tag={{ tag }}">&#171;</a>
+      <a href="?page=1&q={{ q }}&tag={{ tag }}" class="pagination-arrow" aria-label="First">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M16 4 L8 12 L16 20 Z M8 4 L8 20" />
+        </svg>
+      </a>
+      <a href="?page={{ page - 1 }}&q={{ q }}&tag={{ tag }}" class="pagination-arrow" aria-label="Prev">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M15 4 L7 12 L15 20 Z" />
+        </svg>
+      </a>
     {% endif %}
     {% set start = page - 2 if page - 2 > 2 else 1 %}
     {% set end = page + 2 if page + 2 < total_pages - 1 else total_pages %}
@@ -48,8 +56,16 @@
       <a href="?page={{ total_pages }}&q={{ q }}&tag={{ tag }}">{{ total_pages }}</a>
     {% endif %}
     {% if page < total_pages %}
-      <a href="?page={{ page + 1 }}&q={{ q }}&tag={{ tag }}">&#187;</a>
-      <a href="?page={{ total_pages }}&q={{ q }}&tag={{ tag }}">&#187;&#187;</a>
+      <a href="?page={{ page + 1 }}&q={{ q }}&tag={{ tag }}" class="pagination-arrow" aria-label="Next">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M9 4 L17 12 L9 20 Z" />
+        </svg>
+      </a>
+      <a href="?page={{ total_pages }}&q={{ q }}&tag={{ tag }}" class="pagination-arrow" aria-label="Last">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M8 4 L16 12 L8 20 Z M16 4 L24 12 L16 20 Z" />
+        </svg>
+      </a>
     {% endif %}
     <form class="d-inline ml-1" onsubmit="return gotoPage(this);">
       <input type="hidden" name="q" value="{{ q }}" />


### PR DESCRIPTION
## Summary
- style pagination arrows with inline SVG icons
- give pagination more spacing and larger font size
- align new icons with the accent color

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b710e9bc08332956ab2fd238cc7e4