### PR TITLE
Fix domain validation and store CDX domains

### DIFF
--- a/tests/test_fetch_cdx.py
+++ b/tests/test_fetch_cdx.py
@@ -33,10 +33,11 @@ def test_fetch_cdx_inserts_status(tmp_path, monkeypatch):
     client.post('/fetch_cdx', data={'domain': 'example.com'})
 
     with app.app.app_context():
-        rows = app.query_db('SELECT url, timestamp, status_code, mime_type FROM urls')
+        rows = app.query_db('SELECT url, domain, timestamp, status_code, mime_type FROM urls')
     assert len(rows) == 1
     row = rows[0]
     assert row['url'] == "http://example.com/"
+    assert row['domain'] == "example.com"
     assert row['timestamp'] == "20250101010101"
     assert row['status_code'] == 200
     assert row['mime_type'] == "text/html"
@@ -62,5 +63,34 @@ def test_fetch_cdx_handles_dash_status(tmp_path, monkeypatch):
     client.post('/fetch_cdx', data={'domain': 'dash.com'})
 
     with app.app.app_context():
-        rows = app.query_db('SELECT status_code FROM urls')
+        rows = app.query_db('SELECT status_code, domain FROM urls')
     assert rows[0]['status_code'] is None
+    assert rows[0]['domain'] == "dash.com"
+
+
+def test_fetch_cdx_rejects_invalid_domain(tmp_path, monkeypatch):
+    db_path = tmp_path / "reject.db"
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    monkeypatch.setitem(app.app.config, "DATABASE", str(db_path))
+    (tmp_path / "db").mkdir()
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+    app.init_db()
+
+    called = False
+
+    def fake_get(*a, **k):
+        nonlocal called
+        called = True
+        return FakeResponse([])
+
+    monkeypatch.setattr(app.requests, 'get', fake_get)
+
+    client = app.app.test_client()
+    client.post('/fetch_cdx', data={'domain': 'http://bad'})
+
+    assert not called
+    with app.app.app_context():
+        rows = app.query_db('SELECT COUNT(*) AS c FROM urls')
+    assert rows[0]['c'] == 0


### PR DESCRIPTION
## Summary
- validate domain input for `/fetch_cdx`
- store parsed domain when inserting CDX results
- test invalid domain handling
- update fetch_cdx tests for new domain column

## Testing
- `npm install`
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f59cb192c8332930be5e4f1adcf5b