### PR TITLE
Add boolean tag search docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !data/demo_data.json
 !package.json
 !.stylelintrc.json
+!retrorecon.postman.json
 node_modules/
 package-lock.json
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - **CDX import** from the Wayback Machine API
 - **JSON import** of URL lists or records
 - Background import with progress indicator
-- Search and filter by text and tags
+- Search and filter by text and tags, including Boolean tag expressions like `#blue AND #tag1`
 - Inline and bulk tag management
 - Bulk actions with "select all visible" or "select all matching"
 - Quick OSINT links for each URL (Wayback, Shodan, VirusTotal, Google, GitHub, crt.sh)
@@ -64,6 +64,18 @@ Then open <http://127.0.0.1:5000> in your browser.
    name) using the menu. You can also rename the active database from the same
    dropdown.
 6. When you relaunch the app, it automatically reloads the last database you used.
+
+### Boolean Tag Searches
+
+Prefix tags with `#` and combine them using `AND`, `OR` and `NOT` in the search box. Quotes allow tags with spaces.
+
+Example queries:
+
+```bash
+curl -G --data-urlencode "q=#tag1 AND #red" http://localhost:5000/
+curl -G --data-urlencode "q=#blue OR #red" http://localhost:5000/
+curl -G --data-urlencode "q=#\"tag 2\" AND NOT #tag4" http://localhost:5000/
+```
 
 ## License
 MIT

--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -1,0 +1,38 @@
+{
+  "info": {
+    "name": "Retrorecon API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Boolean tag search",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{base_url}}/?q=%23tag1%20AND%20%23red",
+          "host": ["{{base_url}}"],
+          "path": [""],
+          "query": [
+            {"key": "q", "value": "#tag1 AND #red"}
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('status is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "pm.test('contains matching URL', function () {",
+              "    pm.expect(pm.response.text()).to.include('http://b.example/');",
+              "});"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document boolean tag expressions in README
- include example curl commands
- add Postman collection with test for boolean tag search
- allow Postman JSON to be version controlled

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e6ad3db688332919eabcb4192f408