### PR TITLE
Fix per-row tag input alignment

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -1,127 +1,21 @@
 {
   "coverage": {
     "button": {
-      "total": 44,
-      "styled": 37
+      "total": 30,
+      "styled": 30
     },
     "input": {
-      "total": 21,
-      "styled": 14
+      "total": 17,
+      "styled": 11
     },
     "select": {
-      "total": 3,
-      "styled": 3
+      "total": 2,
+      "styled": 2
     },
     "checkbox": {
-      "total": 7,
-      "styled": 7
+      "total": 5,
+      "styled": 5
     }
   },
-  "unscoped_selectors": {
-    "static/base.css": [
-      ".hidden",
-      ".spinner",
-      ".mt-1",
-      ".mt-05",
-      ".ml-1",
-      ".ml-05",
-      ".ml-4px",
-      ".mr-03",
-      ".mb-4px",
-      ".m-2em",
-      ".my-8px",
-      ".w-100",
-      ".w-95",
-      ".w-2em",
-      ".text-left",
-      ".text-center",
-      ".text-muted",
-      ".no-underline",
-      ".d-inline",
-      ".d-inline-block",
-      ".d-block",
-      ".d-flex",
-      ".flex-between",
-      ".nowrap",
-      ".d-none",
-      ".cursor-pointer",
-      ".fw-bold",
-      ".version-text",
-      ".ml-01"
-    ],
-    "static/wabax.css": [
-      "#map-url-input",
-      ".theme-row button",
-      ".theme-row button:hover",
-      "#mapUrlInput",
-      ".page-grid",
-      ".results-grid",
-      ".page-grid h1",
-      ".search-history table",
-      ".search-history td",
-      ".search-history tbody tr:nth-child(even)",
-      ".header-bar",
-      ".header-bar .menu-dropdown",
-      ".header-bar h1",
-      ".bulk-controls",
-      ".bulk-controls input[type=\"text\"]",
-      "#bulk-tag-input",
-      ".bulk-controls button",
-      ".bulk-controls button:hover",
-      ".checkbox-row",
-      ".select-all-label",
-      ".url-table",
-      ".url-table thead",
-      ".url-table th",
-      ".url-row-buttons:nth-child(4n + 1)",
-      ".url-row-buttons:nth-child(4n + 3)",
-      ".url-row-main",
-      ".url-row-main td",
-      ".url-row-buttons td",
-      ".url-row-main input[type=\"checkbox\"]",
-      ".url-tools-row",
-      ".url-tools-row input[type=\"text\"]",
-      ".tag-pill",
-      ".tag-pill form",
-      ".tag-pill button",
-      ".tag-pill button:hover",
-      ".crtsh-btn",
-      ".crtsh-btn:hover",
-      ".explode-btn:active",
-      ".explode-btn:disabled",
-      "button",
-      "button:hover",
-      "button:active",
-      "select",
-      "0%",
-      "50%",
-      "100%",
-      ".pulse",
-      ".pagination",
-      ".pagination strong",
-      ".pagination a:hover",
-      ".pagination strong",
-      ".pagination input[type=\"text\"]",
-      ".pagination button",
-      ".total-count",
-      ".footer",
-      ".row-checkbox",
-      "input[type=\"checkbox\"]",
-      ".url-row-buttons:hover",
-      ".status-2",
-      ".status-3",
-      ".status-4",
-      ".status-5",
-      "#layout-d td"
-    ],
-    "static/themes/theme-openai.css": [
-      "a",
-      ".search-bar",
-      ".search-bar input[type=\"text\"]",
-      ".search-bar button",
-      ".search-bar button:hover",
-      ".url-table th",
-      ".url-table td"
-    ]
-  }
+  "unscoped_selectors": {}
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -290,6 +290,12 @@
                       {% else %}
                       <button type="button" class="btn explode-btn disabled-btn" title="Not a .js.map" disabled>💥 Explode!</button>
                       {% endif %}
+                      <form method="POST" action="/bulk_action" class="d-inline ml-05">
+                        <input type="hidden" name="action" value="add_tag" />
+                        <input type="hidden" name="selected_ids" value="{{ url.id }}" />
+                        <input type="text" name="tag" placeholder="Tag" size="8" required class="form-input" />
+                        <button type="submit" title="Add tag" class="btn">+</button>
+                      </form>
                       {% for tag in (url.tags or '').split(',') if tag %}
                       <span class="tag-pill">{{ tag }}
                         <form method="POST" action="/bulk_action" class="d-inline">
@@ -300,12 +306,6 @@
                         </form>
                       </span>
                       {% endfor %}
-                      <form method="POST" action="/bulk_action" class="d-inline ml-05">
-                        <input type="hidden" name="action" value="add_tag" />
-                        <input type="hidden" name="selected_ids" value="{{ url.id }}" />
-                        <input type="text" name="tag" placeholder="Tag" size="8" required class="form-input" />
-                        <button type="submit" title="Add tag" class="btn">+</button>
-                      </form>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- keep tag button stationary by moving tag pills after the add form
- update CSS audit report

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684cee07a1188332a5e7e5e1a0d7c1cd