### PR TITLE
Fix theme panel opacity slider

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,7 +206,7 @@ def index():
     default_background = 'background.jpg' if 'background.jpg' in AVAILABLE_BACKGROUNDS else (AVAILABLE_BACKGROUNDS[0] if AVAILABLE_BACKGROUNDS else '')
     current_background = session.get('background', default_background)
 
-    table_opacity = float(session.get('table_opacity', 1.0))
+    panel_opacity = float(session.get('panel_opacity', 0.75))
 
     search_history = session.get('search_history', [])
     if q:
@@ -227,7 +227,7 @@ def index():
         current_theme=current_theme,
         backgrounds=AVAILABLE_BACKGROUNDS,
         current_background=current_background,
-        table_opacity=table_opacity,
+        panel_opacity=panel_opacity,
         total_count=total_count,
         db_name=db_name,
         search_history=search_history
@@ -499,14 +499,14 @@ def set_background():
     return ('Invalid background', 400)
 
 
-@app.route('/set_table_opacity', methods=['POST'])
-def set_table_opacity():
+@app.route('/set_panel_opacity', methods=['POST'])
+def set_panel_opacity():
     try:
         opacity = float(request.form.get('opacity', '1'))
     except ValueError:
         return ('Invalid value', 400)
     opacity = max(0.1, min(opacity, 1.0))
-    session['table_opacity'] = opacity
+    session['panel_opacity'] = opacity
     return ('', 204)
 
 @app.route('/tools/webpack-zip', methods=['POST'])

--- a/static/base.css
+++ b/static/base.css
@@ -1,8 +1,9 @@
 :root {
-  --bg-color: #0d011e75;
+  --bg-color: #0d011e;
+  --bg-rgb: 13 1 30;
   --fg-color: #ffffff;
   --accent-color: #1ea1ff;
-  --table-opacity: 1;
+  --panel-opacity: 0.75;
 }
 
 .retrorecon-root h1,
@@ -70,6 +71,11 @@
   background: var(--bg-color);
   color: var(--fg-color);
   padding: 2px 6px;
+}
+.retrorecon-root #theme-select,
+.retrorecon-root #background-select {
+  width: auto;
+  max-width: 180px;
 }
 .retrorecon-root .form-range {
   width: 100%;
@@ -515,8 +521,7 @@
 .retrorecon-root .url-table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--bg-color);
-  opacity: var(--table-opacity);
+  background: rgb(var(--bg-rgb) / var(--panel-opacity));
   margin-bottom: 0.7em;
   box-shadow: 0 1px 8px var(--fg-color);
   font-family: "Segoe UI", "Arial", sans-serif;
@@ -526,7 +531,7 @@
 .retrorecon-root .url-table thead {
   background: var(--fg-color);
   color: var(--bg-color);
-  opacity: var(--table-opacity);
+  opacity: var(--panel-opacity);
 }
 .retrorecon-root .url-table th {
   font-weight: bold;
@@ -553,13 +558,11 @@
 }
 .retrorecon-root .url-row-main:nth-child(4n),
 .retrorecon-root .url-row-buttons:nth-child(4n + 1) {
-  background: var(--bg-color);
-  opacity: var(--table-opacity);
+  background: rgb(var(--bg-rgb) / var(--panel-opacity));
 }
 .retrorecon-root .url-row-main:nth-child(4n + 2),
 .retrorecon-root .url-row-buttons:nth-child(4n + 3) {
-  background: var(--bg-color);
-  opacity: var(--table-opacity);
+  background: rgb(var(--bg-rgb) / var(--panel-opacity));
 }
 
 /* Main row: cursor pointer for entire row */
@@ -771,9 +774,8 @@
 .retrorecon-root #layout-a td,
 .retrorecon-root #layout-c td,
 .retrorecon-root #layout-d td {
-  background: var(--bg-color);
+  background: rgb(var(--bg-rgb) / var(--panel-opacity));
   color: var(--fg-color);
-  opacity: var(--table-opacity);
 }
 
 /* --- End of update --- */

--- a/static/themes/dev-theme-neon.css
+++ b/static/themes/dev-theme-neon.css
@@ -9,7 +9,9 @@
   --input-border: #8be9fd;
 
   /* compatibility with base styles */
-  --bg-color: var(--bg-main);
+  --bg-color: #141222;
+  --bg-rgb: 20 18 34;
+  --panel-opacity: 0.92;
   --fg-color: var(--font-main);
   --accent-color: var(--font-accent);
 }

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -9,7 +9,9 @@
   --input-border: #8be9fd;
 
   /* compatibility with base styles */
-  --bg-color: var(--bg-main);
+  --bg-color: #141222;
+  --bg-rgb: 20 18 34;
+  --panel-opacity: 0.92;
   --fg-color: var(--font-main);
   --accent-color: var(--font-accent);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -168,8 +168,8 @@
                 </label>
               </div>
               <div class="menu-row">
-                <label for="opacity-range" class="form-label menu-label">Table opacity:</label>
-                <input type="range" id="opacity-range" min="10" max="100" value="{{ (table_opacity * 100)|int }}" class="form-range">
+                <label for="opacity-range" class="form-label menu-label">Panel opacity:</label>
+                <input type="range" id="opacity-range" min="10" max="100" value="{{ (panel_opacity * 100)|int }}" class="form-range">
               </div>
           </div>
         </div>
@@ -526,8 +526,8 @@
     const opacityRange = document.getElementById('opacity-range');
     function updateOpacity(val){
       const op = val / 100;
-      document.documentElement.style.setProperty('--table-opacity', op);
-      fetch('/set_table_opacity', {
+      document.documentElement.style.setProperty('--panel-opacity', op);
+      fetch('/set_panel_opacity', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: 'opacity=' + op


### PR DESCRIPTION
## Summary
- allow adjusting panel opacity instead of text opacity
- shrink theme/background dropdown width
- add theme compat variables for panel opacity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9def9898833283dd94ad7df0ff4a