### PR TITLE
Fix boolean tag search with spaces

### DIFF
--- a/app.py
+++ b/app.py
@@ -265,7 +265,10 @@ def execute_db(query: str, args: Union[Tuple, List] = ()) -> int:
 def _tokenize_tag_expr(expr: str) -> List[str]:
     """Return a list of tokens for a boolean tag expression."""
 
-    token_re = re.compile(r"\(|\)|AND|OR|NOT|\"[^\"]+\"|\S+", re.IGNORECASE)
+    token_re = re.compile(
+        r"\(|\)|\bAND\b|\bOR\b|\bNOT\b|\"[^\"]+\"|[^\s()]+",
+        re.IGNORECASE,
+    )
     tokens = token_re.findall(expr)
     return [t.strip('"') for t in tokens]
 

--- a/tests/test_search_boolean.py
+++ b/tests/test_search_boolean.py
@@ -18,6 +18,19 @@ def setup_search_db(monkeypatch, tmp_path):
         app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://b.example/", "hostB,red,tag1"])
     return app.app.test_client()
 
+def setup_space_tag_db(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+    with app.app.app_context():
+        app.create_new_db("search")
+        app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://a.example/", "tag1,tag 2"])
+        app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://b.example/", "tag1,tag4"])
+    return app.app.test_client()
+
 
 def test_tag_and(monkeypatch, tmp_path):
     client = setup_search_db(monkeypatch, tmp_path)
@@ -33,3 +46,14 @@ def test_tag_not(monkeypatch, tmp_path):
     assert resp.status_code == 200
     assert b"http://a.example/" in resp.data
     assert b"http://b.example/" not in resp.data
+
+
+def test_tag_with_space(monkeypatch, tmp_path):
+    client = setup_space_tag_db(monkeypatch, tmp_path)
+    resp = client.get("/?q=%23tag%202%20AND%20NOT%20%23tag4")
+    assert resp.status_code == 200
+    assert b"http://a.example/" in resp.data
+    assert b"http://b.example/" not in resp.data
+    resp = client.get("/?q=%23%22tag%202%22")
+    assert resp.status_code == 200
+    assert b"http://a.example/" in resp.data


### PR DESCRIPTION
## Summary
- update tokenizer regex to handle AND/OR/NOT only as standalone words
- add regression test for tags containing spaces

## Testing
- `npm install`
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e324253d88332a42a6a7d354c88f7