### PR TITLE
Modularize DB helpers and config

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,6 @@ import jwt
 import urllib.parse
 from flask import (
     Flask,
-    g,
     render_template,
     request,
     redirect,
@@ -26,16 +25,29 @@ from flask import (
     Response,
 )
 from markupsafe import escape
+from config import Config
+from database import (
+    get_db,
+    close_connection,
+    query_db,
+    execute_db,
+    init_db,
+    ensure_schema,
+    create_new_db,
+    _sanitize_db_name,
+    _sanitize_export_name,
+)
 
 app = Flask(__name__)
+app.config.from_object(Config)
 app.jwt = jwt
-# Allow overriding the startup database via environment variable
-env_db = os.environ.get('RETRORECON_DB')
+env_db = app.config.get('DB_ENV')
 if env_db:
     app.config['DATABASE'] = env_db if os.path.isabs(env_db) else os.path.join(app.root_path, env_db)
 else:
     app.config['DATABASE'] = None
-app.secret_key = 'CHANGE_THIS_TO_A_RANDOM_SECRET_KEY'
+app.secret_key = app.config.get('SECRET_KEY', 'CHANGE_THIS_TO_A_RANDOM_SECRET_KEY')
+app.teardown_appcontext(close_connection)
 ITEMS_PER_PAGE = 10  # default results per page
 ITEMS_PER_PAGE_OPTIONS = [5, 10, 15, 20, 25]
 TEXT_TOOLS_LIMIT = 64 * 1024  # 64 KB limit for text transformations
@@ -363,27 +375,6 @@ def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False
         except Exception:
             return base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8AAPAIB+AWd1QAAAABJRU5ErkJggg==")
 
-def init_db() -> None:
-    """Initialize the database using the schema.sql file."""
-    schema_path = os.path.join(app.root_path, 'db', 'schema.sql')
-    if not os.path.exists(schema_path):
-        raise FileNotFoundError("schema.sql not found")
-    with open(schema_path, "r", encoding="utf-8") as f:
-        sql = f.read()
-
-    conn = sqlite3.connect(app.config['DATABASE'])
-    for statement in sql.split(';'):
-        stmt = statement.strip()
-        if stmt.upper().startswith("CREATE TABLE IF NOT EXISTS"):
-            conn.execute(stmt)
-    conn.commit()
-    conn.close()
-
-def ensure_schema() -> None:
-    """Apply ``schema.sql`` to an existing database if tables are missing."""
-    if os.path.exists(app.config['DATABASE']):
-        init_db()
-
 def load_demo_data() -> None:
     """Populate the database with entries from ``DEMO_DATA_FILE`` if present."""
     if not os.path.exists(DEMO_DATA_FILE):
@@ -408,101 +399,6 @@ def load_demo_data() -> None:
             )
     db.commit()
     db.close()
