### PR TITLE
Fix JWT cookie jar checkbox width

### DIFF
--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -64,7 +64,7 @@ function initJWTTools(){
       return 0;
     });
     let html = '<table class="table url-table w-100"><thead><tr>'+
-      '<th class="checkbox-col no-resize text-center"><input type="checkbox" id="jwt-select-all" class="form-checkbox" /></th>'+
+      '<th class="w-2em checkbox-col no-resize text-center"><input type="checkbox" id="jwt-select-all" class="form-checkbox" /></th>'+
       '<th class="sortable" data-field="created_at">Time</th>'+
       '<th class="sortable" data-field="issuer">Issuer</th>'+
       '<th class="sortable" data-field="alg">alg</th>'+
@@ -74,7 +74,7 @@ function initJWTTools(){
       '</tr></thead><tbody>';
     for(const row of sorted){
       const claims = Array.isArray(row.claims) ? row.claims.join(',') : '';
-      html += `<tr data-id="${row.id}"><td class="checkbox-col"><input type="checkbox" class="row-checkbox" value="${row.id}"/></td>`+
+      html += `<tr data-id="${row.id}"><td class="w-2em checkbox-col"><input type="checkbox" class="row-checkbox" value="${row.id}"/></td>`+
         `<td><div class="cell-content">${row.created_at}</div></td>`+
         `<td><div class="cell-content">${row.issuer||''}</div></td>`+
         `<td><div class="cell-content">${row.alg||''}</div></td>`+

--- a/static/tools.css
+++ b/static/tools.css
@@ -65,6 +65,7 @@
 .retrorecon-root #jwt-cookie-jar th.checkbox-col,
 .retrorecon-root #jwt-cookie-jar td.checkbox-col {
   text-align: center;
+  width: 2em;
 }
 .retrorecon-root #jwt-cookie-jar .break-all {
   word-break: break-all;


### PR DESCRIPTION
## Summary
- constrain checkbox column width in JWT table
- apply width utility classes to checkbox cells

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f4e8c7f9483329b55590086103765