### PR TITLE
Fix search history tag styling

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -721,6 +721,16 @@
 }
 
 .retrorecon-root .search-history .tag-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  background: var(--bg-color);
+  opacity: 1;
+  border-radius: 10px;
+  border: 1px solid #0d011e;   /* Purple sparklies */
+  margin-right: 4px;
+  font-size: 0.95em;
+  margin-bottom: 4px;
+  color: var(--fg-color);
   cursor: pointer;
 }
 

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -146,6 +146,20 @@ body.bg-hidden {
   transition: opacity 0.2s;
 }
 
+.retrorecon-root .search-history .tag-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  background: var(--bg-color);
+  opacity: 1;
+  border-radius: 10px;
+  border: 1px solid #0d011e;
+  margin-right: 4px;
+  font-size: 0.95em;
+  margin-bottom: 4px;
+  color: var(--fg-color);
+  cursor: pointer;
+}
+
 .retrorecon-root .search-bar button {
   font-size: 1.05em;
   padding: 5px 10px;


### PR DESCRIPTION
## Summary
- ensure saved search history tags share pill styles with result tags
- add themed rule for search history tags

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`
- `python scripts/generate_midnight_themes.py`

------
https://chatgpt.com/codex/tasks/task_e_684e3dfdb8ac8332a33f09dad222f5a1