### PR TITLE
Fix Text Tools overlay

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -1,12 +1,12 @@
 {
   "coverage": {
     "button": {
-      "total": 34,
-      "styled": 34
+      "total": 42,
+      "styled": 42
     },
     "input": {
-      "total": 10,
-      "styled": 6
+      "total": 11,
+      "styled": 7
     },
     "select": {
       "total": 2,

--- a/static/text_tools.js
+++ b/static/text_tools.js
@@ -1,5 +1,5 @@
 /* File: static/text_tools.js */
-document.addEventListener('DOMContentLoaded', function(){
+function initTextTools(){
   const overlay = document.getElementById('text-tools-overlay');
   if(!overlay) return;
   const input = document.getElementById('text-tool-input');
@@ -50,4 +50,10 @@ document.addEventListener('DOMContentLoaded', function(){
   });
 
   closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
-});
+}
+
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', initTextTools);
+} else {
+  initTextTools();
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -689,7 +689,11 @@
           if (!textToolsLoaded) {
             const resp = await fetch('/text_tools');
             const html = await resp.text();
-            document.body.insertAdjacentHTML('beforeend', html);
+            const root = document.querySelector('.retrorecon-root') || document.body;
+            root.insertAdjacentHTML('beforeend', html);
+            const script = document.createElement('script');
+            script.src = '/static/text_tools.js';
+            document.body.appendChild(script);
             textToolsLoaded = true;
           }
           document.getElementById('text-tools-overlay').classList.remove('hidden');

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -10,4 +10,3 @@
     <button type="button" class="btn" id="text-tools-close-btn">Close</button>
   </div>
 </div>
-<script src="{{ url_for('static', filename='text_tools.js') }}"></script>


### PR DESCRIPTION
## Summary
- adjust Text Tools JS so initialization runs when added dynamically
- load Text Tools overlay inside `.retrorecon-root` and attach JS dynamically
- drop unused script tag from template
- regenerate CSS audit report

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684f20664dd48332a6659cb4b9f8d208