### PR TITLE
Enhance JWT cookie jar management

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -806,7 +806,8 @@
 
     // Sorting functionality
     document.querySelectorAll('.url-table th.sortable').forEach(th => {
-      th.addEventListener('click', () => {
+      th.addEventListener('click', (ev) => {
+        if(ev.target.closest('.col-resizer')) return;
         const sort = th.getAttribute('data-sort');
         const params = new URLSearchParams(window.location.search);
         const currentSort = params.get('sort');

--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -11,5 +11,10 @@
     <button type="button" class="btn" id="jwt-close-btn">Close</button>
   </div>
   <div class="mt-05 font-bold">JWT Cookie Jar</div>
+  <div class="mt-05">
+    <button type="button" class="btn" id="jwt-delete-btn">Delete</button>
+    <button type="button" class="btn" id="jwt-export-btn">Export</button>
+    <button type="button" class="btn" id="jwt-edit-btn">Edit</button>
+  </div>
   <div id="jwt-cookie-jar" class="mt-05"></div>
 </div>


### PR DESCRIPTION
## Summary
- allow deleting JWT cookies, exporting, and editing notes
- support selection checkboxes in cookie jar table
- expose endpoints for managing JWT entries
- prevent sorting while resizing columns
- test the new JWT cookie routes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f47eb1a808332895e30580f610b58