### PR TITLE
Show loaded database name

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,7 +198,7 @@ def index():
     """
     rows = query_db(select_sql, params + [ITEMS_PER_PAGE, offset])
 
-    db_name = os.path.basename(app.config['DATABASE'])
+    db_name = session.get('db_display_name') or os.path.basename(app.config['DATABASE'])
 
     default_theme = 'nostalgia.css' if 'nostalgia.css' in AVAILABLE_THEMES else (AVAILABLE_THEMES[0] if AVAILABLE_THEMES else '')
     current_theme = session.get('theme', default_theme)
@@ -570,6 +570,7 @@ def webpack_zip():
 def new_db():
     close_connection(None)
     create_new_db()
+    session['db_display_name'] = os.path.basename(app.config['DATABASE'])
     flash("New demo database created.", "success")
     return redirect(url_for('index'))
 
@@ -583,6 +584,7 @@ def load_db_route():
     try:
         file.save(app.config['DATABASE'])
         ensure_schema()
+        session['db_display_name'] = os.path.basename(file.filename or app.config['DATABASE'])
         flash("Database loaded.", "success")
     except Exception as e:
         flash(f"Error loading database: {e}", "error")

--- a/static/base.css
+++ b/static/base.css
@@ -35,6 +35,7 @@
 .retrorecon-root .w-2em { width: 2em; }
 .retrorecon-root .text-left { text-align: left; }
 .retrorecon-root .text-center { text-align: center; }
+.retrorecon-root .text-right { text-align: right; }
 .retrorecon-root .text-muted { color: #888; }
 .retrorecon-root .no-underline { text-decoration: none; }
 .retrorecon-root .d-inline { display: inline; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -177,6 +177,9 @@
       <td class="text-left">
         <h1>retrorecon <span class="version-text">v1.0.0</span></h1>
       </td>
+      <td class="text-right">
+        <span class="version-text">{{ db_name }}</span>
+      </td>
     </tr>
   </table>
 


### PR DESCRIPTION
## Summary
- show DB name in header next to the version text
- remember loaded DB filename in session
- add helper `.text-right` CSS class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc2b7944c83329017fb22aa0e5be5