### PR TITLE
Refactor app.py into utility modules

### DIFF
--- a/retrorecon/jwt_utils.py
+++ b/retrorecon/jwt_utils.py
@@ -1,0 +1,61 @@
+import json
+from typing import Any, Dict, List, Optional
+
+from database import execute_db, query_db
+
+
+def log_entry(token: str, header: Dict[str, Any], payload: Dict[str, Any], notes: str) -> None:
+    """Insert a decoded JWT into the ``jwt_cookies`` table."""
+    execute_db(
+        "INSERT INTO jwt_cookies (token, header, payload, notes) VALUES (?, ?, ?, ?)",
+        [token, json.dumps(header), json.dumps(payload), notes],
+    )
+
+
+def delete_cookies(ids: List[int]) -> None:
+    """Delete JWT cookie log entries by ID."""
+    if not ids:
+        return
+    for jid in ids:
+        execute_db("DELETE FROM jwt_cookies WHERE id = ?", [jid])
+
+
+def update_cookie(jid: int, notes: str) -> None:
+    """Update the notes for a JWT cookie entry."""
+    execute_db("UPDATE jwt_cookies SET notes = ? WHERE id = ?", [notes, jid])
+
+
+def export_cookie_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
+    """Return JWT cookie entries as dictionaries."""
+    where = ""
+    params: List[Any] = []
+    if ids:
+        placeholders = ",".join("?" for _ in ids)
+        where = f"WHERE id IN ({placeholders})"
+        params.extend(ids)
+    rows = query_db(
+        f"SELECT id, token, header, payload, notes, created_at FROM jwt_cookies {where} ORDER BY id DESC",
+        params,
+    )
+    result = []
+    for r in rows:
+        try:
+            hdr = json.loads(r["header"])
+        except Exception:
+            hdr = {}
+        try:
+            pl = json.loads(r["payload"])
+        except Exception:
+            pl = {}
+        result.append(
+            {
+                "id": r["id"],
+                "token": r["token"],
+                "issuer": pl.get("iss", ""),
+                "alg": hdr.get("alg", ""),
+                "claims": list(pl.keys()),
+                "notes": r["notes"],
+                "created_at": r["created_at"],
+            }
+        )
+    return result

--- a/retrorecon/notes_utils.py
+++ b/retrorecon/notes_utils.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict, List
+import sqlite3
+from markupsafe import escape
+
+from database import query_db, execute_db
+
+
+def get_notes(url_id: int) -> List[sqlite3.Row]:
+    """Return all notes for a specific URL."""
+    return query_db(
+        "SELECT id, url_id, content, created_at, updated_at FROM notes WHERE url_id = ? ORDER BY id",
+        [url_id],
+    )
+
+
+def add_note(url_id: int, content: str) -> int:
+    """Insert a note and return the row id."""
+    return execute_db(
+        "INSERT INTO notes (url_id, content) VALUES (?, ?)",
+        [url_id, escape(content)],
+    )
+
+
+def update_note(note_id: int, content: str) -> None:
+    """Update an existing note."""
+    execute_db(
+        "UPDATE notes SET content = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+        [escape(content), note_id],
+    )
+
+
+def delete_note_entry(note_id: int) -> None:
+    """Delete a note by ID."""
+    execute_db("DELETE FROM notes WHERE id = ?", [note_id])
+
+
+def delete_all_notes(url_id: int) -> None:
+    """Remove all notes for a URL."""
+    execute_db("DELETE FROM notes WHERE url_id = ?", [url_id])
+
+
+def export_notes_data() -> List[Dict[str, Any]]:
+    """Return all notes grouped by URL."""
+    rows = query_db(
+        "SELECT urls.url, notes.content FROM notes JOIN urls ON notes.url_id = urls.id ORDER BY urls.url, notes.id"
+    )
+    grouped: Dict[str, List[str]] = {}
+    for r in rows:
+        grouped.setdefault(r["url"], []).append(r["content"])
+    return [{"url": u, "notes": n} for u, n in grouped.items()]

