### PR TITLE
Update Windows launcher to use venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ python app.py
 # RETRORECON_DB=dsprings.db python app.py
 ```
 On Windows you can run `launch_app.bat` to automatically update the repository,
-install the requirements and start the server:
+set up a `venv` and start the server:
 
 ```cmd
 launch_app.bat

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -2,5 +2,12 @@
 cd /d "%~dp0"
 
 git pull
-pip install -r requirements.txt
-python app.py
+
+if not exist venv (
+    python -m venv venv
+)
+
+venv\Scripts\python -m pip install --upgrade pip
+venv\Scripts\pip install -r requirements.txt
+
+venv\Scripts\python app.py


### PR DESCRIPTION
## Summary
- create a `venv` on first run of `launch_app.bat`
- install requirements and run the server using that venv
- mention new behavior in the README

## Testing
- `npm run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6644b6d883329bd592eb30bb62b1