### PR TITLE
Add table opacity slider and fix menu width

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,6 +206,8 @@ def index():
     default_background = 'background.jpg' if 'background.jpg' in AVAILABLE_BACKGROUNDS else (AVAILABLE_BACKGROUNDS[0] if AVAILABLE_BACKGROUNDS else '')
     current_background = session.get('background', default_background)
 
+    table_opacity = float(session.get('table_opacity', 1.0))
+
     search_history = session.get('search_history', [])
     if q:
         if q in search_history:
@@ -225,6 +227,7 @@ def index():
         current_theme=current_theme,
         backgrounds=AVAILABLE_BACKGROUNDS,
         current_background=current_background,
+        table_opacity=table_opacity,
         total_count=total_count,
         db_name=db_name,
         search_history=search_history
@@ -494,6 +497,17 @@ def set_background():
         session['background'] = bg
         return ('', 204)
     return ('Invalid background', 400)
+
+
+@app.route('/set_table_opacity', methods=['POST'])
+def set_table_opacity():
+    try:
+        opacity = float(request.form.get('opacity', '1'))
+    except ValueError:
+        return ('Invalid value', 400)
+    opacity = max(0.1, min(opacity, 1.0))
+    session['table_opacity'] = opacity
+    return ('', 204)
 
 @app.route('/tools/webpack-zip', methods=['POST'])
 def webpack_zip():

--- a/static/base.css
+++ b/static/base.css
@@ -2,6 +2,7 @@
   --bg-color: #0d011e75;
   --fg-color: #ffffff;
   --accent-color: #1ea1ff;
+  --table-opacity: 1;
 }
 
 .retrorecon-root h1,
@@ -69,6 +70,9 @@
   background: var(--bg-color);
   color: var(--fg-color);
   padding: 2px 6px;
+}
+.retrorecon-root .form-range {
+  width: 100%;
 }
 
 /* Ensure file inputs inherit base form styling */
@@ -314,7 +318,7 @@
     display: none;
     position: absolute;
     background-color: #0e0120fc;
-    min-width: 440px;
+  min-width: 340px;
     box-shadow: 0px 8px 20px #00000033;
     z-index: 1;
     padding: 8px 12px;
@@ -512,6 +516,7 @@
   width: 100%;
   border-collapse: collapse;
   background: var(--bg-color);
+  opacity: var(--table-opacity);
   margin-bottom: 0.7em;
   box-shadow: 0 1px 8px var(--fg-color);
   font-family: "Segoe UI", "Arial", sans-serif;
@@ -521,6 +526,7 @@
 .retrorecon-root .url-table thead {
   background: var(--fg-color);
   color: var(--bg-color);
+  opacity: var(--table-opacity);
 }
 .retrorecon-root .url-table th {
   font-weight: bold;
@@ -548,10 +554,12 @@
 .retrorecon-root .url-row-main:nth-child(4n),
 .retrorecon-root .url-row-buttons:nth-child(4n + 1) {
   background: var(--bg-color);
+  opacity: var(--table-opacity);
 }
 .retrorecon-root .url-row-main:nth-child(4n + 2),
 .retrorecon-root .url-row-buttons:nth-child(4n + 3) {
   background: var(--bg-color);
+  opacity: var(--table-opacity);
 }
 
 /* Main row: cursor pointer for entire row */
@@ -765,6 +773,7 @@
 .retrorecon-root #layout-d td {
   background: var(--bg-color);
   color: var(--fg-color);
+  opacity: var(--table-opacity);
 }
 
 /* --- End of update --- */

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,6 +167,10 @@
                   Show background image
                 </label>
               </div>
+              <div class="menu-row">
+                <label for="opacity-range" class="form-label menu-label">Table opacity:</label>
+                <input type="range" id="opacity-range" min="10" max="100" value="{{ int(table_opacity * 100) }}" class="form-range">
+              </div>
           </div>
         </div>
       </td>
@@ -517,6 +521,23 @@
           body: 'background=' + encodeURIComponent(bg)
         });
       });
+    }
+
+    const opacityRange = document.getElementById('opacity-range');
+    function updateOpacity(val){
+      const op = val / 100;
+      document.documentElement.style.setProperty('--table-opacity', op);
+      fetch('/set_table_opacity', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'opacity=' + op
+      });
+    }
+    if(opacityRange){
+      opacityRange.addEventListener('input', function(){
+        updateOpacity(this.value);
+      });
+      updateOpacity(opacityRange.value);
     }
   </script>
   </div>


### PR DESCRIPTION
## Summary
- add table opacity slider in the theme menu
- store opacity setting on the server and apply using CSS variable
- narrow dropdown menu width
- run npm linter and tests

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8a1d94548332a2b7e9c7f68f9a02