### PR TITLE
Add Text Tools design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - Browser-side search history for quick queries
 - Pagination with jump-to-page and total counts
 - Webpack Exploder: input a `.js.map` URL and download a ZIP of the sources
+- **Text Tools** full-screen editor for Base64 and URL encoding/decoding
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -170,6 +170,41 @@ Parameter:
 curl -X POST -d "map_url=https://host/app.js.map" http://localhost:5000/tools/webpack-zip -o sources.zip
 ```
 
+### `GET /text_tools`
+Serve the Text Tools overlay used for encoding and decoding text.
+
+```
+curl http://localhost:5000/text_tools
+```
+
+### `POST /tools/base64_decode`
+Decode Base64 text sent in the `text` field. Returns plain text.
+
+```
+curl -X POST -d "text=SGVsbG8h" http://localhost:5000/tools/base64_decode
+```
+
+### `POST /tools/base64_encode`
+Encode posted text as Base64.
+
+```
+curl -X POST -d "text=Hello" http://localhost:5000/tools/base64_encode
+```
+
+### `POST /tools/url_decode`
+Convert percent-encoded strings back to their ASCII form.
+
+```
+curl -X POST -d "text=This%20is%20fine%21" http://localhost:5000/tools/url_decode
+```
+
+### `POST /tools/url_encode`
+Percent-encode a string so it is safe for use in URLs.
+
+```
+curl -X POST -d "text=This is fine!" http://localhost:5000/tools/url_encode
+```
+
 ### `POST /new_db`
 Create a new empty SQLite database.
 

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -74,3 +74,19 @@ This ensures database workflow tests are executed along with the existing suite 
 5. **Export Notes**
    - Add notes for multiple URLs.
    - GET `/export_notes` and validate the JSON structure contains each URL and its notes.
+
+## Text Tools Tests
+
+1. **Menu Entry**
+   - Click `Tools → Text Tools` from the navbar.
+   - Verify the overlay opens only when triggered by this menu option.
+
+2. **URL Encode/Decode**
+   - Enter `This is a sketchy string!?"` in the textarea.
+   - Click **URL Encode**, then **URL Decode**.
+   - The final text should match the original string exactly.
+
+3. **Base64 Round Trip**
+   - Input a multiline string using CRLF, LF and CR newlines.
+   - Press **Base64 Encode** then **Base64 Decode**.
+   - Text should return to the original form without errors.

--- a/docs/text_tools_spec.md
+++ b/docs/text_tools_spec.md
@@ -1,0 +1,61 @@
+# Text Tools Feature Plan
+
+This document defines the specification for the new **Text Tools** interface that replaces the existing Base64 Tool. The goal is to provide common text encoding and decoding actions directly within Retrorecon.
+
+## Goals
+- Add a menu option under **Tools** labelled `Text Tools`.
+- Provide a full-screen editor styled like the Notes overlay.
+- Support Base64 and URL encoding/decoding with inline updates.
+- Allow quick copying of the text and closing the tool.
+- Expose REST endpoints for each operation to enable API use and Postman tests.
+- Apply defensive coding practices to sanitize input and handle errors gracefully.
+
+## UI Design
+- When the user selects **Tools → Text Tools**, a full screen modal appears.
+- The modal mirrors the layout of the Notes overlay:
+  - Large `<textarea id="text-tool-input">` spans the top portion.
+  - Beneath the textarea is a row of buttons:
+    - **Base64 Decode**
+    - **Base64 Encode**
+    - **URL Decode**
+    - **URL Encode**
+    - **Copy** (copies the textarea contents using the Clipboard API)
+    - **Close** (hides the overlay)
+- All styles reuse the `.notes-overlay` rules from `static/base.css` with minimal additions under `.retrorecon-root`.
+- Each button triggers a fetch call to its matching API route. The returned text replaces the current textarea contents so chained operations are possible.
+
+## API Routes
+Four POST endpoints operate on a `text` field and return plain text results:
+- `POST /tools/base64_decode`
+- `POST /tools/base64_encode`
+- `POST /tools/url_decode`
+- `POST /tools/url_encode`
+
+Additionally `GET /text_tools` serves the overlay HTML/JS fragment for use in the SPA.
+
+Each route validates input, performs the transformation and returns a 200 response with `text/plain` content. Invalid Base64 data should return a 400 status with an error message.
+
+## Defensive Considerations
+- Limit request payload size (e.g. 64 KB) to avoid memory issues.
+- Use `base64.b64decode(..., validate=True)` so malformed input raises an error.
+- Reject decoding requests containing non-text bytes after decoding.
+- Escape output where it is inserted back into the DOM to prevent XSS.
+
+## Implementation Steps for Codex
+1. Create `text_tools.html` template containing the overlay markup and JavaScript to call the new routes and copy to clipboard.
+2. Add the `/text_tools` and `/tools/*` Flask routes in `app.py`.
+3. Update the `Tools` dropdown in `templates/index.html` to open the new overlay (rename old "Base64 Tool" link).
+4. Add styles in `static/tools.css` scoped under `.retrorecon-root` if needed.
+5. Register the new routes in the Postman collection using `scripts/generate_postman_collection.py`.
+6. Write unit tests covering:
+   - Menu opens the overlay only when triggered.
+   - Round‑trip URL encode/decode of `This is a sketchy string!?"`.
+   - Base64 encode/decode of a multiline string with various newline characters.
+7. Document the endpoints in `docs/api_routes.md` and update the README feature list.
+
+## Task Checklist for Codex
+- [ ] Implement HTML, CSS and JS for the Text Tools overlay.
+- [ ] Create the five Flask routes with validation and tests.
+- [ ] Update navigation link text and behaviour.
+- [ ] Extend documentation (`README.md`, `docs/api_routes.md`, `docs/test_plan.md`).
+- [ ] Regenerate `retrorecon.postman.json` and commit it.

--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -244,6 +244,90 @@
       }
     },
     {
+      "name": "GET /text_tools",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/text_tools",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "text_tools"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/base64_decode",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/base64_decode",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "base64_decode"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/base64_encode",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/base64_encode",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "base64_encode"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/url_decode",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/url_decode",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "url_decode"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/url_encode",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/url_encode",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "url_encode"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /new_db",
       "request": {
         "method": "POST",


### PR DESCRIPTION
## Summary
- create spec for new Text Tools overlay
- document API endpoints for Text Tools
- update feature list and Postman collection
- expand test plan with Text Tools cases

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1b2af9688332829f05d12ceddc5a