### PR TITLE
Fix URL result row styles

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -567,14 +567,23 @@
 }
 
 /* Apply pagination text styling to URL results */
+/*
 .retrorecon-root .url-result {
   font-size: 1.2em;
   font-weight: bold;
   color: var(--accent-color);
 }
+*/
+
+/* URL row button cells */
 .retrorecon-root .url-row-buttons td {
   padding: 0.43em 0.7em;
   border-bottom: 1px solid var(--fg-color);
+}
+.retrorecon-root .url-row-main.url-result td {
+  font-size: 1.2em;
+  font-weight: bold;
+  color: var(--accent-color);
 }
 .retrorecon-root .url-row-main input[type="checkbox"] {
   cursor: pointer;
@@ -798,7 +807,7 @@
 .retrorecon-root #layout-c td,
 .retrorecon-root #layout-d td {
   background: #14122200;
-  color: var(--fg-color);
+  color: inherit;
 }
 
 /* --- End of update --- */

--- a/templates/index.html
+++ b/templates/index.html
@@ -250,7 +250,7 @@
               </thead>
               <tbody>
                 {% for url in urls %}
-                <tr class="url-row-main cursor-pointer" onclick="window.open('{{ url.url }}', '_blank');">
+                <tr class="url-row-main url-result cursor-pointer" onclick="window.open('{{ url.url }}', '_blank');">
                   <td>
                     <input type="checkbox" class="row-checkbox" name="selected_ids" value="{{ url.id }}" onclick="event.stopPropagation()" />
                   </td>
@@ -491,7 +491,6 @@
     // Apply theme colors on the URL results table
     document.querySelectorAll('.url-table tr').forEach(tr => {
       tr.style.backgroundColor = 'var(--bg-color)';
-      tr.style.color = 'var(--fg-color)';
     });
     document.querySelectorAll('.url-table tbody tr').forEach(tr => {
       const cells = tr.querySelectorAll('td');


### PR DESCRIPTION
## Summary
- scope URL result styling to rows
- stop JS from overriding table row text color
- resolve CSS linter error by reordering selectors
- prevent layout styles from overriding `.url-result` cells

## Testing
- `npm install`
- `npm run lint`
- `pip install flask requests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c54598a808332b3b05cc936d098ba