### PR TITLE
Add ScreenShotter feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ package-lock.json
 __pycache__/
 !reports/report.json
 last_db.txt
+static/screenshots/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - **Text Tools** full-screen editor for Base64 and URL encoding/decoding with Save As
 - **JWT Tools** decode, edit and sign JSON Web Tokens inside a full-screen editor
   with a persistent JWT cookie jar
+- **ScreenShotter** capture website screenshots in a headless browser
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,3 +43,11 @@ CREATE TABLE IF NOT EXISTS jwt_cookies (
     notes TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS screenshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT,
+    method TEXT,
+    screenshot_path TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/static/screenshotter.js
+++ b/static/screenshotter.js
@@ -1,0 +1,77 @@
+/* File: static/screenshotter.js */
+function initScreenshotter(){
+  const overlay = document.getElementById('screenshot-overlay');
+  if(!overlay) return;
+  const urlInput = document.getElementById('screenshot-url');
+  const agentSel = document.getElementById('screenshot-agent');
+  const refChk = document.getElementById('screenshot-ref');
+  const captureBtn = document.getElementById('screenshot-capture-btn');
+  const tableDiv = document.getElementById('screenshot-table');
+  const deleteBtn = document.getElementById('screenshot-delete-btn');
+  const closeBtn = document.getElementById('screenshot-close-btn');
+  let tableData = [];
+
+  function render(){
+    let html = '<table class="table url-table w-100"><thead><tr>'+
+      '<th class="checkbox-col no-resize text-center"><input type="checkbox" id="shot-select-all" class="form-checkbox" /></th>'+
+      '<th>Time</th><th>URL</th><th>Method</th><th>Thumbnail</th>'+
+      '</tr></thead><tbody>';
+    for(const row of tableData){
+      const img = `<img src="${row.file}" class="screenshot-thumb"/>`;
+      html += `<tr data-id="${row.id}"><td class="checkbox-col"><input type="checkbox" class="row-checkbox" value="${row.id}"/></td>`+
+        `<td>${row.created_at}</td>`+
+        `<td><div class="cell-content">${row.url}</div></td>`+
+        `<td>${row.method}</td>`+
+        `<td><a href="${row.file}" target="_blank">${img}</a></td></tr>`;
+    }
+    html += '</tbody></table>';
+    tableDiv.innerHTML = html;
+    const selAll = document.getElementById('shot-select-all');
+    if(selAll){
+      selAll.addEventListener('change', () => {
+        tableDiv.querySelectorAll('.row-checkbox').forEach(c => c.checked = selAll.checked);
+      });
+    }
+  }
+
+  async function loadShots(){
+    try{
+      const resp = await fetch('/screenshots');
+      const data = await resp.json();
+      if(Array.isArray(data)) tableData = data; else tableData = [];
+      render();
+    }catch{}
+  }
+
+  captureBtn.addEventListener('click', async () => {
+    const url = urlInput.value.trim();
+    if(!url) return;
+    const params = new URLSearchParams({url, agent: agentSel.value, spoof: refChk.checked ? '1':'0'});
+    const resp = await fetch('/tools/screenshot', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
+    if(resp.ok){ await loadShots(); } else { alert(await resp.text()); }
+  });
+
+  deleteBtn.addEventListener('click', async () => {
+    const ids = Array.from(tableDiv.querySelectorAll('.row-checkbox:checked')).map(c=>c.value);
+    if(!ids.length) return;
+    const params = new URLSearchParams();
+    ids.forEach(id => params.append('ids', id));
+    await fetch('/delete_screenshots', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
+    loadShots();
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/screenshotter'){
+      history.pushState({}, '', '/');
+    }
+  });
+
+  loadShots();
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initScreenshotter);
+}else{
+  initScreenshotter();
+}

--- a/static/tools.css
+++ b/static/tools.css
@@ -89,3 +89,9 @@
 .retrorecon-root #jwt-cookie-jar .cell-content::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* Screenshotter overlay */
+.retrorecon-root .screenshot-thumb {
+  width: 80px;
+  height: auto;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -155,6 +155,7 @@
           <div class="menu-row"><a href="#" class="menu-btn">Site-to-zip</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="text-tools-link">Text Tools</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="jwt-tools-link">JWT Tools</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">ScreenShotter</a></div>
       </div>
     </div>
   </div>
@@ -744,6 +745,50 @@
 
       if(location.pathname === '/tools/jwt' || openTool === 'jwt'){
         showJwtTools(true);
+      }
+
+      const screenshotLink = document.getElementById('screenshot-link');
+      let screenshotLoaded = false;
+
+      async function showScreenshot(skipPush){
+        if(!screenshotLoaded){
+          const resp = await fetch('/screenshotter');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/screenshotter.js';
+          document.body.appendChild(script);
+          screenshotLoaded = true;
+        }
+        document.getElementById('screenshot-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'screenshot'}, '', '/tools/screenshotter');
+        }
+      }
+
+      function hideScreenshot(){
+        const ov = document.getElementById('screenshot-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
+      if(screenshotLink){
+        screenshotLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showScreenshot();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/screenshotter'){
+          showScreenshot(true);
+        } else {
+          hideScreenshot();
+        }
+      });
+
+      if(location.pathname === '/tools/screenshotter' || openTool === 'screenshot'){
+        showScreenshot(true);
       }
 
     const themeSelect = document.getElementById('theme-select');

--- a/templates/screenshotter.html
+++ b/templates/screenshotter.html
@@ -1,0 +1,16 @@
+<!-- File: templates/screenshotter.html -->
+<div id="screenshot-overlay" class="notes-overlay hidden">
+  <div class="mb-05">
+    <input type="text" id="screenshot-url" class="form-input mr-05 w-20em" placeholder="https://example.com" />
+    <select id="screenshot-agent" class="form-select mr-05">
+      <option value="">Desktop</option>
+      <option value="android">Android</option>
+      <option value="bot">Search Engine</option>
+    </select>
+    <label class="mr-05"><input type="checkbox" id="screenshot-ref" class="form-checkbox"> Spoof referrer</label>
+    <button type="button" class="btn" id="screenshot-capture-btn">Capture</button>
+    <button type="button" class="btn" id="screenshot-delete-btn">Delete</button>
+    <button type="button" class="btn" id="screenshot-close-btn">Close</button>
+  </div>
+  <div id="screenshot-table" class="mt-05"></div>
+</div>

--- a/tests/test_screenshotter.py
+++ b/tests/test_screenshotter.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    (tmp_path / "static" / "screenshots").mkdir(parents=True)
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_screenshotter_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/screenshotter')
+        assert resp.status_code == 200
+        assert b'id="screenshot-overlay"' in resp.data
+
+
+def test_screenshot_workflow(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db('shot')
+    with app.app.test_client() as client:
+        def fake_shot(url, agent, spoof):
+            return b'\x89PNG\r\n\x1a\n'
+        monkeypatch.setattr(app, 'take_screenshot', fake_shot)
+        resp = client.post('/tools/screenshot', data={'url': 'http://example.com'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert 'id' in data
+        resp = client.get('/screenshots')
+        rows = resp.get_json()
+        assert rows and rows[0]['url'] == 'http://example.com'
+        sid = rows[0]['id']
+        resp = client.post('/delete_screenshots', data={'ids': sid})
+        assert resp.status_code == 204
+        assert client.get('/screenshots').get_json() == []


### PR DESCRIPTION
## Summary
- add ScreenShotter tool to capture website screenshots
- update database schema with screenshots table
- implement screenshot REST API and UI overlay
- support ScreenShotter from the Tools menu
- document ScreenShotter in README
- include tests for new functionality

## Testing
- `npm run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f511b91cc833289b15d538242a73c