### PR TITLE
Fix new database prompt and sanitization

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,7 +156,7 @@ def _sanitize_db_name(name: str) -> Optional[str]:
     """Return a sanitized ``name.db`` or ``None`` if empty after cleaning."""
 
     base, _ = os.path.splitext(name)
-    safe = re.sub(r"[^A-Za-z0-9_]", "", base)[:64]
+    safe = re.sub(r"[^A-Za-z0-9_-]", "", base)[:64]
     if not safe:
         return None
     return safe + ".db"
@@ -165,7 +165,7 @@ def _sanitize_db_name(name: str) -> Optional[str]:
 def _sanitize_export_name(name: str) -> str:
     """Return a filename safe for download containing only allowed chars."""
 
-    safe = re.sub(r"[^A-Za-z0-9_]", "_", name.strip())
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", name.strip())
     safe = safe.strip("_") or "download"
     if not safe.lower().endswith(".db"):
         safe += ".db"

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,7 +82,7 @@
     <div class="dropdown">
       <button class="dropbtn" data-menu="file-menu">File ▼</button>
       <div class="dropdown-content" id="file-menu">
-          <form method="POST" action="/new_db" class="menu-row">
+          <form method="POST" action="/new_db" class="menu-row" id="new-db-form">
             <input type="hidden" name="db_name" id="new-db-name" />
             <button type="submit" class="menu-btn">New DB</button>
           </form>
@@ -495,7 +495,7 @@
           e.preventDefault();
           const nm = prompt('Enter new database name:', 'waybax');
           if (nm) {
-            const cleaned = nm.replace(/[^A-Za-z0-9_]/g, '').slice(0, 64);
+            const cleaned = nm.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 64);
             if (cleaned) {
               input.value = cleaned;
               this.submit();


### PR DESCRIPTION
## Summary
- restore `File -> New` prompt by adding missing form `id`
- allow hyphens when sanitizing database names on client and server

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684de0a21ddc8332b4ed9000b0148f9c