### PR TITLE
Move loaded prompt next to version text

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -2,11 +2,11 @@
   "coverage": {
     "button": {
       "total": 36,
-      "styled": 28
+      "styled": 36
     },
     "input": {
-      "total": 13,
-      "styled": 9
+      "total": 12,
+      "styled": 8
     },
     "select": {
       "total": 2,

--- a/static/base.css
+++ b/static/base.css
@@ -53,6 +53,7 @@
   letter-spacing: 0.04em;
   font-weight: bold;
   color: var(--accent-color);
+  margin-left: 10px;
 }
 .retrorecon-root .ml-01 { margin-left: 0.1em; }
 

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -105,6 +105,7 @@ body.bg-hidden {
   letter-spacing: 0.04em;
   font-weight: bold;
   color: var(--accent-color);
+  margin-left: 10px;
 }
 
 .retrorecon-root .search-bar input[type="text"] {

--- a/templates/index.html
+++ b/templates/index.html
@@ -172,11 +172,11 @@
           <div class="menu-row"><a href="#" class="menu-btn">JWT Tool</a></div>
       </div>
     </div>
-    <div class="navbar__info">
-      <span class="db-info glow">loaded&gt; {{ db_name }}</span>
-    </div>
     <div class="navbar__title">
-      <h1><a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.0.1</span></a></h1>
+      <h1>
+        <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.0.1</span></a>
+        <span class="db-info glow">loaded&gt; {{ db_name }}</span>
+      </h1>
     </div>
   </nav>
 


### PR DESCRIPTION
## Summary
- show loaded database next to version string in navbar
- add margin between version and prompt
- update CSS audit report

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684def5ad2f08332800c458a20535bb0