### PR TITLE
Refactor import logic for unified file upload

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -98,19 +98,10 @@
                   </td>
                 </tr>
                 <tr>
-                  <td class="import-label"><label for="json-file" class="form-label">📄 Import from JSON:</label></td>
+                  <td class="import-label"><label for="upload-file" class="form-label">📁 Import JSON or DB:</label></td>
                   <td>
-                    <form method="POST" action="/import_json" enctype="multipart/form-data" id="import-form" class="import-form">
-                      <input id="json-file" type="file" name="json_file" required class="form-file" />
-                      <button type="submit" class="btn">Import</button>
-                    </form>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="import-label"><label for="db-file" class="form-label">📂 SQLite DB:</label></td>
-                  <td>
-                    <form method="POST" action="/load_db" enctype="multipart/form-data" class="import-form">
-                      <input id="db-file" type="file" name="db_file" required class="form-file" />
+                    <form method="POST" action="/import_file" enctype="multipart/form-data" id="import-form" class="import-form">
+                      <input id="upload-file" type="file" name="import_file" accept=".json,.db" required class="form-file" />
                       <button type="submit" class="btn">Import</button>
                     </form>
                   </td>

--- a/tests/test_db_workflow.py
+++ b/tests/test_db_workflow.py
@@ -95,7 +95,7 @@ def test_load_json_populates_db(tmp_path, monkeypatch):
                 self.target(*self.args)
 
         monkeypatch.setattr(app.threading, 'Thread', DummyThread)
-        client.post('/import_json', data={'json_file': (io.BytesIO(data), 'cdx.json')})
+        client.post('/import_file', data={'import_file': (io.BytesIO(data), 'cdx.json')})
         with app.app.app_context():
             rows = app.query_db('SELECT url, timestamp, status_code, mime_type FROM urls WHERE url = ?', ['http://wb.example/'])
             assert rows and rows[0]['timestamp'] == '20240101010101'


### PR DESCRIPTION
## Summary
- replace separate JSON and DB import forms with a single file input
- add `/import_file` route that accepts either JSON or SQLite DB files
- update tests for new import workflow

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0a6ff8b8833284f10a765ed508c5