-
-def _sanitize_db_name(name: str) -> Optional[str]:
-    """Return a sanitized ``name.db`` or ``None`` if empty after cleaning."""
-
-    base, _ = os.path.splitext(name)
-    safe = re.sub(r"[^A-Za-z0-9_-]", "", base)[:64]
-    if not safe:
-        return None
-    return safe + ".db"
-
-
-def _sanitize_export_name(name: str) -> str:
-    """Return a filename safe for download containing only allowed chars."""
-
-    safe = re.sub(r"[^A-Za-z0-9_-]", "_", name.strip())
-    safe = safe.strip("_") or "download"
-    if not safe.lower().endswith(".db"):
-        safe += ".db"
-    return safe
-
-
-def create_new_db(name: Optional[str] = None) -> str:
-    """Reset the database and return the newly created filename."""
-    nm = _sanitize_db_name(name) if name else 'waybax.db'
-    if nm is None:
-        raise ValueError('Invalid database name.')
-    db_path = os.path.join(app.root_path, nm)
-    if os.path.exists(db_path):
-        os.remove(db_path)
-    app.config['DATABASE'] = db_path
-    init_db()
-    # Databases used to include demo entries from ``data/demo_data.json``.
-    # For production use we initialize an empty database.
-    return nm
-
-if app.config.get('DATABASE') and os.path.exists(app.config['DATABASE']):
-    ensure_schema()
-
-
-@app.before_request
-def _update_display_name() -> None:
-    """Ensure ``session['db_display_name']`` matches the current DB file."""
-    if app.config.get('DATABASE'):
-        actual_name = os.path.basename(app.config['DATABASE'])
-    else:
-        actual_name = '(none)'
-    if session.get('db_display_name') != actual_name:
-        session['db_display_name'] = actual_name
-
-def get_db() -> sqlite3.Connection:
-    """Return a SQLite connection stored on the Flask ``g`` object."""
-
-    if not app.config.get('DATABASE'):
-        raise RuntimeError('No database loaded.')
-    db = getattr(g, '_database', None)
-    if db is None:
-        db = g._database = sqlite3.connect(app.config['DATABASE'])
-        db.row_factory = sqlite3.Row
-        db.create_function('has_tag', 2, _has_tag)
-    return db
-
-@app.teardown_appcontext
-def close_connection(exception: Optional[BaseException]) -> None:
-    """Close the SQLite connection at app teardown and remove it from ``g``."""
-
-    db = g.pop('_database', None)
-    if db is not None:
-        db.close()
-
-def query_db(query: str, args: Union[Tuple, List] = (), one: bool = False) -> Any:
-    """Execute ``query`` and return rows or a single row."""
-
-    cur = get_db().execute(query, args)
-    rv = cur.fetchall()
-    cur.close()
-    return (rv[0] if rv else None) if one else rv
-
-def execute_db(query: str, args: Union[Tuple, List] = ()) -> int:
-    """Execute ``query`` that modifies the DB and return ``lastrowid``."""
-
-    db = get_db()
-    cur = db.execute(query, args)
-    db.commit()
-    return cur.lastrowid
-
-
-def _has_tag(tags: str, tag: str) -> int:
-    """SQLite helper to check if ``tag`` exists in comma-separated ``tags``."""
-
-    tag = tag.strip().lower()
-    for t in tags.split(','):
-        if t.strip().lower() == tag:
-            return 1
-    return 0
-
 
 def _quote_hashtags(expr: str) -> str:
     """Surround bare hashtag terms with quotes for proper tokenization."""

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import os
+
+class Config:
+    """Application configuration loaded from environment variables."""
+
+    SECRET_KEY = os.environ.get('RETRORECON_SECRET', 'CHANGE_THIS_TO_A_RANDOM_SECRET_KEY')
+    DB_ENV = os.environ.get('RETRORECON_DB')
+    DATABASE = None  # Will be set in app.py after app root is known

--- a/database.py
+++ b/database.py
@@ -1,0 +1,107 @@
+"""SQLite database helpers for Retrorecon."""
+
+import os
+import re
+import sqlite3
+from typing import Any, List, Optional, Tuple, Union
+
+from flask import current_app, g
+
+
+def _has_tag(tags: str, tag: str) -> int:
+    """SQLite helper to check if ``tag`` exists in comma-separated ``tags``."""
+    tag = tag.strip().lower()
+    for t in tags.split(','):
+        if t.strip().lower() == tag:
+            return 1
+    return 0
+
+
+def init_db() -> None:
+    """Initialize the database using the schema.sql file."""
+    app = current_app
+    schema_path = os.path.join(app.root_path, 'db', 'schema.sql')
+    if not os.path.exists(schema_path):
+        raise FileNotFoundError('schema.sql not found')
+    with open(schema_path, 'r', encoding='utf-8') as f:
+        sql = f.read()
+    conn = sqlite3.connect(app.config['DATABASE'])
+    for statement in sql.split(';'):
+        stmt = statement.strip()
+        if stmt.upper().startswith('CREATE TABLE IF NOT EXISTS'):
+            conn.execute(stmt)
+    conn.commit()
+    conn.close()
+
+
+def ensure_schema() -> None:
+    """Apply ``schema.sql`` to an existing database if tables are missing."""
+    if os.path.exists(current_app.config['DATABASE']):
+        init_db()
+
+
+def _sanitize_db_name(name: str) -> Optional[str]:
+    """Return a sanitized ``name.db`` or ``None`` if empty after cleaning."""
+    base, _ = os.path.splitext(name)
+    safe = re.sub(r"[^A-Za-z0-9_-]", "", base)[:64]
+    if not safe:
+        return None
+    return safe + '.db'
+
+
+def _sanitize_export_name(name: str) -> str:
+    """Return a filename safe for download containing only allowed chars."""
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", name.strip())
+    safe = safe.strip('_') or 'download'
+    if not safe.lower().endswith('.db'):
+        safe += '.db'
+    return safe
+
+
+def create_new_db(name: Optional[str] = None) -> str:
+    """Reset the database and return the newly created filename."""
+    nm = _sanitize_db_name(name) if name else 'waybax.db'
+    if nm is None:
+        raise ValueError('Invalid database name.')
+    db_path = os.path.join(current_app.root_path, nm)
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    current_app.config['DATABASE'] = db_path
+    init_db()
+    return nm
+
+
+def get_db() -> sqlite3.Connection:
+    """Return a SQLite connection stored on the Flask ``g`` object."""
+    if not current_app.config.get('DATABASE'):
+        raise RuntimeError('No database loaded.')
+    db = getattr(g, '_database', None)
+    if db is None:
+        db = g._database = sqlite3.connect(current_app.config['DATABASE'])
+        db.row_factory = sqlite3.Row
+        db.create_function('has_tag', 2, _has_tag)
+    return db
+
+
+def close_connection(exception: Optional[BaseException]) -> None:
+    """Close the SQLite connection at app teardown and remove it from ``g``."""
+    db = g.pop('_database', None)
+    if db is not None:
+        db.close()
+
+
+def query_db(query: str, args: Union[Tuple, List] = (), one: bool = False) -> Any:
+    """Execute ``query`` and return rows or a single row."""
+    cur = get_db().execute(query, args)
+    rv = cur.fetchall()
+    cur.close()
+    return (rv[0] if rv else None) if one else rv
+
+
+def execute_db(query: str, args: Union[Tuple, List] = ()) -> int:
+    """Execute ``query`` that modifies the DB and return ``lastrowid``."""
+    db = get_db()
+    cur = db.execute(query, args)
+    db.commit()
+    return cur.lastrowid
+

