### PR TITLE
Add persistent JWT tools page via routing

### DIFF
--- a/app.py
+++ b/app.py
@@ -601,6 +601,10 @@ def index() -> str:
     except ValueError:
         page = 1
 
+    tool = request.args.get('tool')
+    if request.path == '/tools/jwt':
+        tool = 'jwt'
+
     sort = request.args.get('sort', 'id')
     direction = request.args.get('dir', 'desc').lower()
     if direction not in ['asc', 'desc']:
@@ -700,7 +704,8 @@ def index() -> str:
         db_name=db_name,
         search_history=search_history,
         current_sort=sort,
-        current_dir=direction
+        current_dir=direction,
+        open_tool=tool
     )
 
 @app.route('/fetch_cdx', methods=['POST'])
@@ -1268,6 +1273,13 @@ def jwt_tools_page() -> str:
     """Return the JWT Tools overlay HTML fragment."""
 
     return render_template('jwt_tools.html')
+
+
+@app.route('/tools/jwt', methods=['GET'])
+def jwt_tools_full_page() -> str:
+    """Render index page with JWT Tools open for bookmarkable view."""
+
+    return index()
 
 
 @app.route('/tools/jwt_decode', methods=['POST'])

--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -183,7 +183,12 @@ function initJWTTools(){
     secret.value = '';
   });
 
-  closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/jwt'){
+      history.pushState({}, '', '/');
+    }
+  });
 
   function getSelected(){
     return Array.from(jarDiv.querySelectorAll('.row-checkbox:checked')).map(c => c.value);

--- a/templates/index.html
+++ b/templates/index.html
@@ -681,6 +681,8 @@
         });
       }
 
+      const openTool = "{{ open_tool or '' }}";
+
       const textToolsLink = document.getElementById('text-tools-link');
       let textToolsLoaded = false;
       if (textToolsLink) {
@@ -702,21 +704,46 @@
 
       const jwtToolsLink = document.getElementById('jwt-tools-link');
       let jwtToolsLoaded = false;
+
+      async function showJwtTools(skipPush){
+        if (!jwtToolsLoaded) {
+          const resp = await fetch('/jwt_tools');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/jwt_tools.js';
+          document.body.appendChild(script);
+          jwtToolsLoaded = true;
+        }
+        document.getElementById('jwt-tools-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'jwt'}, '', '/tools/jwt');
+        }
+      }
+
+      function hideJwtTools(){
+        const ov = document.getElementById('jwt-tools-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
       if (jwtToolsLink) {
         jwtToolsLink.addEventListener('click', async (e) => {
           e.preventDefault();
-          if (!jwtToolsLoaded) {
-            const resp = await fetch('/jwt_tools');
-            const html = await resp.text();
-            const root = document.querySelector('.retrorecon-root') || document.body;
-            root.insertAdjacentHTML('beforeend', html);
-            const script = document.createElement('script');
-            script.src = '/static/jwt_tools.js';
-            document.body.appendChild(script);
-            jwtToolsLoaded = true;
-          }
-          document.getElementById('jwt-tools-overlay').classList.remove('hidden');
+          showJwtTools();
         });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/jwt'){
+          showJwtTools(true);
+        } else {
+          hideJwtTools();
+        }
+      });
+
+      if(location.pathname === '/tools/jwt' || openTool === 'jwt'){
+        showJwtTools(true);
       }
 
     const themeSelect = document.getElementById('theme-select');

--- a/tests/test_jwt_tools.py
+++ b/tests/test_jwt_tools.py
@@ -24,6 +24,14 @@ def test_jwt_tools_route(tmp_path, monkeypatch):
         assert b'id="jwt-tool-input"' in resp.data
 
 
+def test_jwt_tools_full_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/tools/jwt')
+        assert resp.status_code == 200
+        assert b'openTool = "jwt"' in resp.data
+
+
 def test_jwt_decode_encode_roundtrip(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     with app.app.test_client() as client:


### PR DESCRIPTION
## Summary
- allow bookmarking JWT tools with `/tools/jwt` route
- keep overlay open when navigating directly to `/tools/jwt`
- update JS to push history state on open and close
- test new bookmarkable route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f4b9ec6948332804baad82ca62502