### PR TITLE
Style: highlight no results message

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -536,6 +536,15 @@
   gap: 1em;
 }
 
+/* Styling for the "no results" message */
+.retrorecon-root .results-grid__no-results {
+  background: #000;
+  color: #fff;
+  font-weight: bold;
+  text-shadow: 0 0 6px var(--accent-color);
+  padding: 1em;
+}
+
 .retrorecon-root .page-grid h1 {
   margin: 0;
   font-size: 1.8em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -285,7 +285,7 @@
             </table>
           </form>
           {% else %}
-            <div class="m-2em text-muted text-center">No URLs found for this query.</div>
+            <div class="m-2em text-center results-grid__no-results">No URLs found for this query.</div>
           {% endif %}
         </div>
       </td>


### PR DESCRIPTION
## Summary
- add BEM-styled class for empty results message
- update index template to use the new style

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9dea2e40833291ac1d3dc3ff3597