--- a/retrorecon/progress.py
+++ b/retrorecon/progress.py
@@ -1,0 +1,32 @@
+import os
+import json
+import threading
+from typing import Any, Dict
+
+_IMPORT_LOCK = threading.Lock()
+
+def set_progress(file_path: str, status: str, message: str = '', current: int = 0, total: int = 0) -> None:
+    """Write progress information to ``file_path``."""
+    with _IMPORT_LOCK:
+        progress = {
+            'status': status,
+            'message': message,
+            'current': current,
+            'total': total
+        }
+        with open(file_path, 'w') as f:
+            json.dump(progress, f)
+
+def get_progress(file_path: str) -> Dict[str, Any]:
+    """Return the import progress stored at ``file_path``."""
+    with _IMPORT_LOCK:
+        if not os.path.exists(file_path):
+            return {'status': 'idle', 'message': '', 'current': 0, 'total': 0}
+        with open(file_path, 'r') as f:
+            return json.load(f)
+
+def clear_progress(file_path: str) -> None:
+    """Remove ``file_path`` if it exists."""
+    with _IMPORT_LOCK:
+        if os.path.exists(file_path):
+            os.remove(file_path)

--- a/retrorecon/saved_tags.py
+++ b/retrorecon/saved_tags.py
@@ -1,0 +1,26 @@
+import json
+import os
+import threading
+from typing import List
+
+_TAGS_LOCK = threading.Lock()
+
+def load_tags(file_path: str) -> List[str]:
+    """Return saved search tags from ``file_path``."""
+    with _TAGS_LOCK:
+        if not os.path.exists(file_path):
+            return []
+        try:
+            with open(file_path, 'r') as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                return [str(t) for t in data]
+        except Exception:
+            pass
+        return []
+
+def save_tags(file_path: str, tags: List[str]) -> None:
+    """Persist ``tags`` to ``file_path``."""
+    with _TAGS_LOCK:
+        with open(file_path, 'w') as f:
+            json.dump(tags, f)

--- a/retrorecon/screenshot_utils.py
+++ b/retrorecon/screenshot_utils.py
@@ -1,0 +1,122 @@
+import os
+import io
+import base64
+import logging
+from typing import Any, Dict, List, Optional
+
+import sqlite3
+from database import execute_db, query_db
+
+logger = logging.getLogger(__name__)
+
+
+def save_record(dir_path: str, url: str, path: str, thumb: str, method: str = 'GET') -> int:
+    os.makedirs(dir_path, exist_ok=True)
+    return execute_db(
+        "INSERT INTO screenshots (url, method, screenshot_path, thumbnail_path) VALUES (?, ?, ?, ?)",
+        [url, method, path, thumb],
+    )
+
+
+def list_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
+    where = ""
+    params: List[Any] = []
+    if ids:
+        placeholders = ",".join("?" for _ in ids)
+        where = f"WHERE id IN ({placeholders})"
+        params.extend(ids)
+    rows = query_db(
+        f"SELECT id, url, method, screenshot_path, thumbnail_path, created_at FROM screenshots {where} ORDER BY id DESC",
+        params,
+    )
+    result = []
+    for r in rows:
+        result.append(
+            {
+                "id": r["id"],
+                "url": r["url"],
+                "method": r["method"],
+                "screenshot_path": r["screenshot_path"],
+                "thumbnail_path": r["thumbnail_path"],
+                "created_at": r["created_at"],
+            }
+        )
+    return result
+
+
+def delete_records(dir_path: str, ids: List[int]) -> None:
+    if not ids:
+        return
+    for sid in ids:
+        row = query_db(
+            "SELECT screenshot_path, thumbnail_path FROM screenshots WHERE id = ?",
+            [sid],
+            one=True,
+        )
+        if row:
+            file_path = os.path.join(dir_path, row["screenshot_path"])
+            thumb_path = os.path.join(dir_path, row["thumbnail_path"])
+            for fp in (file_path, thumb_path):
+                try:
+                    os.remove(fp)
+                except OSError:
+                    pass
+        execute_db("DELETE FROM screenshots WHERE id = ?", [sid])
+
+
+def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False, executable_path: Optional[str] = None) -> bytes:
+    logger.debug("take_screenshot url=%s agent=%s spoof=%s", url, user_agent, spoof_referrer)
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception as e:
+        logger.debug("playwright not available: %s", e)
+        return placeholder_image(url)
+
+    def _cap() -> bytes:
+        launch_opts = {"args": ["--no-sandbox"]}
+        exec_path = os.environ.get("PLAYWRIGHT_CHROMIUM_PATH") or executable_path
+        if exec_path:
+            launch_opts["executable_path"] = exec_path
+            if "PLAYWRIGHT_CHROMIUM_PATH" in os.environ:
+                logger.debug("using PLAYWRIGHT_CHROMIUM_PATH=%s", exec_path)
+            else:
+                logger.debug("using executable_path=%s", exec_path)
+        try:
+            with sync_playwright() as pw:
+                browser = pw.chromium.launch(**launch_opts)
+                ctx_opts = {}
+                if user_agent:
+                    ctx_opts["user_agent"] = user_agent
+                context = browser.new_context(**ctx_opts)
+                if spoof_referrer:
+                    context.set_extra_http_headers({"Referer": url})
+                page = context.new_page()
+                page.goto(url, wait_until="networkidle")
+                data = page.screenshot(full_page=True)
+                browser.close()
+                return data
+        except Exception as e:
+            logger.debug("screenshot capture failed: %s", e)
+            raise
+
+    try:
+        return _cap()
+    except Exception:
+        return placeholder_image(url)
+
+
+def placeholder_image(text: str) -> bytes:
+    try:
+        from PIL import Image, ImageDraw
+
+        img = Image.new("RGB", (800, 600), color="white")
+        draw = ImageDraw.Draw(img)
+        draw.text((10, 10), text, fill="black")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue()
+    except Exception:
+        return base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8AAPAI" \
+            "B+AWd1QAAAABJRU5ErkJggg=="
+        )

