### PR TITLE
Fix timezone-aware UTC timestamps

### DIFF
--- a/app.py
+++ b/app.py
@@ -1573,7 +1573,7 @@ def screenshot_route() -> Response:
         img_bytes = take_screenshot(url, agent, spoof)
     except Exception as e:
         return (f'Error taking screenshot: {e}', 500)
-    fname = f'shot_{int(datetime.datetime.utcnow().timestamp()*1000)}.png'
+    fname = f'shot_{int(datetime.datetime.now(datetime.UTC).timestamp()*1000)}.png'
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
     with open(os.path.join(SCREENSHOT_DIR, fname), 'wb') as f:
         f.write(img_bytes)

--- a/tests/test_jwt_tools.py
+++ b/tests/test_jwt_tools.py
@@ -73,7 +73,7 @@ def test_jwt_decode_warnings_and_exp(tmp_path, monkeypatch):
         assert data['alg_warning'] is True
 
         import datetime
-        exp = int((datetime.datetime.utcnow() - datetime.timedelta(seconds=1)).timestamp())
+        exp = int((datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=1)).timestamp())
         token = app.jwt.encode({'exp': exp}, 'secret', algorithm='HS256')
         resp = client.post('/tools/jwt_decode', data={'token': token})
         data = resp.get_json()


### PR DESCRIPTION
## Summary
- use timezone-aware UTC when naming screenshot files
- adjust tests to use timezone-aware UTC

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5bdcd6f88332a04d681f03bbbd3a