### PR TITLE
Fix Import dialog to show JSON files

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -87,7 +87,7 @@
             <button type="submit" class="menu-btn">New DB</button>
           </form>
           <form method="POST" action="/load_db" enctype="multipart/form-data" class="menu-row">
-            <input type="file" name="db_file" accept=".db" required class="form-file" />
+            <input type="file" name="db_file" accept=".db,.json" required class="form-file" />
             <button type="submit" class="menu-btn">Open DB</button>
           </form>
           <form method="POST" action="/rename_db" class="menu-row">


### PR DESCRIPTION
## Summary
- allow `.json` files in the Open DB dialog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684de419b074833283bbdd0845ceffb9