### PR TITLE
Add boolean tag search

### DIFF
--- a/tests/test_search_boolean.py
+++ b/tests/test_search_boolean.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_search_db(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+    with app.app.app_context():
+        app.create_new_db("search")
+        app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://a.example/", "hostA,blue,tag1"])
+        app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://b.example/", "hostB,red,tag1"])
+    return app.app.test_client()
+
+
+def test_tag_and(monkeypatch, tmp_path):
+    client = setup_search_db(monkeypatch, tmp_path)
+    resp = client.get("/?tag=tag1+AND+red")
+    assert resp.status_code == 200
+    assert b"http://b.example/" in resp.data
+    assert b"http://a.example/" not in resp.data
+
+
+def test_tag_not(monkeypatch, tmp_path):
+    client = setup_search_db(monkeypatch, tmp_path)
+    resp = client.get("/?tag=NOT+hostB")
+    assert resp.status_code == 200
+    assert b"http://a.example/" in resp.data
+    assert b"http://b.example/" not in resp.data


### PR DESCRIPTION
## Summary
- enable boolean logic for tag search by parsing expressions
- fall back to simple LIKE queries on parse errors
- add tests covering boolean tag search

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0844a91c8332aba6fb236f8bc2b9