### PR TITLE
Add API documentation and Postman generator

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -1,0 +1,169 @@
+# Retrorecon REST API
+
+This document describes the HTTP endpoints exposed by the Flask application. All examples assume the server is running locally on `http://localhost:5000` and the `base_url` variable used by the Postman collection refers to that address.
+
+## General Notes
+
+- POST endpoints expect form data unless otherwise indicated.
+- JSON responses are returned only from a few routes as noted.
+- Successful POST requests typically redirect back to `/` with a flash message.
+
+## Routes
+
+### `GET /`
+Render the main search page.
+
+```
+curl http://localhost:5000/
+```
+
+### `POST /fetch_cdx`
+Fetch Wayback Machine CDX records for a domain and insert any new URLs into the loaded database.
+
+Parameters:
+- `domain` – domain name to query.
+
+Example:
+```
+curl -X POST -d "domain=example.com" http://localhost:5000/fetch_cdx
+```
+
+### `POST /import_file` (`/import_json`)
+Import URLs from a JSON file or load a database file. The route is accessible via both `/import_file` and `/import_json`.
+
+Parameters depend on the uploaded file:
+- `import_file` or `json_file` – JSON array/lines of records.
+- `db_file` – SQLite `.db` file to load.
+
+Example (JSON import):
+```
+curl -X POST -F "import_file=@records.json" http://localhost:5000/import_file
+```
+
+### `GET /import_progress`
+Return JSON describing the current import status.
+
+Example:
+```
+curl http://localhost:5000/import_progress
+```
+Response:
+```json
+{"status": "done", "progress": 10, "total": 10, "detail": "Imported 10 records."}
+```
+
+### `POST /add_tag`
+Add a tag to a single URL entry.
+
+Parameters:
+- `entry_id` – ID of the entry.
+- `new_tag` – tag text to add.
+
+Example:
+```
+curl -X POST -d "entry_id=1" -d "new_tag=important" http://localhost:5000/add_tag
+```
+
+### `POST /bulk_action`
+Apply a tag, remove a tag or delete many entries at once.
+
+Parameters:
+- `action` – `add_tag`, `remove_tag` or `delete`.
+- `tag` – tag name used with add/remove actions.
+- `selected_ids` – repeated form field of entry IDs.
+- `select_all_matching` – when set to `true`, apply to all search results.
+
+Example (add tag to two IDs):
+```
+curl -X POST \
+  -F "action=add_tag" -F "tag=archive" \
+  -F "selected_ids=3" -F "selected_ids=4" \
+  http://localhost:5000/bulk_action
+```
+
+### `POST /set_theme`
+Persist the chosen theme in the user session.
+
+Parameter:
+- `theme` – CSS filename from `static/themes/`.
+
+```
+curl -X POST -d "theme=nostalgia.css" http://localhost:5000/set_theme
+```
+
+### `POST /set_background`
+Persist the selected background image.
+
+Parameter:
+- `background` – image filename from `static/img/`.
+
+```
+curl -X POST -d "background=stars.jpg" http://localhost:5000/set_background
+```
+
+### `POST /set_panel_opacity`
+Update the UI panel opacity stored in the session.
+
+Parameter:
+- `opacity` – float between `0.1` and `1.0`.
+
+```
+curl -X POST -d "opacity=0.5" http://localhost:5000/set_panel_opacity
+```
+
+### `POST /tools/webpack-zip`
+Download sources referenced in a Webpack `.js.map` file as a ZIP archive.
+
+Parameter:
+- `map_url` – URL of the `.js.map` file.
+
+```
+curl -X POST -d "map_url=https://host/app.js.map" http://localhost:5000/tools/webpack-zip -o sources.zip
+```
+
+### `POST /new_db`
+Create a new empty SQLite database.
+
+Parameter:
+- `db_name` – desired base name (optional, sanitized to `<name>.db`).
+
+```
+curl -X POST -d "db_name=project" http://localhost:5000/new_db
+```
+
+### `POST /load_db`
+Upload and load a database file.
+
+Parameter:
+- `db_file` – uploaded `.db` file.
+
+```
+curl -X POST -F "db_file=@existing.db" http://localhost:5000/load_db
+```
+
+### `GET /save_db`
+Download the currently loaded database. Use the optional `name` query parameter to specify the download filename.
+
+```
+curl -L "http://localhost:5000/save_db?name=backup.db" -o backup.db
+```
+
+### `POST /rename_db`
+Rename the current database file.
+
+Parameter:
+- `new_name` – new base filename.
+
+```
+curl -X POST -d "new_name=renamed" http://localhost:5000/rename_db
+```
+
+## Generating a Postman Collection
+Run the helper script to generate a Postman collection from the application's route map:
+
+```
+python scripts/generate_postman_collection.py > retrorecon.postman.json
+```
+
+Import the resulting `retrorecon.postman.json` file into Postman and set the `base_url` variable to your server address.
+

--- a/scripts/generate_postman_collection.py
+++ b/scripts/generate_postman_collection.py
@@ -1,0 +1,44 @@
+import json
+from typing import Dict, Any, List
+
+from app import app
+
+
+def _url_parts(route: str) -> Dict[str, Any]:
+    """Return Postman URL object for ``route``."""
+    clean = route.lstrip('/')
+    return {
+        "raw": f"{{{{base_url}}}}{route}",
+        "host": ["{{base_url}}"],
+        "path": clean.split('/') if clean else []
+    }
+
+
+def build_collection() -> Dict[str, Any]:
+    """Generate a Postman collection dictionary from Flask routes."""
+    items: List[Dict[str, Any]] = []
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint == 'static':
+            continue
+        methods = sorted(m for m in rule.methods if m not in {'HEAD', 'OPTIONS'})
+        for method in methods:
+            items.append({
+                "name": f"{method} {rule.rule}",
+                "request": {
+                    "method": method,
+                    "header": [],
+                    "url": _url_parts(rule.rule)
+                }
+            })
+    return {
+        "info": {
+            "name": "Retrorecon API",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": items
+    }
+
+
+if __name__ == '__main__':
+    collection = build_collection()
+    print(json.dumps(collection, indent=2))


### PR DESCRIPTION
## Summary
- document all Flask API routes under `docs/api_routes.md`
- add helper script to build a Postman collection automatically

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684da60725748332a5d079692826081c