### PR TITLE
Update header version and color

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -47,7 +47,7 @@
 .retrorecon-root .d-none { display: none; }
 .retrorecon-root .cursor-pointer { cursor: pointer; }
 .retrorecon-root .fw-bold { font-weight: bold; }
-.retrorecon-root .version-text { font-size: 0.7em; color: #666; }
+.retrorecon-root .version-text { font-size: 0.7em; color: var(--accent-color); }
 .retrorecon-root .db-info {
   font-size: 1.6em;
   letter-spacing: 0.04em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -175,7 +175,7 @@
         </div>
       </td>
       <td class="text-left">
-        <h1><a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.0.0</span></a></h1>
+        <h1><a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.0.1</span></a></h1>
       </td>
       <td class="text-right">
         <span class="db-info glow w-100 d-inline-block text-center">loaded&gt; {{ db_name }}</span>


### PR DESCRIPTION
## Summary
- bump version text to v1.0.1 on the home page
- style version text using the accent color so it matches the logo

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c8979af348332bd96539ee9667fd4