### PR TITLE
Fix startup database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A Flask web application for exploring Wayback Machine data. It fetches CDX recor
 pip install -r requirements.txt
 python scripts/init_db.py  # set up wabax.db with demo data
 python app.py
+# Optionally set RETRORECON_DB to open a specific database on launch
+# RETRORECON_DB=dsprings.db python app.py
 ```
 Then open <http://127.0.0.1:5000> in your browser.
 

--- a/app.py
+++ b/app.py
@@ -24,7 +24,12 @@ from flask import (
 )
 
 app = Flask(__name__)
-app.config['DATABASE'] = os.path.join(app.root_path, 'waybax.db')
+# Allow overriding the startup database via environment variable
+env_db = os.environ.get('RETRORECON_DB')
+if env_db:
+    app.config['DATABASE'] = env_db if os.path.isabs(env_db) else os.path.join(app.root_path, env_db)
+else:
+    app.config['DATABASE'] = os.path.join(app.root_path, 'waybax.db')
 app.secret_key = 'CHANGE_THIS_TO_A_RANDOM_SECRET_KEY'
 ITEMS_PER_PAGE = 20
 

--- a/tests/test_env_db.py
+++ b/tests/test_env_db.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+
+# Set environment variable before importing app
+os.environ['RETRORECON_DB'] = 'envtest.db'
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def test_env_db_loaded(monkeypatch, tmp_path):
+    # point app root to temp dir
+    monkeypatch.setattr(app.app, 'root_path', str(tmp_path))
+    monkeypatch.setitem(app.app.config, 'DATABASE', os.path.join(str(tmp_path), 'envtest.db'))
+    # create minimal schema
+    (tmp_path / 'db').mkdir()
+    (tmp_path / 'data').mkdir()
+    schema_src = Path(__file__).resolve().parents[1] / 'db' / 'schema.sql'
+    (tmp_path / 'db' / 'schema.sql').write_text(schema_src.read_text())
+    app.create_new_db('envtest')
+
+    with app.app.test_client() as client:
+        client.get('/')
+        with client.session_transaction() as sess:
+            assert sess['db_display_name'] == 'envtest.db'
+
+    del os.environ['RETRORECON_DB']
+
+


### PR DESCRIPTION
## Summary
- allow overriding the startup database using `RETRORECON_DB`
- document new env variable in README
- test env override

## Testing
- `pytest -q`
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cf1e87d288332895486628726c4d4