### PR TITLE
Bugfix: sanitize HTML when saving notes

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from flask import (
     jsonify,
     Response,
 )
+from markupsafe import escape
 
 app = Flask(__name__)
 # Allow overriding the startup database via environment variable
@@ -147,7 +148,7 @@ def add_note(url_id: int, content: str) -> int:
 
     return execute_db(
         "INSERT INTO notes (url_id, content) VALUES (?, ?)",
-        [url_id, content],
+        [url_id, escape(content)],
     )
 
 
@@ -156,7 +157,7 @@ def update_note(note_id: int, content: str) -> None:
 
     execute_db(
         "UPDATE notes SET content = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-        [content, note_id],
+        [escape(content), note_id],
     )
 
 


### PR DESCRIPTION
## Summary
- sanitize note text using `markupsafe.escape` when saving

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f123d555c833290eb73385896fa53