### PR TITLE
Fix menu hover glow

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -352,6 +352,7 @@
 .retrorecon-root .dropbtn:hover,
 .retrorecon-root .dropbtn:focus {
   opacity: 0.8;
+  box-shadow: none;
 }
 .retrorecon-root .dropdown-content {
   display: none;


### PR DESCRIPTION
## Summary
- prevent glow effect on nav menu buttons

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e99fe7edc8332a9998fd3b93a8b60