### PR TITLE
Fix JWT tools header styling and resizable columns

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -646,8 +646,8 @@
 
 /* Table header style this seems wrong to me JB*/
 .retrorecon-root .url-table thead {
-  background: var(--fg-color);
-  color: var(--bg-color);
+  background: #000;
+  color: #fff;
   opacity: 1;
 }
 .retrorecon-root .url-table th {

--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -17,8 +17,10 @@ function initJWTTools(){
   let sortDir = 'desc';
 
   function makeResizable(table){
+    table.style.tableLayout = 'fixed';
     const ths = table.querySelectorAll('th');
     ths.forEach(th => {
+      th.style.width = th.offsetWidth + 'px';
       const res = document.createElement('div');
       res.className = 'col-resizer';
       th.appendChild(res);

--- a/templates/index.html
+++ b/templates/index.html
@@ -824,8 +824,10 @@
 
     // Column resizing
     function makeResizable(table){
+      table.style.tableLayout = 'fixed';
       const ths = table.querySelectorAll('th');
       ths.forEach(th => {
+        th.style.width = th.offsetWidth + 'px';
         const res = document.createElement('div');
         res.className = 'col-resizer';
         th.appendChild(res);


### PR DESCRIPTION
## Summary
- use solid black background with white text for table headers
- make resizable columns work by setting `table-layout: fixed` and initial widths

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f458ff3488332a982c3c8382c9398