### PR TITLE
Fix search history tag styling

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -721,8 +721,25 @@
 }
 
 .retrorecon-root .search-history .tag-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  background: var(--bg-color);
+  opacity: 1;
+  border-radius: 10px;
+  border: 1px solid #0d011e;   /* Purple sparklies */
+  margin-right: 4px;
+  font-size: 0.95em;
+  margin-bottom: 4px;
+  color: var(--fg-color);
   cursor: pointer;
 }
+.retrorecon-root .tag-pill:hover,
+.retrorecon-root .search-history .tag-pill:hover {
+  opacity: 0.8;
+  box-shadow: 0 0 6px var(--fg-color);
+}
+
 
 /* Buttons in row actions */
 .retrorecon-root .copy-btn,
@@ -836,6 +853,16 @@
   fill: var(--accent-color);
 }
 
+.retrorecon-root .search-history .tag-pill button {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1em;
+  margin-left: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
 .retrorecon-root .search-bar button:hover{
   opacity: 0.8;
 }
@@ -850,9 +877,11 @@
   opacity: 0.85;
 }
 .retrorecon-root .tag-pill button:hover {
+  box-shadow: none;
   opacity: 0.8;
 }
 .retrorecon-root .search-history .tag-pill button:hover {
+  box-shadow: none;
   opacity: 0.8;
 }
 .retrorecon-root .total-count {

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -145,6 +145,44 @@ body.bg-hidden {
   cursor: pointer;
   transition: opacity 0.2s;
 }
+.retrorecon-root .tag-pill button:hover {
+  box-shadow: none;
+  opacity: 0.8;
+}
+
+.retrorecon-root .search-history .tag-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  background: var(--bg-color);
+  opacity: 1;
+  border-radius: 10px;
+  border: 1px solid #0d011e;
+  margin-right: 4px;
+  font-size: 0.95em;
+  margin-bottom: 4px;
+  color: var(--fg-color);
+  cursor: pointer;
+}
+.retrorecon-root .tag-pill:hover,
+.retrorecon-root .search-history .tag-pill:hover {
+  opacity: 0.8;
+  box-shadow: 0 0 6px var(--fg-color);
+}
+
+.retrorecon-root .search-history .tag-pill button {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1em;
+  margin-left: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.retrorecon-root .search-history .tag-pill button:hover {
+  box-shadow: none;
+  opacity: 0.8;
+}
 
 .retrorecon-root .search-bar button {
   font-size: 1.05em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -455,6 +455,7 @@
       pill.appendChild(label);
       const close = document.createElement('button');
       close.type = 'button';
+      close.className = 'btn';
       close.innerHTML = '&times;';
       close.title = 'Remove tag';
       close.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- display saved search tags with same pill styles as result tags
- highlight full pill on hover instead of button

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`
- `python scripts/generate_midnight_themes.py`


------
https://chatgpt.com/codex/tasks/task_e_684e3dfdb8ac8332a33f09dad222f5a1