### PR TITLE
Add warnings and timestamp details to JWT Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ curl -X POST -d "theme=nostalgia.css" -d "size=16" \
 ```bash
 # Decode a JWT
 curl -X POST -d "token=eyJhbGciOi..." http://localhost:5000/tools/jwt_decode
+# Returns JSON with header and payload plus `exp_readable`, `expired`,
+# `alg_warning` and `key_warning` flags.
 
 # Encode and sign a payload
 curl -X POST -d "payload={\"sub\":1}" -d "secret=mykey" \

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -213,7 +213,9 @@ curl http://localhost:5000/jwt_tools
 ```
 
 ### `POST /tools/jwt_decode`
-Decode a JWT sent in the `token` field. Returns formatted JSON with readable timestamps.
+Decode a JWT sent in the `token` field. Returns JSON containing the header,
+payload and additional fields:
+`exp_readable`, `expired`, `alg_warning` and `key_warning`.
 
 ```
 curl -X POST -d "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -99,7 +99,8 @@ This ensures database workflow tests are executed along with the existing suite 
 
 2. **Decode Demo Token**
    - Post a known demo token to `/tools/jwt_decode`.
-   - Response should contain formatted JSON and readable `exp` timestamp.
+   - Response should contain formatted JSON and a readable `exp` timestamp.
+   - The JSON also includes `alg_warning` and `key_warning` flags.
 
 3. **Edit and Encode**
    - Decode a token, modify the JSON payload and encode it again.

--- a/static/tools.css
+++ b/static/tools.css
@@ -53,3 +53,18 @@
 .retrorecon-root #text-tools-overlay .btn {
   margin-right: 0.25em;
 }
+
+/* JWT Tools overlay */
+.retrorecon-root #jwt-tools-overlay .btn {
+  margin-right: 0.25em;
+}
+.retrorecon-root #jwt-warning {
+  color: #c00;
+  margin-top: 0.5em;
+}
+.retrorecon-root #jwt-exp.valid {
+  color: #0a0;
+}
+.retrorecon-root #jwt-exp.expired {
+  color: #000;
+}

--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -9,4 +9,6 @@
     <button type="button" class="btn" id="jwt-save-btn">Save As</button>
     <button type="button" class="btn" id="jwt-close-btn">Close</button>
   </div>
+  <div id="jwt-warning" class="hidden"></div>
+  <div id="jwt-exp" class="hidden"></div>
 </div>


### PR DESCRIPTION
## Summary
- enhance JWT decode route with header info, timestamp conversion and warnings
- expose warnings and decoded timestamp in JWT Tools UI
- update README and docs
- extend CSS and template for JWT Tools overlay
- add tests for warnings and expiration

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f313bf8e0833298a46f195f2e8058