### PR TITLE
Update Dockerfile for Playwright support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 FROM python:3.11-slim
+
 WORKDIR /app
+
+# Install Python dependencies and Playwright browsers with required system libs
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && python -m playwright install --with-deps
+
 COPY . .
+
 EXPOSE 5000
+
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ can use its default location. Alternatively set `PLAYWRIGHT_CHROMIUM_PATH` to an
 existing Chrome executable. You can also assign a path to `app.executablePath`
 before calling screenshot functions to override the Chromium binary.
 
+### Docker Quick Start
+
+Build the container image:
+
+```bash
+docker build -t retrorecon .
+```
+
+Run it with shared folders so imports and exports persist on the host:
+
+```bash
+docker run -p 5000:5000 \
+  -v "$PWD/db:/app/db" \
+  -v "$PWD/data:/app/data" \
+  -v "$PWD/static/screenshots:/app/static/screenshots" \
+  retrorecon
+```
+
+The mounted volumes store databases, uploaded files and screenshots outside
+the container.
+
 ## Usage
 1. **Import from CDX**: enter a domain to fetch URLs from the Wayback API.
 2. **Import from JSON**: upload a JSON file containing URLs or full CDX records.


### PR DESCRIPTION
## Summary
- add Playwright installation to Dockerfile
- document running the container with shared volumes for imports/exports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f905ba56c8332896bd52f049ccf90