### PR TITLE
Add Site2Zip design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - **JWT Tools** decode, edit and sign JSON Web Tokens inside a full-screen editor
   with a persistent JWT cookie jar
 - **ScreenShotter** capture website screenshots in a headless browser
+- **Site2Zip** crawl a URL, generate a sitemap and download all assets as a ZIP
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -317,3 +317,43 @@ python scripts/generate_postman_collection.py > retrorecon.postman.json
 
 Import the resulting `retrorecon.postman.json` file into Postman and set the `base_url` variable to your server address.
 
+### `GET /site2zip`
+Serve the Site2Zip overlay for capturing a full page snapshot.
+
+```
+curl http://localhost:5000/site2zip
+```
+
+### `POST /tools/site2zip`
+Launch a capture job and return JSON with the record ID.
+
+Parameters:
+- `url` – page to fetch.
+- `agent` – optional user agent (`android`, `bot` or blank for desktop).
+- `spoof_referrer` – set to `1` to spoof the referrer header.
+
+```
+curl -X POST -d "url=https://example.com" http://localhost:5000/tools/site2zip
+```
+
+### `GET /sitezips`
+List previous Site2Zip captures as JSON.
+
+```
+curl http://localhost:5000/sitezips
+```
+
+### `GET /download_sitezip/<id>`
+Download the ZIP archive for a capture.
+
+```
+curl -O http://localhost:5000/download_sitezip/1
+```
+
+### `POST /delete_sitezips`
+Delete one or more captures by ID.
+
+```
+curl -X POST -d "ids=1,2" http://localhost:5000/delete_sitezips
+```
+

--- a/docs/site2zip_spec.md
+++ b/docs/site2zip_spec.md
@@ -1,0 +1,62 @@
+# Site2Zip Feature Plan
+
+This document describes the design for a new **Site2Zip** tool. The tool crawls a URL with a headless browser, collects all assets, generates a sitemap and packages everything in a ZIP for download. It combines screenshot capture, network logging and optional webpack source extraction.
+
+## Goals
+- Allow users to input a URL and retrieve a ZIP archive containing:
+  - Rendered HTML and dynamic assets (scripts, styles, media, fonts).
+  - A sitemap of discovered links.
+  - HTTP request and response headers for every resource.
+  - Screenshots of the initial page.
+  - Unpacked sources when source maps reference inline or Base64 encoded bundles.
+- Emulate a desktop browser by default with user agent options for Android or search engine bots.
+- Support referrer spoofing via checkbox.
+- Display a results table listing each capture with thumbnail preview, URL, timestamp and method. Clicking the thumbnail opens the full screenshot and provides a download link for the ZIP.
+
+## Database Changes
+Add a new `sitezips` table:
+```sql
+CREATE TABLE IF NOT EXISTS sitezips (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT NOT NULL,
+    method TEXT DEFAULT 'GET',
+    zip_path TEXT,
+    screenshot_path TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+`ensure_schema()` should create this table when missing.
+
+## Flask Routes
+- `GET /site2zip` – serve the overlay with the capture form.
+- `GET /tools/site2zip` – full-page version of the overlay for direct links.
+- `POST /tools/site2zip` – launch the capture. Parameters:
+  - `url` – target to fetch.
+  - `agent` – optional user agent (`''`, `android`, `bot`).
+  - `spoof_referrer` – `1` to spoof the referrer header.
+- `GET /sitezips` – return JSON metadata for captured entries.
+- `GET /download_sitezip/<int:id>` – download the ZIP archive.
+- `POST /delete_sitezips` – remove captures by ID.
+
+## UI Design
+- Add **Site2Zip** to the Tools menu. Selecting it loads `site2zip.html` similar to `screenshotter.html`.
+- The overlay contains a URL input, user agent dropdown and referrer spoof checkbox.
+- A table below the form shows past captures with a delete checkbox per row, timestamp, URL, method, thumbnail and download link.
+- Columns should be resizable as in other tables.
+
+## Implementation Steps for Codex
+1. Extend `db/schema.sql` and helper functions for the new `sitezips` table.
+2. Implement capture logic using Pyppeteer to fetch all resources, execute scripts and record network traffic. Save headers to text files and write files to a temporary directory before zipping.
+3. When a source map references inline or Base64 encoded bundles, invoke the existing Webpack Exploder to unpack them into the ZIP.
+4. Store the ZIP and screenshot under `static/sitezips/` and create DB entries via `save_sitezip_record()`.
+5. Build the overlay template and accompanying JavaScript to call the new routes and update the results table.
+6. Add unit tests covering capture, listing, download and deletion.
+7. Document endpoints in `docs/api_routes.md`, update the README feature list and regenerate `retrorecon.postman.json`.
+
+## Task Checklist for Codex
+- [ ] Update database schema and helpers.
+- [ ] Add capture functions and Flask routes.
+- [ ] Create `site2zip.html`, styles and JavaScript for the overlay.
+- [ ] Provide unit tests for the workflow and header logging.
+- [ ] Update documentation (`README.md`, `docs/api_routes.md`, `docs/test_plan.md`).
+- [ ] Regenerate `retrorecon.postman.json` with the new routes.

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -117,3 +117,23 @@ This ensures database workflow tests are executed along with the existing suite 
 
 7. **Cookie Jar Entry**
    - After a successful decode, `/jwt_cookies` should list the new token with issuer, algorithm and notes.
+
+## Site2Zip Tests
+
+1. **Menu Entry**
+   - Select `Tools → Site2Zip` from the navbar.
+   - Verify the overlay only loads when triggered.
+
+2. **Capture a Page**
+   - POST `/tools/site2zip` with `url=https://example.com`.
+   - Expect a JSON response with an ID and a screenshot file.
+   - `GET /sitezips` should list the entry with a ZIP download link.
+
+3. **User Agent Option**
+   - Capture the same URL with `agent=android` and confirm the header log reflects the Android user agent.
+
+4. **Referrer Spoofing**
+   - Capture with `spoof_referrer=1` and verify the logged request headers contain a Referrer matching the target URL.
+
+5. **Delete Capture**
+   - POST `/delete_sitezips` with the capture ID and confirm it is removed from `/sitezips`.

--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -505,6 +505,88 @@
           ]
         }
       }
+    },
+    {
+      "name": "GET /site2zip",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/site2zip",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "site2zip"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /tools/site2zip",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/site2zip",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "site2zip"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /sitezips",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/sitezips",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "sitezips"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /download_sitezip/<int:id>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/download_sitezip/<int:id>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "download_sitezip",
+            "<int:id>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /delete_sitezips",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/delete_sitezips",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "delete_sitezips"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- design a new Site2Zip feature for archiving a page and all assets
- document new Site2Zip REST API routes
- describe Site2Zip tests
- update README feature list
- update Postman collection with placeholder routes

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f54c6dbdc83329dd834ac34b89774