### PR TITLE
Fix screenshot fallback dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - **Text Tools** full-screen editor for Base64 and URL encoding/decoding with Save As
 - **JWT Tools** decode, edit and sign JSON Web Tokens inside a full-screen editor
   with a persistent JWT cookie jar
-- **ScreenShotter** capture website screenshots in a headless browser
+- **ScreenShotter** capture website screenshots in a headless browser (requires `pyppeteer`; falls back to a Pillow placeholder)
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import zipfile
 import threading
 import re
 import datetime
+import base64
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
@@ -317,15 +318,21 @@ def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False
         import asyncio
         from pyppeteer import launch
     except Exception:
-        # Fallback blank image with URL text
-        from PIL import Image, ImageDraw
+        # Fallback placeholder if pyppeteer or Pillow are unavailable
+        try:
+            from PIL import Image, ImageDraw
 
-        img = Image.new('RGB', (800, 600), color='white')
-        draw = ImageDraw.Draw(img)
-        draw.text((10, 10), url, fill='black')
-        buf = io.BytesIO()
-        img.save(buf, format='PNG')
-        return buf.getvalue()
+            img = Image.new("RGB", (800, 600), color="white")
+            draw = ImageDraw.Draw(img)
+            draw.text((10, 10), url, fill="black")
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            return buf.getvalue()
+        except Exception:
+            # 1x1 transparent PNG
+            return base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8AAPAIB+AWd1QAAAABJRU5ErkJggg=="
+            )
 
     async def _cap() -> bytes:
         browser = await launch(args=['--no-sandbox'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4
 cssutils
 pytest
 PyJWT
+Pillow


### PR DESCRIPTION
## Summary
- add Pillow to requirements
- clarify screenshotter in README
- handle missing Pillow gracefully in fallback screenshot

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f55ea6c048332b2664d9fbc27c99f