### PR TITLE
Fix CDX import crash on hyphen status

### DIFF
--- a/app.py
+++ b/app.py
@@ -256,7 +256,11 @@ def fetch_cdx():
             continue
         original_url = row[0]
         timestamp = row[1] if len(row) > 1 else None
-        status_code = int(row[2]) if len(row) > 2 and row[2] else None
+        if len(row) > 2:
+            status_raw = str(row[2])
+            status_code = int(status_raw) if status_raw.isdigit() else None
+        else:
+            status_code = None
         mime_type = row[3] if len(row) > 3 else None
         existing = query_db(
             "SELECT id FROM urls WHERE url = ?",


### PR DESCRIPTION
## Summary
- handle non-numeric status codes in CDX import
- test dash status handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b872d3e288332a9bad60d16d6fc4d