### PR TITLE
Improve saved tag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ curl -G --data-urlencode "q=NOT http:404" http://localhost:5000/
 ```bash
 # List saved tags
 curl http://localhost:5000/saved_tags
-# Add a tag query
-curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/saved_tags
+# Add a tag query (the leading # is optional)
+curl -X POST -d "tag=foo" http://localhost:5000/saved_tags
 # Remove a tag query
 curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/delete_saved_tag
 ```

--- a/app.py
+++ b/app.py
@@ -975,6 +975,8 @@ def saved_tags() -> Response:
     tag = request.form.get('tag', '').strip()
     if not tag:
         return ('', 400)
+    if not tag.startswith('#'):
+        tag = '#' + tag
     tags = load_saved_tags()
     if tag not in tags:
         tags.append(tag)
@@ -989,6 +991,8 @@ def delete_saved_tag() -> Response:
     tag = request.form.get('tag', '').strip()
     if not tag:
         return ('', 400)
+    if not tag.startswith('#'):
+        tag = '#' + tag
     tags = load_saved_tags()
     if tag in tags:
         tags.remove(tag)

--- a/templates/index.html
+++ b/templates/index.html
@@ -449,7 +449,7 @@
       pill.className = 'tag-pill';
       pill.style.cursor = 'pointer';
       const label = document.createElement('span');
-      label.textContent = text;
+      label.textContent = text.replace(/#/g, '');
       pill.appendChild(label);
       const close = document.createElement('button');
       close.type = 'button';
@@ -481,8 +481,11 @@
     }
 
     function saveTag(){
-      const val = document.getElementById('searchbox').value.trim();
+      let val = document.getElementById('searchbox').value.trim();
       if(!val) return;
+      if(!val.startsWith('#')){
+        val = '#' + val;
+      }
       addHistoryButton(val);
       fetch('/saved_tags', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:val})});
     }

--- a/tests/test_saved_tags.py
+++ b/tests/test_saved_tags.py
@@ -23,11 +23,11 @@ def test_saved_tag_crud(tmp_path, monkeypatch):
         assert (tmp_path / "tags.json").exists()
 
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": ["foo"]}
+        assert resp.get_json() == {"tags": ["#foo"]}
 
         client.post('/saved_tags', data={'tag': 'foo'})  # duplicate
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": ["foo"]}
+        assert resp.get_json() == {"tags": ["#foo"]}
 
         resp = client.post('/delete_saved_tag', data={'tag': 'foo'})
         assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- store hashtags for saved searches server-side
- auto prepend `#` when saving via UI
- display saved tags without the `#` prefix
- document hashtag behavior
- adjust tests for saved tags

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9646a48083328ca9e258eaa9b688