### PR TITLE
Add Save As option to Text Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - Browser-side search history for quick queries
 - Pagination with jump-to-page and total counts
 - Webpack Exploder: input a `.js.map` URL and download a ZIP of the sources
-- **Text Tools** full-screen editor for Base64 and URL encoding/decoding
+- **Text Tools** full-screen editor for Base64 and URL encoding/decoding with Save As
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/docs/text_tools_spec.md
+++ b/docs/text_tools_spec.md
@@ -20,6 +20,7 @@ This document defines the specification for the new **Text Tools** interface tha
     - **URL Decode**
     - **URL Encode**
     - **Copy** (copies the textarea contents using the Clipboard API)
+    - **Save As** (downloads the textarea contents as a plain text file)
     - **Close** (hides the overlay)
 - All styles reuse the `.notes-overlay` rules from `static/base.css` with minimal additions under `.retrorecon-root`.
 - Each button triggers a fetch call to its matching API route. The returned text replaces the current textarea contents so chained operations are possible.

--- a/static/text_tools.js
+++ b/static/text_tools.js
@@ -5,6 +5,7 @@ function initTextTools(){
   const input = document.getElementById('text-tool-input');
   const closeBtn = document.getElementById('text-tools-close-btn');
   const copyBtn = document.getElementById('text-copy-btn');
+  const saveBtn = document.getElementById('text-save-btn');
   const b64DecodeBtn = document.getElementById('b64-decode-btn');
   const b64EncodeBtn = document.getElementById('b64-encode-btn');
   const urlDecodeBtn = document.getElementById('url-decode-btn');
@@ -47,6 +48,18 @@ function initTextTools(){
       document.execCommand('copy');
       document.body.removeChild(t);
     }
+  });
+
+  saveBtn.addEventListener('click', () => {
+    const blob = new Blob([input.value], {type: 'text/plain'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'text.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   });
 
   closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -7,6 +7,7 @@
     <button type="button" class="btn" id="url-decode-btn">URL Decode</button>
     <button type="button" class="btn" id="url-encode-btn">URL Encode</button>
     <button type="button" class="btn" id="text-copy-btn">Copy</button>
+    <button type="button" class="btn" id="text-save-btn">Save As</button>
     <button type="button" class="btn" id="text-tools-close-btn">Close</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add **Save As** button in `text_tools.html`
- implement file download logic in `text_tools.js`
- document the new option in `README.md` and feature spec

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2409a5808332b0ca1073011436f8