### PR TITLE
Normalize neon table font size

### DIFF
--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -42,9 +42,15 @@ body.bg-hidden {
   background: #14122200;
   color: var(--font-main);
   border-bottom: 1px solid var(--border-color);
+  font-size: 13.333px;
 }
+
+.retrorecon-root .url-row-main td {
+  font-size: 13.333px;
+}
+
 .retrorecon-root .url-row-main.url-result td {
-  font-size: 1.2em;
+  font-size: 13.333px;
   font-weight: bold;
   color: var(--accent-color);
 }


### PR DESCRIPTION
## Summary
- ensure `.url-table` fonts are consistently `13.333px` in `theme-neon.css`

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684e75b1e1a08332ade912e84fabdedb