### PR TITLE
Fix repeated opacity updates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -847,9 +847,15 @@
     }
 
     const opacityRange = document.getElementById('opacity-range');
+    let currentOpacity = null;
     function updateOpacity(val){
       const op = val / 100;
       document.documentElement.style.setProperty('--panel-opacity', op);
+    }
+    function persistOpacity(val){
+      const op = val / 100;
+      if(op === currentOpacity) return;
+      currentOpacity = op;
       fetch('/set_panel_opacity', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -860,7 +866,11 @@
       opacityRange.addEventListener('input', function(){
         updateOpacity(this.value);
       });
+      opacityRange.addEventListener('change', function(){
+        persistOpacity(this.value);
+      });
       updateOpacity(opacityRange.value);
+      currentOpacity = parseFloat(opacityRange.value)/100;
     }
 
     const fontInput = document.getElementById('font-size-input');


### PR DESCRIPTION
## Summary
- reduce server posts from opacity slider by sending an update only when the value actually changes

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f5eac062083329b364a8c934ea487