### PR TITLE
Fix audit script missing menu-btn style

### DIFF
--- a/scripts/audit_css.py
+++ b/scripts/audit_css.py
@@ -9,7 +9,7 @@ coverage = {
 }
 
 styled_classes = {
-    'button': {'btn', 'dropbtn', 'explode-btn', 'bulk-action-btn', 'delete-btn', 'copy-btn', 'disabled-btn'},
+    'button': {'btn', 'menu-btn', 'dropbtn', 'explode-btn', 'bulk-action-btn', 'delete-btn', 'copy-btn', 'disabled-btn'},
     'input': {'form-input', 'form-file', 'bulk-tag-input'},
     'select': {'form-select'},
     'checkbox': {'form-checkbox', 'row-checkbox'},


### PR DESCRIPTION
## Summary
- update audit_css.py to recognize `menu-btn` as a styled button

## Testing
- `pytest -q`
- `npm run lint`
- `python scripts/audit_css.py | jq .`

------
https://chatgpt.com/codex/tasks/task_e_684de22407288332ab1b6f3ab9c5c0e7