### PR TITLE
Improve DB name display

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -48,6 +48,12 @@
 .retrorecon-root .cursor-pointer { cursor: pointer; }
 .retrorecon-root .fw-bold { font-weight: bold; }
 .retrorecon-root .version-text { font-size: 0.7em; color: #666; }
+.retrorecon-root .db-info {
+  font-size: 1.6em;
+  letter-spacing: 0.04em;
+  font-weight: bold;
+  color: var(--accent-color);
+}
 .retrorecon-root .ml-01 { margin-left: 0.1em; }
 
 /* Generic form styles */

--- a/templates/index.html
+++ b/templates/index.html
@@ -178,7 +178,7 @@
         <h1>retrorecon <span class="version-text">v1.0.0</span></h1>
       </td>
       <td class="text-right">
-        <span class="version-text">{{ db_name }}</span>
+        <span class="db-info glow">loaded&gt; {{ db_name }}</span>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
## Summary
- larger, glowing db name indicator
- use `loaded>` prefix for sqlite style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcd23ef8c83328e8fdaa186872dd8