--- a/tests/test_env_db.py
+++ b/tests/test_env_db.py
@@ -18,7 +18,8 @@ def test_env_db_loaded(monkeypatch, tmp_path):
     (tmp_path / 'data').mkdir()
     schema_src = Path(__file__).resolve().parents[1] / 'db' / 'schema.sql'
     (tmp_path / 'db' / 'schema.sql').write_text(schema_src.read_text())
-    app.create_new_db('envtest')
+    with app.app.app_context():
+        app.create_new_db('envtest')
 
     with app.app.test_client() as client:
         client.get('/')

--- a/tests/test_fetch_cdx.py
+++ b/tests/test_fetch_cdx.py
@@ -21,7 +21,8 @@ def test_fetch_cdx_inserts_status(tmp_path, monkeypatch):
     monkeypatch.setitem(app.app.config, "DATABASE", str(db_path))
     (tmp_path / "db").mkdir()
     (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
-    app.init_db()
+    with app.app.app_context():
+        app.init_db()
 
     sample = [
         ["original", "timestamp", "statuscode", "mimetype"],
@@ -51,7 +52,8 @@ def test_fetch_cdx_handles_dash_status(tmp_path, monkeypatch):
     monkeypatch.setitem(app.app.config, "DATABASE", str(db_path))
     (tmp_path / "db").mkdir()
     (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
-    app.init_db()
+    with app.app.app_context():
+        app.init_db()
 
     sample = [
         ["original", "timestamp", "statuscode", "mimetype"],
@@ -76,7 +78,8 @@ def test_fetch_cdx_rejects_invalid_domain(tmp_path, monkeypatch):
     monkeypatch.setitem(app.app.config, "DATABASE", str(db_path))
     (tmp_path / "db").mkdir()
     (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
-    app.init_db()
+    with app.app.app_context():
+        app.init_db()
 
     called = False
 
@@ -104,7 +107,8 @@ def test_fetch_cdx_uses_limit_param(tmp_path, monkeypatch):
     monkeypatch.setitem(app.app.config, "DATABASE", str(db_path))
     (tmp_path / "db").mkdir()
     (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
-    app.init_db()
+    with app.app.app_context():
+        app.init_db()
 
     captured = None
 

--- a/tests/test_secret_key_env.py
+++ b/tests/test_secret_key_env.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ['RETRORECON_SECRET'] = 'sup3rsecret'
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import importlib
+import config
+importlib.reload(config)
+import app
+importlib.reload(app)
+
+
+def test_secret_key_loaded(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, 'root_path', str(tmp_path))
+    with app.app.app_context():
+        assert app.app.secret_key == 'sup3rsecret'
+    del os.environ['RETRORECON_SECRET']


### PR DESCRIPTION
## Summary
- centralize environment configuration in `config.py`
- split database helper functions to `database.py`
- load secret key and DB path from environment
- adjust tests to use application context
- add regression test for loading secret key from env

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6aee5d4883328c573bf671873486