### PR TITLE
Fix neon font styling in navbar

### DIFF
--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -99,6 +99,18 @@ body.bg-hidden {
   background: rgb(var(--bg-rgb)/var(--panel-opacity));
 }
 
+/* Ensure nav menu controls use the theme font */
+.retrorecon-root .navbar button,
+.retrorecon-root .navbar select,
+.retrorecon-root .navbar input,
+.retrorecon-root .navbar .menu-label {
+  font-family: inherit;
+  color: var(--font-main);
+}
+.retrorecon-root .navbar .menu-btn {
+  font-family: inherit;
+}
+
 
 .retrorecon-root .db-info {
   font-size: 0.7em;


### PR DESCRIPTION
## Summary
- ensure navbar menu buttons and labels inherit the neon theme font

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684e71295bc083329869a9309ea124f5