### PR TITLE
Make nav menu square

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -353,9 +353,20 @@
   margin-top: 6px;
   color: var(--fg-color);
 }
+/* Square styling for all navbar controls */
+.retrorecon-root .navbar input,
+.retrorecon-root .navbar select,
+.retrorecon-root .navbar button,
+.retrorecon-root .navbar .menu-btn,
+.retrorecon-root .navbar .dropdown-content {
+  border-radius: 0 !important;
+}
+
 .retrorecon-root .dropdown.show .dropdown-content {
   display: block;
 }
+
+
 
 /* Fixed menu placement */
 .retrorecon-root .menu-dropdown{


### PR DESCRIPTION
## Summary
- remove rounded corners from dropdown menu controls
- enforce squared look for nav menu inputs, selects, and buttons

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dd7c590c48332a08d573842de11ab