### PR TITLE
Fix dropdown theme inconsistencies

### DIFF
--- a/docs/dropdown_style_audit.md
+++ b/docs/dropdown_style_audit.md
@@ -1,0 +1,18 @@
+# Dropdown Style Audit
+
+This document enumerates the drop-down menus, navbar menu sections and other selection inputs found in the UI. It lists their key classes and indicates whether each style is explicitly defined in `static/themes/theme-neon.css`.
+
+| Element | Selector | Theme Styles? |
+|---------|----------|---------------|
+| File menu | `.dropdown-content#file-menu` | uses base styles |
+| Edit menu | `.dropdown-content#edit-menu` | uses base styles |
+| Preferences menu | `.dropdown-content#prefs-menu` | uses base styles |
+| Tools menu | `.dropdown-content#tools-menu` | **missing** |
+| Results per page | `#results-per-page-select` | uses base styles |
+| Theme selector | `#theme-select` | uses base styles |
+| Background selector | `#background-select` | uses base styles |
+| Row tool selector | `.tool-select` | uses base styles |
+| Screenshot agent selector | `#screenshot-agent` | uses base styles |
+
+The `theme-neon.css` file only overrides `.dropbtn` and navbar fonts. It lacks specific rules for `.dropdown-content` and menu buttons, causing inconsistent backgrounds in some menus.
+

--- a/reports/report.json
+++ b/reports/report.json
@@ -1,20 +1,20 @@
 {
   "coverage": {
     "button": {
-      "total": 42,
-      "styled": 42
+      "total": 47,
+      "styled": 47
     },
     "input": {
-      "total": 11,
-      "styled": 7
+      "total": 14,
+      "styled": 9
     },
     "select": {
-      "total": 2,
-      "styled": 2
+      "total": 5,
+      "styled": 5
     },
     "checkbox": {
-      "total": 3,
-      "styled": 3
+      "total": 4,
+      "styled": 4
     }
   },
   "unscoped_selectors": {}

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -333,3 +333,19 @@ body.bg-hidden {
   color: var(--fg-color);
   padding: 2px 6px;
 }
+
+/* Standardize dropdown menu styling */
+.retrorecon-root .dropdown-content {
+  background-color: #000;
+  color: var(--font-main);
+  border: 1px solid var(--font-accent);
+}
+.retrorecon-root .dropdown-content .menu-btn,
+.retrorecon-root .dropdown-content a.menu-btn {
+  color: var(--font-main);
+}
+.retrorecon-root .dropdown-content .menu-btn:hover,
+.retrorecon-root .dropdown-content a.menu-btn:hover {
+  background: var(--font-accent);
+  color: #000;
+}


### PR DESCRIPTION
## Summary
- audit dropdown styles across the app
- document where the Neon theme was missing dropdown rules
- add consistent dark dropdown styles to `theme-neon.css`

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684f9aaab4d08332aa95841da3e68142