### PR TITLE
Add close buttons to saved search pills

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -1,12 +1,12 @@
 {
   "coverage": {
     "button": {
-      "total": 36,
-      "styled": 36
+      "total": 35,
+      "styled": 35
     },
     "input": {
-      "total": 12,
-      "styled": 8
+      "total": 10,
+      "styled": 6
     },
     "select": {
       "total": 2,

--- a/static/base.css
+++ b/static/base.css
@@ -279,16 +279,6 @@
   gap: 0.3em;
 }
 
-.retrorecon-root .search-history button {
-   background: var(--bg-color);
-   border: 1px solid var(--fg-color);
-   color: var(--fg-color);
-   border-radius: 12px;
-   font-size: 0.95em;
-   padding: 2px 12px;
-   cursor: pointer;
-   transition: opacity 0.2s;
-}
 
 .retrorecon-root .db-buttons{
   display: flex;
@@ -729,6 +719,10 @@
   transition: opacity 0.2s;
 }
 
+.retrorecon-root .search-history .tag-pill {
+  cursor: pointer;
+}
+
 /* Buttons in row actions */
 .retrorecon-root .copy-btn,
 .retrorecon-root .delete-btn,
@@ -845,9 +839,6 @@
   opacity: 0.8;
 }
 /* Style for the total results count */
-.retrorecon-root .search-history button:hover{
-  opacity: 0.8;
-}
 .retrorecon-root .db-buttons button:hover{
   opacity: 0.85;
 }
@@ -858,6 +849,9 @@
   opacity: 0.85;
 }
 .retrorecon-root .tag-pill button:hover {
+  opacity: 0.8;
+}
+.retrorecon-root .search-history .tag-pill button:hover {
   opacity: 0.8;
 }
 .retrorecon-root .total-count {

--- a/templates/index.html
+++ b/templates/index.html
@@ -447,18 +447,26 @@
 
     function addHistoryButton(text){
       const historyDiv = document.getElementById('search-history');
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.textContent = text;
-      btn.addEventListener('click', () => quickSearch(text));
-      btn.addEventListener('contextmenu', (e) => {
-        e.preventDefault();
+      const pill = document.createElement('span');
+      pill.className = 'tag-pill';
+      pill.style.cursor = 'pointer';
+      const label = document.createElement('span');
+      label.textContent = text;
+      pill.appendChild(label);
+      const close = document.createElement('button');
+      close.type = 'button';
+      close.innerHTML = '&times;';
+      close.title = 'Remove tag';
+      close.addEventListener('click', (e) => {
+        e.stopPropagation();
         if(confirm('Delete saved tag?')){
-          historyDiv.removeChild(btn);
+          historyDiv.removeChild(pill);
           fetch('/delete_saved_tag', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:text})});
         }
       });
-      historyDiv.appendChild(btn);
+      pill.appendChild(close);
+      pill.addEventListener('click', () => quickSearch(text));
+      historyDiv.appendChild(pill);
     }
 
     async function loadHistory(){


### PR DESCRIPTION
## Summary
- refactor search history buttons into removable tag pills
- style search tag pills consistently with other tags
- update CSS report

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684e3838b0b883328cda56469d913992