### PR TITLE
Center align header title

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -316,13 +316,17 @@
 
 /* Navbar layout */
 .retrorecon-root .navbar {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   align-items: center;
-  gap: 0.6em;
   margin: 0 10px;
 }
+.retrorecon-root .navbar__menus {
+  display: flex;
+  gap: 0.6em;
+}
 .retrorecon-root .navbar__title {
-  flex: 1;
+  text-align: center;
 }
 .retrorecon-root .navbar__info {
   margin-left: 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,6 +61,7 @@
   <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
 
   <nav class="navbar">
+  <div class="navbar__menus">
     <div class="dropdown">
       <button class="dropbtn" data-menu="file-menu">File ▼</button>
       <div class="dropdown-content" id="file-menu">
@@ -157,12 +158,14 @@
           <div class="menu-row"><a href="#" class="menu-btn">JWT Tool</a></div>
       </div>
     </div>
+  </div>
     <div class="navbar__title">
       <h1>
         <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.0.1</span></a>
         <span class="db-info glow">loaded&gt; {{ db_name }}</span>
       </h1>
     </div>
+  <div class="navbar__spacer"></div>
   </nav>
 
   <!-- Table B : Search bar and buttons -->


### PR DESCRIPTION
## Summary
- restructure `navbar` HTML to use a `navbar__menus` wrapper and add a spacer
- change navbar CSS to grid layout so the title is centered

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e88af51908332b88e67aefe03f109