### PR TITLE
Enable quick open database via header

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -161,7 +161,7 @@
     <div class="navbar__title">
       <h1>
         <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.1.0</span></a>
-        <span class="db-info glow">loaded&gt; {{ db_name }}</span>
+        <span class="db-info glow cursor-pointer" id="db-display">loaded&gt; {{ db_name }}</span>
       </h1>
     </div>
   <div class="navbar__spacer"></div>
@@ -547,6 +547,10 @@
     const loadForm = document.getElementById('load-db-form');
     if (loadBtn && loadInput && loadForm) {
       loadBtn.addEventListener('click', () => loadInput.click());
+      const dbDisplay = document.getElementById('db-display');
+      if (dbDisplay) {
+        dbDisplay.addEventListener('click', () => loadInput.click());
+      }
       loadInput.addEventListener('change', () => {
         if (loadInput.files.length) {
           loadForm.submit();


### PR DESCRIPTION
## Summary
- make the database label clickable
- trigger the "Open Database" file picker when clicking the label

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ea104e0588332b64ef8429e2c434d