### PR TITLE
Add automated wiki sync

### DIFF
--- a/.github/workflows/wiki_sync.yml
+++ b/.github/workflows/wiki_sync.yml
@@ -13,5 +13,5 @@ jobs:
           python-version: '3.x'
       - name: Run wiki sync script
         env:
-          WIKI_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/thesavant42/retrorecon.wiki.git
+          WIKI_URL: https://x-access-token:${{ secrets.WIKI_PAT }}@github.com/thesavant42/retrorecon.wiki.git
         run: python scripts/update_wiki.py

--- a/.github/workflows/wiki_sync.yml
+++ b/.github/workflows/wiki_sync.yml
@@ -1,0 +1,17 @@
+name: Sync Wiki
+on:
+  push:
+    paths:
+      - '**/*.md'
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run wiki sync script
+        env:
+          WIKI_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/thesavant42/retrorecon.wiki.git
+        run: python scripts/update_wiki.py

--- a/README.md
+++ b/README.md
@@ -72,3 +72,10 @@ MIT
 - [Wayback Machine API](https://archive.org/help/wayback_api.php)
 - [Webpack Exploder](https://spaceraccoon.github.io/webpack-exploder/)
 - [Map Room conceptual inspiration](https://indianajones.fandom.com/wiki/Map_Room)
+
+## Wiki Sync
+Markdown files in this repository are automatically mirrored to the
+[project wiki](https://github.com/thesavant42/retrorecon/wiki) via the
+`update_wiki.py` script. On each push that modifies `.md` files, a GitHub
+Actions workflow clones the wiki repository, copies the updated files and
+pushes the changes.

--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ Markdown files in this repository are automatically mirrored to the
 [project wiki](https://github.com/thesavant42/retrorecon/wiki) via the
 `update_wiki.py` script. On each push that modifies `.md` files, a GitHub
 Actions workflow clones the wiki repository, copies the updated files and
-pushes the changes.
+pushes the changes. The workflow expects a repository secret named
+`WIKI_PAT` with permissions to push to the wiki repository.

--- a/scripts/update_wiki.py
+++ b/scripts/update_wiki.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+WIKI_URL = os.environ.get('WIKI_URL', 'https://github.com/thesavant42/retrorecon.wiki.git')
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd, cwd=None):
+    """Run a shell command and raise if it fails."""
+    subprocess.check_call(cmd, cwd=cwd)
+
+
+def copy_markdown(src_root: Path, dest_root: Path) -> None:
+    """Copy all Markdown files from src_root into dest_root preserving paths."""
+    for md in src_root.rglob('*.md'):
+        if '.git' in md.parts or 'node_modules' in md.parts:
+            continue
+        rel = md.relative_to(src_root)
+        dest = dest_root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(md, dest)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run(['git', 'clone', WIKI_URL, tmpdir])
+        wiki_path = Path(tmpdir)
+
+        # remove existing files except .git
+        for item in wiki_path.iterdir():
+            if item.name == '.git':
+                continue
+            if item.is_dir():
+                shutil.rmtree(item)
+            else:
+                item.unlink()
+
+        copy_markdown(REPO_ROOT, wiki_path)
+
+        run(['git', 'add', '.'], cwd=wiki_path)
+        status = subprocess.run(['git', 'status', '--porcelain'], cwd=wiki_path,
+                                capture_output=True, text=True, check=True)
+        if status.stdout.strip():
+            run(['git', 'commit', '-m', 'Update wiki pages from repository markdown'], cwd=wiki_path)
+            run(['git', 'push'], cwd=wiki_path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to clone the wiki repo and copy markdown files
- create workflow to update the wiki whenever markdown files change
- document wiki automation in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dad81614c83328573caaf324416ee