### PR TITLE
Apply white outline to pills and buttons

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -60,7 +60,7 @@
 
 /* Generic form styles */
 .retrorecon-root .btn {
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   background: var(--bg-color);
   color: var(--fg-color);
   padding: 2px 10px;
@@ -75,7 +75,7 @@
 .retrorecon-root .form-input,
 .retrorecon-root .form-file,
 .retrorecon-root .form-select {
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -91,7 +91,7 @@
 
 /* Ensure file inputs inherit base form styling */
 .retrorecon-root input[type="file"] {
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -109,7 +109,7 @@
 /* Glowing style for all buttons */
 .retrorecon-root button {
   background: var(--fg-color);
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   color: var(--fg-color);
   border-radius: 7px;
   padding: 2px 11px;
@@ -129,7 +129,7 @@
 .retrorecon-root input[type="text"],
 .retrorecon-root input[type="file"],
 .retrorecon-root select {
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -243,7 +243,7 @@
   font-size: 1.2em;
   padding: 6px 10px;
   border-radius: 5px;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   background: var(--bg-color);
   color: var(--fg-color);
   flex: 2;
@@ -261,7 +261,7 @@
   font-size: 1.05em;
   padding: 5px 10px;
   border-radius: 5px;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   background: var(--bg-color);
   color: var(--fg-color);
   cursor: pointer;
@@ -305,7 +305,7 @@
   margin: 0;
 }
 .retrorecon-root .db-buttons button{
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   background: var(--bg-color);
   color: var(--fg-color);
   padding: 2px 10px;
@@ -342,7 +342,7 @@
   font-size: 1em;
   cursor: pointer;
   transition: opacity 0.2s;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 0;
 }
 .retrorecon-root .dropbtn:hover,
@@ -358,7 +358,7 @@
   z-index: 1;
   padding: 8px 12px;
   border-radius: 0;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   margin-top: 6px;
   color: var(--fg-color);
 }
@@ -416,7 +416,7 @@
 .retrorecon-root .menu-row .menu-btn,
 .retrorecon-root .menu-row a.menu-btn {
   background: transparent;
-  border: none;
+  border: 1px solid #fff;
   color: var(--fg-color);
   padding: 0.2em 0.4em;
   text-align: left;
@@ -428,7 +428,7 @@
 .retrorecon-root .dropdown-content .menu-btn,
 .retrorecon-root .dropdown-content a.menu-btn {
   background: transparent;
-  border: none;
+  border: 1px solid #fff;
   color: var(--fg-color);
   padding: 0.2em 0.4em;
   text-align: left;
@@ -462,7 +462,7 @@
 .retrorecon-root .import-row input[type="text"], .retrorecon-root .import-row input[type="file"]{
   width: 100%;
   max-width: 250px;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -470,7 +470,7 @@
 }
 
 .retrorecon-root .import-row button {
-    border: 1px solid var(--fg-color);
+    border: 1px solid #fff;
     background: var(--bg-color);
     color: var(--fg-color);
     padding: 2px 10px;
@@ -484,7 +484,7 @@
 .retrorecon-root #map-url-input {
   width: 250px;
   max-width: 100%;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -496,7 +496,7 @@
 }
 
 .retrorecon-root .theme-row button {
-    border: 1px solid var(--fg-color);
+    border: 1px solid #fff;
     background: var(--bg-color);
     color: var(--fg-color);
     padding: 2px 10px;
@@ -508,7 +508,7 @@
 .retrorecon-root #mapUrlInput {
   flex: 1;
   font-size: 1em;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -587,7 +587,7 @@
   font-size: 0.98em;
   padding: 2px 8px;
   border-radius: 5px;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   background: var(--bg-color);
   color: var(--fg-color);
 }
@@ -596,7 +596,7 @@
   font-size: 0.98em;
   padding: 2px 8px;
   border-radius: 5px;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   background: var(--bg-color);
   color: var(--fg-color);
 }
@@ -705,7 +705,7 @@
 .retrorecon-root .url-tools-row input[type="text"] {
   font-size: 0.9em;
   padding: 2px 6px;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -717,7 +717,7 @@
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
-  border: 1px solid #0d011e;   /* Purple sparklies */
+  border: 1px solid #fff;
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
@@ -743,7 +743,7 @@
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
-  border: 1px solid #0d011e;   /* Purple sparklies */
+  border: 1px solid #fff;
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
@@ -769,7 +769,7 @@
 .retrorecon-root .google-btn,
 .retrorecon-root .crtsh-btn {
   background: var(--bg-color);
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 7px;
   color: #2cbaf3;
   font-size: 1em;
@@ -816,7 +816,7 @@
     margin: 1em;
     border-radius: 4px;
     transition: background 0.2s;
-    /* border: 1px solid var(--fg-color); */
+    /* border: 1px solid #fff; */
     color: var(--fg-color);
     background: var(--bg-color);
     display: flex;
@@ -850,7 +850,7 @@
   font-size: 0.9em;
   padding: 1px 4px;
   text-align: center;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -145,7 +145,7 @@ body.bg-hidden {
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
-  border: 1px solid #0d011e;
+  border: 1px solid #fff;
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
@@ -177,7 +177,7 @@ body.bg-hidden {
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
-  border: 1px solid #0d011e;
+  border: 1px solid #fff;
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
@@ -211,7 +211,7 @@ body.bg-hidden {
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
-  border: 1px solid #0d011e;
+  border: 1px solid #fff;
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
@@ -233,7 +233,7 @@ body.bg-hidden {
   font-size: 1.05em;
   padding: 5px 10px;
   border-radius: 5px;
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   background: var(--bg-color);
   color: var(--fg-color);
   cursor: pointer;
@@ -273,7 +273,7 @@ body.bg-hidden {
 .retrorecon-root .google-btn,
 .retrorecon-root .crtsh-btn {
   background: var(--bg-color);
-  border: 1px solid var(--fg-color);
+  border: 1px solid #fff;
   border-radius: 7px;
   color: #2cbaf3;
   font-size: 1em;

--- a/static/tools.css
+++ b/static/tools.css
@@ -33,7 +33,7 @@
   padding: 0.5em 1em;
   font-size: 1em;
   background-color: #f3f3f3;
-  border: 1px solid #999;
+  border: 1px solid #fff;
   border-radius: 4px;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- make tag pills in search history and URL results use a white border
- ensure all buttons in base styles and neon theme have white borders
- adjust webpack tools button border

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e83373d3483328267c840583d84d9