### PR TITLE
Refactor search bar layout

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -215,6 +215,15 @@
   width: 100%;
 }
 
+/* Row containing search input and buttons */
+.retrorecon-root .search-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
 /* Row below search input containing history pills and buttons */
 .retrorecon-root .search-actions{
   display: flex;
@@ -238,6 +247,12 @@
   color: var(--fg-color);
   flex: 2;
   min-width: 0;
+}
+
+/* Specific width for main search box */
+.retrorecon-root #searchbox {
+  width: calc(100% - 270px);
+  flex: none;
 }
 
 /* Buttons inside search bar */

--- a/templates/index.html
+++ b/templates/index.html
@@ -188,21 +188,15 @@
   <!-- Table B : Search bar and buttons -->
   <div class="search-bar">
     <form method="GET" action="/" id="search-form">
-      <table class="w-100">
-        <tr>
-          <td class="text-center">
-            <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" class="w-100 form-input" />
-          </td>
-        </tr>
-      </table>
-      <div class="search-actions">
-        <div id="search-history" class="search-history"></div>
+      <div class="search-input-row">
+        <input type="text" name="q" placeholder="Search..." value="{{ q }}" id="searchbox" class="w-100 form-input" />
         <div class="search-buttons">
-          <button type="button" id="save-tag-btn" class="btn">Save Tag</button>
           <button type="submit" class="btn">Search</button>
+          <button type="button" id="save-tag-btn" class="btn">Save Tag</button>
           <button type="button" class="btn" onclick="document.getElementById('searchbox').value=''; document.getElementById('search-form').submit();">Clear</button>
         </div>
       </div>
+      <div id="search-history" class="search-history"></div>
     </form>
   </div>
 


### PR DESCRIPTION
## Summary
- shorten the width of the main search box
- move search buttons next to the input

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e46f0cdbc83329f135b15504b6303