--- a/retrorecon/search_utils.py
+++ b/retrorecon/search_utils.py
@@ -1,0 +1,184 @@
+import re
+from typing import List, Tuple
+
+
+def quote_hashtags(expr: str) -> str:
+    """Surround bare hashtag terms with quotes for proper tokenization."""
+    pattern = r'#([^#()]+?)(?=(?:\s+(?:AND|OR|NOT)\b|\s*\)|\s*#|$))'
+
+    def repl(match: re.Match) -> str:
+        inner = match.group(1).strip()
+        if ' ' in inner and not (inner.startswith('"') and inner.endswith('"')):
+            inner = f'"{inner}"'
+        return f'tag:{inner}'
+
+    return re.sub(pattern, repl, expr, flags=re.IGNORECASE)
+
+
+def tokenize_tag_expr(expr: str) -> List[str]:
+    """Return a list of tokens for a boolean tag expression."""
+    token_re = re.compile(r"\(|\)|\bAND\b|\bOR\b|\bNOT\b|\"[^\"]+\"|[^\s()]+", re.IGNORECASE)
+    tokens = token_re.findall(expr)
+    return [t.strip('"') for t in tokens]
+
+
+def parse_tag_expression(tokens: List[str], pos: int = 0) -> Tuple[str, List[str], int]:
+    """Recursive descent parser returning SQL and params."""
+    def parse_or(p: int) -> Tuple[str, List[str], int]:
+        sql, params, p = parse_and(p)
+        while p < len(tokens):
+            t = tokens[p].upper()
+            if t == 'OR':
+                p += 1
+                rhs_sql, rhs_params, p = parse_and(p)
+                sql = f"({sql} OR {rhs_sql})"
+                params.extend(rhs_params)
+            else:
+                break
+        return sql, params, p
+
+    def parse_and(p: int) -> Tuple[str, List[str], int]:
+        sql, params, p = parse_not(p)
+        while p < len(tokens):
+            t = tokens[p].upper()
+            if t == 'AND':
+                p += 1
+            elif t in ('OR', ')'):
+                break
+            else:
+                pass
+            rhs_sql, rhs_params, p = parse_not(p)
+            sql = f"({sql} AND {rhs_sql})"
+            params.extend(rhs_params)
+        return sql, params, p
+
+    def parse_not(p: int) -> Tuple[str, List[str], int]:
+        if p < len(tokens) and tokens[p].upper() == 'NOT':
+            p += 1
+            sql, params, p = parse_not(p)
+            return f"(NOT {sql})", params, p
+        return parse_primary(p)
+
+    def parse_primary(p: int) -> Tuple[str, List[str], int]:
+        if p >= len(tokens):
+            raise ValueError('Unexpected end of expression')
+        tok = tokens[p]
+        if tok == '(':  # parse subexpression
+            sql, params, p = parse_or(p + 1)
+            if p >= len(tokens) or tokens[p] != ')':
+                raise ValueError('Unmatched parenthesis')
+            return sql, params, p + 1
+        if tok == ')':
+            raise ValueError('Unexpected )')
+        return "has_tag(tags, ?)", [tok], p + 1
+
+    return parse_or(pos)
+
+
+def build_tag_filter_sql(expr: str) -> Tuple[str, List[str]]:
+    tokens = tokenize_tag_expr(expr)
+    sql, params, pos = parse_tag_expression(tokens)
+    if pos != len(tokens):
+        raise ValueError('Invalid syntax')
+    return sql, params
+
+
+def tokenize_search_expr(expr: str) -> List[str]:
+    token_re = re.compile(r"\(|\)|\bAND\b|\bOR\b|\bNOT\b|[a-zA-Z]+:\"[^\"]+\"|\"[^\"]+\"|[^\s()]+", re.IGNORECASE)
+    raw = token_re.findall(expr)
+    tokens = []
+    for t in raw:
+        if ':' in t:
+            prefix, rest = t.split(':', 1)
+            if rest.startswith('"') and rest.endswith('"'):
+                rest = rest[1:-1]
+            tokens.append(f"{prefix}:{rest}")
+        else:
+            if t.startswith('"') and t.endswith('"'):
+                t = t[1:-1]
+            tokens.append(t)
+    return tokens
+
+
+def parse_search_expression(tokens: List[str], pos: int = 0) -> Tuple[str, List[str], int]:
+    def parse_or(p: int) -> Tuple[str, List[str], int]:
+        sql, params, p = parse_and(p)
+        while p < len(tokens):
+            t = tokens[p].upper()
+            if t == 'OR':
+                p += 1
+                rhs_sql, rhs_params, p = parse_and(p)
+                sql = f"({sql} OR {rhs_sql})"
+                params.extend(rhs_params)
+            else:
+                break
+        return sql, params, p
+
+    def parse_and(p: int) -> Tuple[str, List[str], int]:
+        sql, params, p = parse_not(p)
+        while p < len(tokens):
+            t = tokens[p].upper()
+            if t == 'AND':
+                p += 1
+            elif t in ('OR', ')'):
+                break
+            else:
+                pass
+            rhs_sql, rhs_params, p = parse_not(p)
+            sql = f"({sql} AND {rhs_sql})"
+            params.extend(rhs_params)
+        return sql, params, p
+
+    def parse_not(p: int) -> Tuple[str, List[str], int]:
+        if p < len(tokens) and tokens[p].upper() == 'NOT':
+            p += 1
+            sql, params, p = parse_not(p)
+            return f"(NOT {sql})", params, p
+        return parse_primary(p)
+
+    def term_sql(tok: str) -> Tuple[str, List[str]]:
+        lower = tok.lower()
+        if lower.startswith('url:'):
+            val = tok[4:]
+            return "url LIKE ?", [f"%{val}%"]
+        if lower.startswith('timestamp:'):
+            val = tok[len('timestamp:'):]
+            return "CAST(timestamp AS TEXT) LIKE ?", [f"%{val}%"]
+        if lower.startswith('http:'):
+            val = tok[5:]
+            return "CAST(status_code AS TEXT) LIKE ?", [f"%{val}%"]
+        if lower.startswith('mime:'):
+            val = tok[5:]
+            return "mime_type LIKE ?", [f"%{val}%"]
+        if lower.startswith('tag:'):
+            return "has_tag(tags, ?)", [tok[4:]]
+        return (
+            "(" "url LIKE ? OR tags LIKE ? OR CAST(timestamp AS TEXT) LIKE ? OR "
+            "CAST(status_code AS TEXT) LIKE ? OR mime_type LIKE ?" ")",
+            [f"%{tok}%"] * 5,
+        )
+
+    def parse_primary(p: int) -> Tuple[str, List[str], int]:
+        if p >= len(tokens):
+            raise ValueError('Unexpected end of expression')
+        tok = tokens[p]
+        if tok == '(':  # subexpression
+            sql, params, p = parse_or(p + 1)
+            if p >= len(tokens) or tokens[p] != ')':
+                raise ValueError('Unmatched parenthesis')
+            return sql, params, p + 1
+        if tok == ')':
+            raise ValueError('Unexpected )')
+        sql, params = term_sql(tok)
+        return sql, params, p + 1
+
+    return parse_or(pos)
+
+
+def build_search_sql(expr: str) -> Tuple[str, List[str]]:
+    expr = quote_hashtags(expr)
+    tokens = tokenize_search_expr(expr)
+    sql, params, pos = parse_search_expression(tokens)
+    if pos != len(tokens):
+        raise ValueError('Invalid syntax')
+    return sql, params


### PR DESCRIPTION
## Summary
- split helper functions into new `retrorecon` package
- add wrappers in `app.py` that delegate to the new modules
- keep Flask routes intact but avoid giant monolithic file
- added screenshot utilities module and updated imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f92f0d0c08332bd4e9d13e3aad6d2