### PR TITLE
Implement DB rename workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import zipfile
 import threading
+import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
@@ -23,7 +24,7 @@ from flask import (
 )
 
 app = Flask(__name__)
-app.config['DATABASE'] = os.path.join(app.root_path, 'wabax.db')
+app.config['DATABASE'] = os.path.join(app.root_path, 'waybax.db')
 app.secret_key = 'CHANGE_THIS_TO_A_RANDOM_SECRET_KEY'
 ITEMS_PER_PAGE = 20
 
@@ -140,12 +141,32 @@ def load_demo_data() -> None:
     db.commit()
     db.close()
 
-def create_new_db() -> None:
-    """Reset the database and load demo records."""
-    if os.path.exists(app.config['DATABASE']):
-        os.remove(app.config['DATABASE'])
+def _sanitize_db_name(name: str) -> Optional[str]:
+    """Return a safe ``name.db`` or ``None`` if invalid."""
+    nm = name.strip()
+    if not nm:
+        return None
+    if len(nm) > 64 or any(sep in nm for sep in ('/', '\\')):
+        return None
+    if not re.match(r'^[A-Za-z0-9_-]+(\.db)?$', nm):
+        return None
+    if not nm.lower().endswith('.db'):
+        nm += '.db'
+    return nm
+
+
+def create_new_db(name: Optional[str] = None) -> str:
+    """Reset the database and load demo records, returning the filename."""
+    nm = _sanitize_db_name(name) if name else 'waybax.db'
+    if nm is None:
+        raise ValueError('Invalid database name.')
+    db_path = os.path.join(app.root_path, nm)
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    app.config['DATABASE'] = db_path
     init_db()
     load_demo_data()
+    return nm
 
 if not os.path.exists(app.config['DATABASE']):
     create_new_db()
@@ -163,9 +184,9 @@ def get_db() -> sqlite3.Connection:
 
 @app.teardown_appcontext
 def close_connection(exception: Optional[BaseException]) -> None:
-    """Close the SQLite connection at app teardown."""
+    """Close the SQLite connection at app teardown and remove it from ``g``."""
 
-    db = getattr(g, '_database', None)
+    db = g.pop('_database', None)
     if db is not None:
         db.close()
 
@@ -609,9 +630,13 @@ def webpack_zip() -> Response:
 def new_db() -> Response:
     """Create a fresh database and load demo entries."""
     close_connection(None)
-    create_new_db()
-    session['db_display_name'] = os.path.basename(app.config['DATABASE'])
-    flash("New demo database created.", "success")
+    name = request.form.get('db_name', '').strip()
+    try:
+        db_name = create_new_db(name or None)
+        session['db_display_name'] = db_name
+        flash("New demo database created.", "success")
+    except ValueError as e:
+        flash(str(e), "error")
     return redirect(url_for('index'))
 
 @app.route('/load_db', methods=['POST'])
@@ -646,6 +671,27 @@ def save_db() -> Response:
         as_attachment=True,
         download_name=safe_name
     )
+
+
+@app.route('/rename_db', methods=['POST'])
+def rename_db() -> Response:
+    """Rename the current database file."""
+    new_name = request.form.get('new_name', '').strip()
+    safe = _sanitize_db_name(new_name or '')
+    if not safe:
+        flash('Invalid database name.', 'error')
+        return redirect(url_for('index'))
+    close_connection(None)
+    new_path = os.path.join(app.root_path, safe)
+    try:
+        os.rename(app.config['DATABASE'], new_path)
+    except OSError as e:
+        flash(f'Error renaming database: {e}', 'error')
+        return redirect(url_for('index'))
+    app.config['DATABASE'] = new_path
+    session['db_display_name'] = safe
+    flash('Database renamed.', 'success')
+    return redirect(url_for('index'))
 
 if __name__ == '__main__':
     if not os.path.exists(app.config['DATABASE']):

--- a/templates/index.html
+++ b/templates/index.html
@@ -108,7 +108,12 @@
                   <button type="submit" class="btn">💾 Save As</button>
                 </form>
                 <form method="POST" action="/new_db" class="d-inline ml-4px">
+                  <input type="text" name="db_name" placeholder="Name" class="form-input w-8em" />
                   <button type="submit" class="btn">🆕 New DB</button>
+                </form>
+                <form method="POST" action="/rename_db" class="d-inline ml-4px">
+                  <input type="text" name="new_name" placeholder="New name" class="form-input w-8em" />
+                  <button type="submit" class="btn">✏️ Rename DB</button>
                 </form>
               </div>
             </div>
@@ -479,7 +484,7 @@
       saveForm.addEventListener('submit', function(e) {
         if (!/name=/.test(this.action)) {
           e.preventDefault();
-          const nm = prompt('Enter database name:', 'wabax');
+          const nm = prompt('Enter database name:', 'waybax');
           if (nm) {
             const enc = encodeURIComponent(nm.trim());
             window.location = '/save_db?name=' + enc;

--- a/tests/test_db_workflow.py
+++ b/tests/test_db_workflow.py
@@ -1,0 +1,79 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", os.path.join(str(tmp_path), "waybax.db"))
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+    demo = orig / "data" / "demo_data.json"
+    if demo.exists():
+        (tmp_path / "data" / "demo_data.json").write_text(demo.read_text())
+
+
+def test_create_new_db_with_name(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        client.post('/new_db', data={'db_name': 'client1'})
+        db_file = tmp_path / 'client1.db'
+        assert db_file.exists()
+        with client.session_transaction() as sess:
+            assert sess['db_display_name'] == 'client1.db'
+        with app.app.app_context():
+            rows = app.query_db("SELECT name FROM sqlite_master WHERE type='table' AND name='urls'")
+            assert rows
+
+
+def test_create_new_db_default(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        client.post('/new_db')
+        db_file = tmp_path / 'waybax.db'
+        assert db_file.exists()
+        with client.session_transaction() as sess:
+            assert sess['db_display_name'] == 'waybax.db'
+
+
+def test_rename_database(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        client.post('/new_db', data={'db_name': 'orig'})
+        with app.app.app_context():
+            app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://a.com", ""])
+        client.post('/rename_db', data={'new_name': 'renamed'})
+        assert not (tmp_path / 'orig.db').exists()
+        new_db = tmp_path / 'renamed.db'
+        assert new_db.exists()
+        with app.app.app_context():
+            rows = app.query_db('SELECT url FROM urls')
+            assert rows[0]['url'] == 'http://a.com'
+
+
+def test_invalid_names(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        client.post('/new_db')
+        prev = app.app.config['DATABASE']
+        client.post('/new_db', data={'db_name': '../bad'})
+        assert app.app.config['DATABASE'] == prev
+        client.post('/rename_db', data={'new_name': 'foo?bar'})
+        assert app.app.config['DATABASE'] == prev
+
+
+def test_rename_while_open(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        client.post('/new_db', data={'db_name': 'open'})
+        conn = sqlite3.connect(app.app.config['DATABASE'])
+        monkeypatch.setattr(app.os, 'rename', lambda *a, **k: (_ for _ in ()).throw(OSError('locked')))
+        client.post('/rename_db', data={'new_name': 'fail'})
+        assert (tmp_path / 'open.db').exists()
+        conn.close()


### PR DESCRIPTION
## Summary
- allow naming database when created
- add rename database route and UI controls
- update default db name to `waybax.db`
- provide tests for new workflow
- fix connection cleanup to prevent closed connection errors

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c902390e8833281c3aed22861ae93