### PR TITLE
Implement Text Tools feature

### DIFF
--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -227,18 +227,66 @@
       }
     },
     {
-      "name": "POST /tools/webpack-zip",
+      "name": "GET /notes/<int:url_id>",
       "request": {
-        "method": "POST",
+        "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{base_url}}/tools/webpack-zip",
+          "raw": "{{base_url}}/notes/<int:url_id>",
           "host": [
             "{{base_url}}"
           ],
           "path": [
-            "tools",
-            "webpack-zip"
+            "notes",
+            "<int:url_id>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /notes",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/notes",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "notes"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /delete_note",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/delete_note",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "delete_note"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /export_notes",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/export_notes",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "export_notes"
           ]
         }
       }
@@ -323,6 +371,23 @@
           "path": [
             "tools",
             "url_encode"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/webpack-zip",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/webpack-zip",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "webpack-zip"
           ]
         }
       }

--- a/static/text_tools.js
+++ b/static/text_tools.js
@@ -1,0 +1,53 @@
+/* File: static/text_tools.js */
+document.addEventListener('DOMContentLoaded', function(){
+  const overlay = document.getElementById('text-tools-overlay');
+  if(!overlay) return;
+  const input = document.getElementById('text-tool-input');
+  const closeBtn = document.getElementById('text-tools-close-btn');
+  const copyBtn = document.getElementById('text-copy-btn');
+  const b64DecodeBtn = document.getElementById('b64-decode-btn');
+  const b64EncodeBtn = document.getElementById('b64-encode-btn');
+  const urlDecodeBtn = document.getElementById('url-decode-btn');
+  const urlEncodeBtn = document.getElementById('url-encode-btn');
+
+  async function transform(url){
+    const text = input.value;
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: {'Content-Type':'application/x-www-form-urlencoded'},
+        body: new URLSearchParams({text})
+      });
+      const data = await resp.text();
+      if(resp.ok){
+        input.value = data;
+      } else {
+        alert(data);
+      }
+    } catch(err){
+      alert('Error: ' + err);
+    }
+  }
+
+  b64DecodeBtn.addEventListener('click', () => transform('/tools/base64_decode'));
+  b64EncodeBtn.addEventListener('click', () => transform('/tools/base64_encode'));
+  urlDecodeBtn.addEventListener('click', () => transform('/tools/url_decode'));
+  urlEncodeBtn.addEventListener('click', () => transform('/tools/url_encode'));
+
+  copyBtn.addEventListener('click', async () => {
+    try{
+      await navigator.clipboard.writeText(input.value);
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1000);
+    } catch {
+      const t = document.createElement('textarea');
+      t.value = input.value;
+      document.body.appendChild(t);
+      t.select();
+      document.execCommand('copy');
+      document.body.removeChild(t);
+    }
+  });
+
+  closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+});

--- a/static/tools.css
+++ b/static/tools.css
@@ -48,3 +48,8 @@
   max-height: 400px;
   overflow-y: auto;
 }
+
+/* Text Tools overlay adjustments */
+.retrorecon-root #text-tools-overlay .btn {
+  margin-right: 0.25em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -153,7 +153,7 @@
             <button type="button" class="menu-btn" id="webpack-btn">Webpack Exploder</button>
           </form>
           <div class="menu-row"><a href="#" class="menu-btn">Site-to-zip</a></div>
-          <div class="menu-row"><a href="#" class="menu-btn">Base64 Tool</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="text-tools-link">Text Tools</a></div>
           <div class="menu-row"><a href="#" class="menu-btn">JWT Tool</a></div>
       </div>
     </div>
@@ -671,15 +671,30 @@
     const webpackBtn = document.getElementById('webpack-btn');
     const webpackInput = document.getElementById('webpack-url-input');
     const webpackForm = document.getElementById('webpack-form');
-    if (webpackBtn && webpackInput && webpackForm) {
-      webpackBtn.addEventListener('click', () => {
-        const url = prompt('Enter .js.map URL to explode:');
-        if (url) {
-          webpackInput.value = url;
-          webpackForm.submit();
-        }
-      });
-    }
+      if (webpackBtn && webpackInput && webpackForm) {
+        webpackBtn.addEventListener('click', () => {
+          const url = prompt('Enter .js.map URL to explode:');
+          if (url) {
+            webpackInput.value = url;
+            webpackForm.submit();
+          }
+        });
+      }
+
+      const textToolsLink = document.getElementById('text-tools-link');
+      let textToolsLoaded = false;
+      if (textToolsLink) {
+        textToolsLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          if (!textToolsLoaded) {
+            const resp = await fetch('/text_tools');
+            const html = await resp.text();
+            document.body.insertAdjacentHTML('beforeend', html);
+            textToolsLoaded = true;
+          }
+          document.getElementById('text-tools-overlay').classList.remove('hidden');
+        });
+      }
 
     const themeSelect = document.getElementById('theme-select');
     const themeForm = document.getElementById('set-theme-form');

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -1,0 +1,13 @@
+<!-- File: templates/text_tools.html -->
+<div id="text-tools-overlay" class="notes-overlay hidden">
+  <textarea id="text-tool-input" class="form-input notes-textarea" rows="6" placeholder="Enter text..."></textarea>
+  <div class="mt-05">
+    <button type="button" class="btn" id="b64-decode-btn">Base64 Decode</button>
+    <button type="button" class="btn" id="b64-encode-btn">Base64 Encode</button>
+    <button type="button" class="btn" id="url-decode-btn">URL Decode</button>
+    <button type="button" class="btn" id="url-encode-btn">URL Encode</button>
+    <button type="button" class="btn" id="text-copy-btn">Copy</button>
+    <button type="button" class="btn" id="text-tools-close-btn">Close</button>
+  </div>
+</div>
+<script src="{{ url_for('static', filename='text_tools.js') }}"></script>

--- a/tests/test_text_tools.py
+++ b/tests/test_text_tools.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_text_tools_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/text_tools')
+        assert resp.status_code == 200
+        assert b'id="text-tools-overlay"' in resp.data
+
+
+def test_url_encode_decode_roundtrip(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        original = 'This is a sketchy string!?"'
+        resp = client.post('/tools/url_encode', data={'text': original})
+        assert resp.status_code == 200
+        encoded = resp.get_data(as_text=True)
+        resp = client.post('/tools/url_decode', data={'text': encoded})
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == original
+
+
+def test_base64_roundtrip(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        text = 'line1\r\nline2\nline3\rend'
+        resp = client.post('/tools/base64_encode', data={'text': text})
+        assert resp.status_code == 200
+        b64 = resp.get_data(as_text=True)
+        resp = client.post('/tools/base64_decode', data={'text': b64})
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == text


### PR DESCRIPTION
## Summary
- implement Text Tools overlay HTML/JS
- create routes for base64/url encode and decode
- hook Text Tools link into navigation
- minor CSS tweak for buttons
- add tests and update Postman collection

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1e5690d88332abd1c541af265f6f