### PR TITLE
Release 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - Browser-side search history for quick queries
 - Pagination with jump-to-page and total counts
 - Webpack Exploder: input a `.js.map` URL and download a ZIP of the sources
+- Save favorite tag searches for quick reuse
+- Adjustable panel opacity and font size
 
 ## Installation
 ```bash
@@ -64,6 +66,8 @@ Then open <http://127.0.0.1:5000> in your browser.
    name) using the menu. You can also rename the active database from the same
    dropdown.
 6. When you relaunch the app, it automatically reloads the last database you used.
+7. Save frequent tag searches with the **Save Tag** button or via the `/saved_tags` API.
+8. Adjust panel opacity and text size from the **Edit** menu or using the `/set_panel_opacity` and `/set_font_size` endpoints.
 
 ### Boolean Tag Searches
 
@@ -75,6 +79,24 @@ Example queries:
 curl -G --data-urlencode "q=#tag1 AND #red" http://localhost:5000/
 curl -G --data-urlencode "q=#blue OR #red" http://localhost:5000/
 curl -G --data-urlencode "q=#\"tag 2\" AND NOT #tag4" http://localhost:5000/
+```
+
+### Managing Saved Tags
+
+```bash
+# List saved tags
+curl http://localhost:5000/saved_tags
+# Add a tag query
+curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/saved_tags
+# Remove a tag query
+curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/delete_saved_tag
+```
+
+### Adjusting Font Size
+
+```bash
+curl -X POST -d "theme=nostalgia.css" -d "size=16" \
+  http://localhost:5000/set_font_size
 ```
 
 ## License

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -111,6 +111,45 @@ Parameter:
 curl -X POST -d "opacity=0.5" http://localhost:5000/set_panel_opacity
 ```
 
+### `POST /set_font_size`
+Adjust the base font size in the active theme.
+
+Parameters:
+- `size` – integer between `10` and `18`.
+- `theme` – CSS theme filename (optional if already set).
+
+```
+curl -X POST -d "theme=nostalgia.css" -d "size=16" \
+  http://localhost:5000/set_font_size
+```
+
+### `GET /saved_tags`
+Return the list of saved tag searches.
+
+```
+curl http://localhost:5000/saved_tags
+```
+
+### `POST /saved_tags`
+Add a new tag query to the saved list.
+
+Parameter:
+- `tag` – search expression to store.
+
+```
+curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/saved_tags
+```
+
+### `POST /delete_saved_tag`
+Remove a saved tag search.
+
+Parameter:
+- `tag` – query string to delete.
+
+```
+curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/delete_saved_tag
+```
+
 ### `POST /tools/webpack-zip`
 Download sources referenced in a Webpack `.js.map` file as a ZIP archive.
 

--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -5,34 +5,307 @@
   },
   "item": [
     {
-      "name": "Boolean tag search",
+      "name": "GET /",
       "request": {
         "method": "GET",
+        "header": [],
         "url": {
-          "raw": "{{base_url}}/?q=%23tag1%20AND%20%23red",
-          "host": ["{{base_url}}"],
-          "path": [""],
-          "query": [
-            {"key": "q", "value": "#tag1 AND #red"}
+          "raw": "{{base_url}}/",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": []
+        }
+      }
+    },
+    {
+      "name": "POST /fetch_cdx",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/fetch_cdx",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "fetch_cdx"
           ]
         }
-      },
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "type": "text/javascript",
-            "exec": [
-              "pm.test('status is 200', function () {",
-              "    pm.response.to.have.status(200);",
-              "});",
-              "pm.test('contains matching URL', function () {",
-              "    pm.expect(pm.response.text()).to.include('http://b.example/');",
-              "});"
-            ]
-          }
+      }
+    },
+    {
+      "name": "POST /import_json",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/import_json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "import_json"
+          ]
         }
-      ]
+      }
+    },
+    {
+      "name": "POST /import_file",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/import_file",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "import_file"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /import_progress",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/import_progress",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "import_progress"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /add_tag",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/add_tag",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "add_tag"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /bulk_action",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/bulk_action",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "bulk_action"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /set_theme",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/set_theme",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "set_theme"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /set_background",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/set_background",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "set_background"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /set_panel_opacity",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/set_panel_opacity",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "set_panel_opacity"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /set_font_size",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/set_font_size",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "set_font_size"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /saved_tags",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/saved_tags",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "saved_tags"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /saved_tags",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/saved_tags",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "saved_tags"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /delete_saved_tag",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/delete_saved_tag",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "delete_saved_tag"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/webpack-zip",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/webpack-zip",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "webpack-zip"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /new_db",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/new_db",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "new_db"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /load_db",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/load_db",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "load_db"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /save_db",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/save_db",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "save_db"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /rename_db",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/rename_db",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "rename_db"
+          ]
+        }
+      }
     }
   ]
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -161,7 +161,7 @@
   </div>
     <div class="navbar__title">
       <h1>
-        <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.0.1</span></a>
+        <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.1.0</span></a>
         <span class="db-info glow">loaded&gt; {{ db_name }}</span>
       </h1>
     </div>


### PR DESCRIPTION
## Summary
- regenerate Postman collection
- document new API routes and usage examples
- mention saved tag feature and custom font/opacity in README
- bump displayed version to `v1.1.0`
- tag release

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e8b72037c833288f94ff4337532d8