### PR TITLE
Add persistent saved tags

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -195,13 +195,18 @@
             <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" class="w-95 form-input" />
           </td>
         </tr>
+        <tr>
+          <td class="text-center">
+            <input type="text" name="tag" placeholder="Tags..." value="{{ tag }}" id="tagbox" class="w-95 form-input mt-05" />
+          </td>
+        </tr>
       </table>
       <div class="search-actions">
         <div id="search-history" class="search-history"></div>
         <div class="search-buttons">
           <button type="button" id="save-tag-btn" class="btn">Save Tag</button>
           <button type="submit" class="btn">Search</button>
-          <button type="button" class="btn" onclick="document.getElementById('searchbox').value=''; document.getElementById('search-form').submit();">Clear</button>
+          <button type="button" class="btn" onclick="document.getElementById('searchbox').value=''; document.getElementById('tagbox').value=''; document.getElementById('search-form').submit();">Clear</button>
         </div>
       </div>
     </form>
@@ -445,7 +450,10 @@
     pollImport();
 
     function quickSearch(term){
-      document.getElementById('searchbox').value = term;
+      const tagInput = document.getElementById('tagbox');
+      if(tagInput){
+        tagInput.value = term;
+      }
       document.getElementById('search-form').submit();
     }
 
@@ -466,7 +474,6 @@
     }
 
     async function loadHistory(){
-      const defaults = ['.js.map','.php','.env','.zip','.rar','.svg','.docx'];
       let saved = [];
       try {
         const resp = await fetch('/saved_tags');
@@ -475,12 +482,11 @@
           saved = Array.isArray(data.tags) ? data.tags : [];
         }
       } catch(e){}
-      const all = Array.from(new Set(defaults.concat(saved)));
-      all.forEach(addHistoryButton);
+      saved.forEach(addHistoryButton);
     }
 
     function saveTag(){
-      const val = document.getElementById('searchbox').value.trim();
+      const val = document.getElementById('tagbox').value.trim();
       if(!val) return;
       addHistoryButton(val);
       fetch('/saved_tags', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:val})});

--- a/templates/index.html
+++ b/templates/index.html
@@ -455,13 +455,26 @@
       btn.type = 'button';
       btn.textContent = text;
       btn.addEventListener('click', () => quickSearch(text));
+      btn.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        if(confirm('Delete saved tag?')){
+          historyDiv.removeChild(btn);
+          fetch('/delete_saved_tag', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:text})});
+        }
+      });
       historyDiv.appendChild(btn);
     }
 
-    function loadHistory(){
+    async function loadHistory(){
       const defaults = ['.js.map','.php','.env','.zip','.rar','.svg','.docx'];
       let saved = [];
-      try { saved = JSON.parse(localStorage.getItem('searchHistory') || '[]'); } catch(e){}
+      try {
+        const resp = await fetch('/saved_tags');
+        if(resp.ok){
+          const data = await resp.json();
+          saved = Array.isArray(data.tags) ? data.tags : [];
+        }
+      } catch(e){}
       const all = Array.from(new Set(defaults.concat(saved)));
       all.forEach(addHistoryButton);
     }
@@ -470,12 +483,7 @@
       const val = document.getElementById('searchbox').value.trim();
       if(!val) return;
       addHistoryButton(val);
-      let saved = [];
-      try { saved = JSON.parse(localStorage.getItem('searchHistory') || '[]'); } catch(e){}
-      if(!saved.includes(val)){
-        saved.push(val);
-        localStorage.setItem('searchHistory', JSON.stringify(saved));
-      }
+      fetch('/saved_tags', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:val})});
     }
 
     document.getElementById('save-tag-btn').addEventListener('click', saveTag);

--- a/tests/test_saved_tags.py
+++ b/tests/test_saved_tags.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    monkeypatch.setattr(app, "SAVED_TAGS_FILE", str(tmp_path / "tags.json"))
+
+
+def test_saved_tag_crud(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/saved_tags')
+        assert resp.get_json() == {"tags": []}
+
+        resp = client.post('/saved_tags', data={'tag': 'foo'})
+        assert resp.status_code == 204
+        assert (tmp_path / "tags.json").exists()
+
+        resp = client.get('/saved_tags')
+        assert resp.get_json() == {"tags": ["foo"]}
+
+        client.post('/saved_tags', data={'tag': 'foo'})  # duplicate
+        resp = client.get('/saved_tags')
+        assert resp.get_json() == {"tags": ["foo"]}
+
+        resp = client.post('/delete_saved_tag', data={'tag': 'foo'})
+        assert resp.status_code == 204
+        resp = client.get('/saved_tags')
+        assert resp.get_json() == {"tags": []}


### PR DESCRIPTION
## Summary
- store saved tags in `saved_tags.json`
- expose `/saved_tags` and `/delete_saved_tag` routes
- update UI to use new endpoints and allow deleting tags
- test saved tag CRUD behavior

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0d7f6b848332be0da122834e4a1c