### PR TITLE
Add Windows pyppeteer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ set up a `venv` and start the server:
 launch_app.bat
 ```
 Then open <http://127.0.0.1:5000> in your browser.
+### Pyppeteer on Windows
+If screenshot capture shows a placeholder image, Pyppeteer likely could not download its bundled Chromium browser.
+Run `py -m pyppeteer install` or download revision 1181205 from https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1181205/chrome-win.zip and extract it to `%LOCALAPPDATA%\pyppeteer\local-chromium\1181205`.
+You can also set `PYPPETEER_BROWSER_PATH` to the path of an existing Chrome executable.
 
 ## Usage
 1. **Import from CDX**: enter a domain to fetch URLs from the Wayback API.

--- a/app.py
+++ b/app.py
@@ -334,7 +334,11 @@ def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False
             return base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8AAPAIB+AWd1QAAAABJRU5ErkJggg==")
 
     async def _cap() -> bytes:
-        browser = await launch(args=['--no-sandbox'])
+        launch_opts = {'args': ['--no-sandbox']}
+        exec_path = os.environ.get('PYPPETEER_BROWSER_PATH')
+        if exec_path:
+            launch_opts['executablePath'] = exec_path
+        browser = await launch(**launch_opts)
         page = await browser.newPage()
         if user_agent:
             await page.setUserAgent(user_agent)


### PR DESCRIPTION
## Summary
- document how to manually install the Chromium snapshot on Windows
- allow overriding the browser path using `PYPPETEER_BROWSER_PATH`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f633941288332a3c9be42555c8cd8