### PR TITLE
Implement JWT cookie jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - Webpack Exploder: input a `.js.map` URL and download a ZIP of the sources
 - **Text Tools** full-screen editor for Base64 and URL encoding/decoding with Save As
 - **JWT Tools** decode, edit and sign JSON Web Tokens inside a full-screen editor
+  with a persistent JWT cookie jar
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor
@@ -130,6 +131,11 @@ curl -X POST -d "token=eyJhbGciOi..." http://localhost:5000/tools/jwt_decode
 # Encode and sign a payload
 curl -X POST -d "payload={\"sub\":1}" -d "secret=mykey" \
   http://localhost:5000/tools/jwt_encode
+```
+
+```bash
+# View logged JWT decodes
+curl http://localhost:5000/jwt_cookies
 ```
 
 ## License

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -34,3 +34,12 @@ CREATE TABLE IF NOT EXISTS notes (
     updated_at TIMESTAMP,
     FOREIGN KEY(url_id) REFERENCES urls(id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_cookies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    token TEXT,
+    header TEXT,
+    payload TEXT,
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -230,6 +230,14 @@ curl -X POST -d "payload={\"sub\":1}" -d "secret=mykey" \
   http://localhost:5000/tools/jwt_encode
 ```
 
+### `GET /jwt_cookies`
+Return the last 50 decoded JWT entries. Each object includes `issuer`, `alg`,
+`claims`, `notes`, `token` and `created_at`.
+
+```
+curl http://localhost:5000/jwt_cookies
+```
+
 ### `POST /new_db`
 Create a new empty SQLite database.
 

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -114,3 +114,6 @@ This ensures database workflow tests are executed along with the existing suite 
 
 6. **Fixed Key Warning**
    - Provide a token signed with a known default key; decoding should highlight the weak key.
+
+7. **Cookie Jar Entry**
+   - After a successful decode, `/jwt_cookies` should list the new token with issuer, algorithm and notes.

--- a/static/tools.css
+++ b/static/tools.css
@@ -68,3 +68,10 @@
 .retrorecon-root #jwt-exp.expired {
   color: #000;
 }
+.retrorecon-root #jwt-cookie-jar table {
+  table-layout: fixed;
+  font-size: 0.875em;
+}
+.retrorecon-root #jwt-cookie-jar .break-all {
+  word-break: break-all;
+}

--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -7,8 +7,10 @@
     <button type="button" class="btn" id="jwt-encode-btn">JWT Encode</button>
     <button type="button" class="btn" id="jwt-copy-btn">Copy</button>
     <button type="button" class="btn" id="jwt-save-btn">Save As</button>
+    <button type="button" class="btn" id="jwt-clear-btn">Clear</button>
     <button type="button" class="btn" id="jwt-close-btn">Close</button>
   </div>
   <div id="jwt-warning" class="hidden"></div>
   <div id="jwt-exp" class="hidden"></div>
+  <div id="jwt-cookie-jar" class="mt-05"></div>
 </div>


### PR DESCRIPTION
## Summary
- add jwt_cookie table to DB schema
- log decoded JWT tokens and expose them via `/jwt_cookies`
- show a cookie jar table below the JWT overlay
- add Clear button for JWT Tools
- update docs and tests

## Testing
- `npm run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3884091c83329520b1c1c98c34f2