### PR TITLE
Fix hyperlink hover styling

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -179,7 +179,7 @@
   transition: color 0.2s;
 }
 .retrorecon-root a:hover{
-  text-decoration: underline;
+  text-decoration: none;
   color: var(--accent-color);
 }
 


### PR DESCRIPTION
## Summary
- ensure anchor hover state doesn't apply underline

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684efe4251ec83329a70d5b2ab8560ec