### PR TITLE
Move notes button before explode

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -253,6 +253,7 @@
                         <input type="hidden" name="q" value="{{ q }}" />
                         <button type="submit" class="btn delete-btn" title="Delete">🗑️</button>
                       </form>
+                      <button type="button" class="btn ml-05 notes-btn" data-url-id="{{ url.id }}" onclick="openNotes(this)">📝 Notes</button>
                       {% if ".js.map" in url.url %}
                       <form method="POST" action="/tools/webpack-zip" class="d-inline ml-01">
                         <input type="hidden" name="map_url" value="{{ url.url }}" />
@@ -267,7 +268,6 @@
                         <input type="text" name="tag" placeholder="Tag" size="8" required class="form-input" />
                         <button type="submit" title="Add tag" class="btn">+</button>
                       </form>
-                      <button type="button" class="btn ml-05 notes-btn" data-url-id="{{ url.id }}" onclick="openNotes(this)">📝 Notes</button>
                       {% for tag in (url.tags or '').split(',') if tag %}
                       <span class="tag-pill">{{ tag }}
                         <form method="POST" action="/bulk_action" class="d-inline">


### PR DESCRIPTION
## Summary
- tweak notes button position so it appears after the Delete button and before the Explode button

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0f0f5b1883328a64f05c6b79c00a