### PR TITLE
Remove demo data from new DB creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Flask web application for exploring Wayback Machine data. It fetches CDX recor
 ## Installation
 ```bash
 pip install -r requirements.txt
-python scripts/init_db.py  # set up wabax.db with demo data
+python scripts/init_db.py  # initialize wabax.db
 python app.py
 # Optionally set RETRORECON_DB to open a specific database on launch
 # RETRORECON_DB=dsprings.db python app.py

--- a/app.py
+++ b/app.py
@@ -173,7 +173,7 @@ def _sanitize_export_name(name: str) -> str:
 
 
 def create_new_db(name: Optional[str] = None) -> str:
-    """Reset the database and load demo records, returning the filename."""
+    """Reset the database and return the newly created filename."""
     nm = _sanitize_db_name(name) if name else 'waybax.db'
     if nm is None:
         raise ValueError('Invalid database name.')
@@ -182,7 +182,8 @@ def create_new_db(name: Optional[str] = None) -> str:
         os.remove(db_path)
     app.config['DATABASE'] = db_path
     init_db()
-    load_demo_data()
+    # Databases used to include demo entries from ``data/demo_data.json``.
+    # For production use we initialize an empty database.
     return nm
 
 if app.config.get('DATABASE') and os.path.exists(app.config['DATABASE']):
@@ -679,7 +680,7 @@ def webpack_zip() -> Response:
 
 @app.route('/new_db', methods=['POST'])
 def new_db() -> Response:
-    """Create a fresh database and load demo entries."""
+    """Create a fresh empty database."""
     name = request.form.get('db_name', '').strip()
     safe = _sanitize_db_name(name)
     if not safe:
@@ -689,7 +690,7 @@ def new_db() -> Response:
     try:
         db_name = create_new_db(safe)
         session['db_display_name'] = db_name
-        flash('New demo database created.', 'success')
+        flash('New database created.', 'success')
     except ValueError as e:
         flash(str(e), 'error')
     return redirect(url_for('index'))

--- a/docs/db_workflow_plan.md
+++ b/docs/db_workflow_plan.md
@@ -16,7 +16,7 @@ This document outlines the steps required to implement the updated database work
   - Allow alphanumeric characters, dashes and underscores.
   - Reject names longer than 64 characters or containing path separators.
   - Append `.db` if missing.
-- Remove the existing database (if any) and initialize using the current schema and demo data.
+  - Remove the existing database (if any) and initialize using the current schema without demo entries.
 - Store the name in `session['db_display_name']` and update `app.config['DATABASE']` to point to the new file.
 
 ### 2. Add `rename_database`


### PR DESCRIPTION
## Summary
- initialize new databases without demo data
- update instructions regarding demo data

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d0309c1248332a6289a6b7f7a445e