### PR TITLE
Add JWT Tools design spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - Pagination with jump-to-page and total counts
 - Webpack Exploder: input a `.js.map` URL and download a ZIP of the sources
 - **Text Tools** full-screen editor for Base64 and URL encoding/decoding with Save As
+- **JWT Tools** decode, edit and sign JSON Web Tokens inside a full-screen editor
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor
@@ -116,6 +117,17 @@ curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/delete_saved_tag
 ```bash
 curl -X POST -d "theme=nostalgia.css" -d "size=16" \
   http://localhost:5000/set_font_size
+```
+
+### JWT Tools API
+
+```bash
+# Decode a JWT
+curl -X POST -d "token=eyJhbGciOi..." http://localhost:5000/tools/jwt_decode
+
+# Encode and sign a payload
+curl -X POST -d "payload={\"sub\":1}" -d "secret=mykey" \
+  http://localhost:5000/tools/jwt_encode
 ```
 
 ## License

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -205,6 +205,29 @@ Percent-encode a string so it is safe for use in URLs.
 curl -X POST -d "text=This is fine!" http://localhost:5000/tools/url_encode
 ```
 
+### `GET /jwt_tools`
+Serve the JWT Tools overlay used for decoding and encoding JWTs.
+
+```
+curl http://localhost:5000/jwt_tools
+```
+
+### `POST /tools/jwt_decode`
+Decode a JWT sent in the `token` field. Returns formatted JSON with readable timestamps.
+
+```
+curl -X POST -d "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
+  http://localhost:5000/tools/jwt_decode
+```
+
+### `POST /tools/jwt_encode`
+Encode a JSON payload into a JWT. Accepts `payload` and optional `secret`.
+
+```
+curl -X POST -d "payload={\"sub\":1}" -d "secret=mykey" \
+  http://localhost:5000/tools/jwt_encode
+```
+
 ### `POST /new_db`
 Create a new empty SQLite database.
 

--- a/docs/jwt_tools_spec.md
+++ b/docs/jwt_tools_spec.md
@@ -1,0 +1,52 @@
+# JWT Tools Feature Plan
+
+This document specifies the design for a new **JWT Tools** window within Retrorecon. The tool lets users decode, edit and re-encode JSON Web Tokens without leaving the application.
+
+## Goals
+- Provide a menu entry under **Tools** labelled `JWT Tools`.
+- Display a full-screen editor like the existing Text Tools overlay.
+- Allow decoding of JWTs into formatted JSON with timestamp conversion.
+- Allow encoding (and optional signing) of JWTs from edited JSON.
+- Highlight weak algorithms and fixed keys.
+- Offer quick copy and save actions.
+
+## UI Design
+- Selecting **Tools → JWT Tools** opens a modal overlay similar to `text_tools.html`.
+- The top half contains `<textarea id="jwt-tool-input">` for the JWT or JSON payload.
+- Beneath the textarea is a row of buttons:
+  - **JWT Decode**
+  - **JWT Encode**
+  - **Save As** – downloads the current text
+  - **Copy** – copies to the clipboard
+  - **Close** – hides the overlay
+- When decoding, the tool pretty prints the header and payload. Epoch values for `iat`, `nbf` and `exp` are translated to readable timestamps. Expired tokens show the `exp` value in black; valid tokens show it in green.
+- A small text input allows supplying a `secret` used when encoding/signing.
+- Algorithms considered weak (`none`, `HS256`, etc.) or tokens signed with a known fixed key should trigger a visible warning banner.
+
+## API Routes
+- `GET /jwt_tools` – serve the overlay HTML fragment.
+- `POST /tools/jwt_decode` – accept a `token` field and return formatted JSON. Validation errors return status 400.
+- `POST /tools/jwt_encode` – accept `payload` (JSON) and optional `secret`. Returns the encoded token.
+
+## Defensive Considerations
+- Limit request payloads to ~64 KB.
+- Use Python's `jwt` library with explicit algorithms to avoid `none` spoofing.
+- Catch decoding exceptions and return clear error messages.
+- Sanitize any JSON inserted back into the DOM.
+
+## Implementation Steps for Codex
+1. Create `jwt_tools.html` template and accompanying JS in `static/jwt_tools.js`.
+2. Implement the new Flask routes in `app.py` with robust error handling.
+3. Update the navigation menu text (`Text Tools` entry renamed to `JWT Tools`).
+4. Add CSS under `.retrorecon-root` in `tools.css` if additional styling is required.
+5. Regenerate the Postman collection via `scripts/generate_postman_collection.py` once routes are added.
+6. Extend documentation and unit tests as outlined below.
+
+## Task Checklist for Codex
+- [ ] Build the HTML, CSS and JS for the JWT Tools overlay.
+- [ ] Add the `/jwt_tools`, `/tools/jwt_decode` and `/tools/jwt_encode` routes.
+- [ ] Support optional signing when a secret is provided.
+- [ ] Display algorithm and key warnings when decoding.
+- [ ] Update the navigation menu and ensure the overlay only opens from the menu.
+- [ ] Create unit tests for decoding, encoding, signing and warnings.
+- [ ] Update `README.md`, `docs/api_routes.md`, `docs/test_plan.md` and regenerate `retrorecon.postman.json`.

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -90,3 +90,26 @@ This ensures database workflow tests are executed along with the existing suite 
    - Input a multiline string using CRLF, LF and CR newlines.
    - Press **Base64 Encode** then **Base64 Decode**.
    - Text should return to the original form without errors.
+
+## JWT Tools Tests
+
+1. **Menu Entry**
+   - Select `Tools → JWT Tools` from the navbar.
+   - Ensure the overlay opens only from this menu item and not during page load.
+
+2. **Decode Demo Token**
+   - Post a known demo token to `/tools/jwt_decode`.
+   - Response should contain formatted JSON and readable `exp` timestamp.
+
+3. **Edit and Encode**
+   - Decode a token, modify the JSON payload and encode it again.
+   - Decoding the result should reflect the edited fields.
+
+4. **Sign with Secret**
+   - Encode `{"sub":1}` with secret `secret123` and verify the signature using the same secret.
+
+5. **Weak Algorithm Warning**
+   - Decoding a token signed with `none` should return a warning flag in the response.
+
+6. **Fixed Key Warning**
+   - Provide a token signed with a known default key; decoding should highlight the weak key.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 beautifulsoup4
 cssutils
 pytest
+PyJWT

--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -376,6 +376,56 @@
       }
     },
     {
+      "name": "GET /jwt_tools",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/jwt_tools",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "jwt_tools"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/jwt_decode",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/jwt_decode",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "jwt_decode"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/jwt_encode",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/jwt_encode",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "jwt_encode"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /tools/webpack-zip",
       "request": {
         "method": "POST",

--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -1,0 +1,63 @@
+/* File: static/jwt_tools.js */
+function initJWTTools(){
+  const overlay = document.getElementById('jwt-tools-overlay');
+  if(!overlay) return;
+  const input = document.getElementById('jwt-tool-input');
+  const secret = document.getElementById('jwt-secret');
+  const decodeBtn = document.getElementById('jwt-decode-btn');
+  const encodeBtn = document.getElementById('jwt-encode-btn');
+  const copyBtn = document.getElementById('jwt-copy-btn');
+  const saveBtn = document.getElementById('jwt-save-btn');
+  const closeBtn = document.getElementById('jwt-close-btn');
+
+  async function call(url, data){
+    try{
+      const resp = await fetch(url, {
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded'},
+        body:new URLSearchParams(data)
+      });
+      const text = await resp.text();
+      if(resp.ok){
+        input.value = text;
+      }else{
+        alert(text);
+      }
+    }catch(err){
+      alert('Error: '+err);
+    }
+  }
+
+  decodeBtn.addEventListener('click', () => {
+    call('/tools/jwt_decode', {token: input.value});
+  });
+
+  encodeBtn.addEventListener('click', () => {
+    call('/tools/jwt_encode', {payload: input.value, secret: secret.value});
+  });
+
+  copyBtn.addEventListener('click', async () => {
+    try{
+      await navigator.clipboard.writeText(input.value);
+      copyBtn.textContent = 'Copied!';
+      setTimeout(()=>{copyBtn.textContent='Copy';},1000);
+    }catch{
+      const t=document.createElement('textarea');
+      t.value=input.value;document.body.appendChild(t);t.select();document.execCommand('copy');document.body.removeChild(t);
+    }
+  });
+
+  saveBtn.addEventListener('click', () => {
+    const blob=new Blob([input.value],{type:'text/plain'});
+    const url=URL.createObjectURL(blob);
+    const a=document.createElement('a');a.href=url;a.download='jwt.txt';document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);
+  });
+
+  closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initJWTTools);
+}else{
+  initJWTTools();
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -154,7 +154,7 @@
           </form>
           <div class="menu-row"><a href="#" class="menu-btn">Site-to-zip</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="text-tools-link">Text Tools</a></div>
-          <div class="menu-row"><a href="#" class="menu-btn">JWT Tool</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="jwt-tools-link">JWT Tools</a></div>
       </div>
     </div>
   </div>
@@ -697,6 +697,25 @@
             textToolsLoaded = true;
           }
           document.getElementById('text-tools-overlay').classList.remove('hidden');
+        });
+      }
+
+      const jwtToolsLink = document.getElementById('jwt-tools-link');
+      let jwtToolsLoaded = false;
+      if (jwtToolsLink) {
+        jwtToolsLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          if (!jwtToolsLoaded) {
+            const resp = await fetch('/jwt_tools');
+            const html = await resp.text();
+            const root = document.querySelector('.retrorecon-root') || document.body;
+            root.insertAdjacentHTML('beforeend', html);
+            const script = document.createElement('script');
+            script.src = '/static/jwt_tools.js';
+            document.body.appendChild(script);
+            jwtToolsLoaded = true;
+          }
+          document.getElementById('jwt-tools-overlay').classList.remove('hidden');
         });
       }
 

--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -1,0 +1,12 @@
+<!-- File: templates/jwt_tools.html -->
+<div id="jwt-tools-overlay" class="notes-overlay hidden">
+  <textarea id="jwt-tool-input" class="form-input notes-textarea" rows="6" placeholder="Enter JWT or JSON payload..."></textarea>
+  <div class="mt-05">
+    <input type="text" id="jwt-secret" class="form-input mr-05" placeholder="secret (optional)" />
+    <button type="button" class="btn" id="jwt-decode-btn">JWT Decode</button>
+    <button type="button" class="btn" id="jwt-encode-btn">JWT Encode</button>
+    <button type="button" class="btn" id="jwt-copy-btn">Copy</button>
+    <button type="button" class="btn" id="jwt-save-btn">Save As</button>
+    <button type="button" class="btn" id="jwt-close-btn">Close</button>
+  </div>
+</div>

--- a/tests/test_jwt_tools.py
+++ b/tests/test_jwt_tools.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_jwt_tools_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/jwt_tools')
+        assert resp.status_code == 200
+        assert b'id="jwt-tool-input"' in resp.data
+
+
+def test_jwt_decode_encode_roundtrip(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        demo = app.jwt.encode({'sub': '1'}, 'secret', algorithm='HS256')
+        resp = client.post('/tools/jwt_decode', data={'token': demo})
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload['sub'] == '1'
+        resp = client.post('/tools/jwt_encode', data={'payload': payload, 'secret': 'secret'})
+        assert resp.status_code == 200
+        new_jwt = resp.get_data(as_text=True)
+        assert new_jwt
+
+


### PR DESCRIPTION
## Summary
- document new JWT Tools overlay and routes
- describe API examples and tests
- update Postman collection
- mention JWT Tools in feature list and README API examples

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: jwt tools routes not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_684f2e1837888332b2f73378a781d83a