### PR TITLE
Add results-per-page control

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -85,6 +85,9 @@
 .retrorecon-root #background-select {
   width: 180px;
 }
+.retrorecon-root #results-per-page-select {
+  width: 3.5em;
+}
 .retrorecon-root .form-range {
   width: 100%;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,8 +24,16 @@
 </head>
 <body class="app">
   <div class="retrorecon-root">
-  {% macro render_pagination(page, total_pages, q, total_count) %}
+  {% macro render_pagination(page, total_pages, q, total_count, items_per_page) %}
   <div class="pagination mt-1">
+    <form id="set-items-form" method="POST" action="/set_items_per_page" class="d-none">
+      <input type="hidden" name="count" id="items-count-input" />
+    </form>
+    <select id="results-per-page-select" class="form-select" form="set-items-form">
+      {% for n in [5,10,15,20,25] %}
+      <option value="{{ n }}" {% if items_per_page == n %}selected{% endif %}>{{ '%02d' % n }}</option>
+      {% endfor %}
+    </select>
     <span class="page-info">Page {{ page }} of {{ total_pages }}</span>
     {% if page > 1 %}
       <a href="?page=1&q={{ q }}" class="pagination-arrow" aria-label="First">&laquo;&laquo;</a>
@@ -187,7 +195,7 @@
   <table id="layout-c" class="w-100 mt-1">
     <tr>
       <td class="text-left">
-        {{ render_pagination(page, total_pages, q, total_count) }}
+        {{ render_pagination(page, total_pages, q, total_count, items_per_page) }}
       </td>
     </tr>
   </table>
@@ -294,7 +302,7 @@
     </tr>
     <tr>
       <td class="text-center mt-1">
-        {{ render_pagination(page, total_pages, q, total_count) }}
+        {{ render_pagination(page, total_pages, q, total_count, items_per_page) }}
       </td>
     </tr>
     <tr>
@@ -883,6 +891,15 @@
           headers: {'Content-Type': 'application/x-www-form-urlencoded'},
           body: new URLSearchParams({size: this.value, theme: theme})
         });
+      });
+    }
+
+    const perPageSelect = document.getElementById('results-per-page-select');
+    const perPageInput = document.getElementById('items-count-input');
+    if(perPageSelect && perPageInput){
+      perPageSelect.addEventListener('change', function(){
+        perPageInput.value = this.value;
+        document.getElementById('set-items-form').submit();
       });
     }
 

--- a/tests/test_items_per_page.py
+++ b/tests/test_items_per_page.py
@@ -1,0 +1,29 @@
+import sys
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+
+
+def test_set_items_per_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.post('/set_items_per_page', data={'count': '15'})
+        assert resp.status_code == 302
+        with client.session_transaction() as sess:
+            assert sess['items_per_page'] == 15
+
+
+def test_invalid_items(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.post('/set_items_per_page', data={'count': '7'})
+        assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- allow customizing number of results per page
- add dropdown UI and JS to change page size
- store selection via new `/set_items_per_page` API
- style select element and update pagination macro
- test route

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f655fa2e48332892ee65a133760d7