### PR TITLE
Improve cookie jar table UX

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -670,6 +670,17 @@
   width: 5px;
   height: 100%;
   cursor: col-resize;
+  background: transparent;
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.retrorecon-root .checkbox-col {
+  text-align: center;
+}
+
+.retrorecon-root .col-resizer:hover {
+  background: var(--accent-color);
+  box-shadow: 0 0 4px var(--accent-color);
 }
 
 /* Allow center alignment on specific header cells */

--- a/static/tools.css
+++ b/static/tools.css
@@ -62,6 +62,10 @@
   table-layout: fixed;
   font-size: 0.875em;
 }
+.retrorecon-root #jwt-cookie-jar th.checkbox-col,
+.retrorecon-root #jwt-cookie-jar td.checkbox-col {
+  text-align: center;
+}
 .retrorecon-root #jwt-cookie-jar .break-all {
   word-break: break-all;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -216,7 +216,7 @@
             <table class="url-table">
               <thead>
                 <tr>
-                  <th class="w-2em">
+                  <th class="w-2em no-resize text-center">
                     <input type="checkbox" id="select-all-rows" onchange="toggleSelectAllRows(this)" onclick="event.stopPropagation()" class="form-checkbox" />
                   </th>
                   <th class="sortable" data-sort="url">URL{% if current_sort=='url' %} {{ '▲' if current_dir=='asc' else '▼' }}{% endif %}</th>
@@ -228,7 +228,7 @@
               <tbody>
                 {% for url in urls %}
                 <tr class="url-row-main url-result cursor-pointer" onclick="window.open('{{ url.url }}', '_blank');">
-                  <td>
+                  <td class="checkbox-col">
                     <input type="checkbox" class="row-checkbox" name="selected_ids" value="{{ url.id }}" onclick="event.stopPropagation()" />
                   </td>
                   <td class="url-result"><div class="cell-content">{{ url.url }}</div></td>
@@ -824,11 +824,16 @@
     });
 
     // Column resizing
-    function makeResizable(table){
+    function makeResizable(table, key){
       table.style.tableLayout = 'fixed';
       const ths = table.querySelectorAll('th');
-      ths.forEach(th => {
-        th.style.width = th.offsetWidth + 'px';
+      let widths = {};
+      try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
+      ths.forEach((th, idx) => {
+        const id = idx;
+        if(widths[id]) th.style.width = widths[id];
+        th.style.width = th.style.width || th.offsetWidth + 'px';
+        if(th.classList.contains('no-resize')) return;
         const res = document.createElement('div');
         res.className = 'col-resizer';
         th.appendChild(res);
@@ -844,16 +849,18 @@
         function onMove(e){
           const w = startWidth + (e.pageX - startX);
           th.style.width = w + 'px';
+          widths[id] = th.style.width;
         }
         function stop(){
           document.removeEventListener('mousemove', onMove);
           document.removeEventListener('mouseup', stop);
+          localStorage.setItem(key, JSON.stringify(widths));
         }
       });
     }
 
     const urlTable = document.querySelector('.url-table');
-    if(urlTable) makeResizable(urlTable);
+    if(urlTable) makeResizable(urlTable, 'url-col-widths');
   </script>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- center checkboxes in the cookie jar table and main URL table
- highlight column drag handles on hover
- skip resizing the checkbox column
- remember column widths between sessions

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4a5bddd48332980b626c3ae1085c