### PR TITLE
Fix newline handling for notes

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,6 @@ from flask import (
     jsonify,
     Response,
 )
-from markupsafe import escape
 
 app = Flask(__name__)
 # Allow overriding the startup database via environment variable
@@ -148,7 +147,7 @@ def add_note(url_id: int, content: str) -> int:
 
     return execute_db(
         "INSERT INTO notes (url_id, content) VALUES (?, ?)",
-        [url_id, escape(content)],
+        [url_id, content],
     )
 
 
@@ -157,7 +156,7 @@ def update_note(note_id: int, content: str) -> None:
 
     execute_db(
         "UPDATE notes SET content = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-        [escape(content), note_id],
+        [content, note_id],
     )
 
 

--- a/static/base.css
+++ b/static/base.css
@@ -1012,3 +1012,6 @@ body.bg-hidden {
 .retrorecon-root .note-item {
   margin-bottom: 0.5em;
 }
+.retrorecon-root .note-item span {
+  white-space: pre-wrap;
+}

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -76,3 +76,13 @@ def test_export_notes(tmp_path, monkeypatch):
         data = client.get("/export_notes").get_json()
         assert any(item["url"] == "http://a.com" and "foo" in item["notes"] for item in data)
         assert any(item["url"] == "http://b.com" and "bar" in item["notes"] for item in data)
+
+
+def test_multiline_note(tmp_path, monkeypatch):
+    url_id = init_sample(monkeypatch, tmp_path)
+    multiline = "Line1\nLine2\nLine3"
+    with app.app.test_client() as client:
+        resp = client.post("/notes", data={"url_id": url_id, "content": multiline})
+        assert resp.status_code == 204
+        data = client.get(f"/notes/{url_id}").get_json()
+        assert data[0]["content"] == multiline


### PR DESCRIPTION
## Summary
- remove unnecessary escaping of note text so newlines persist
- display notes using `white-space: pre-wrap`
- add regression test for multiline notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0cbfe5948332b054794d018f2213