### PR TITLE
Refactor app into submodules

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,28 @@ from database import (
     _sanitize_db_name,
     _sanitize_export_name,
 )
-from retrorecon import progress as progress_mod, saved_tags as saved_tags_mod, notes_utils, jwt_utils, search_utils, screenshot_utils
+from retrorecon import search_utils
+from retrorecon.services import (
+    set_import_progress as _set_progress,
+    get_import_progress as _get_progress,
+    clear_import_progress as _clear_progress,
+    load_saved_tags,
+    save_saved_tags,
+    get_notes,
+    add_note,
+    update_note,
+    delete_note_entry,
+    delete_all_notes,
+    export_notes_data,
+    log_jwt_entry,
+    delete_jwt_cookies,
+    update_jwt_cookie,
+    export_jwt_cookie_data,
+    save_screenshot_record as _save_screenshot_record,
+    list_screenshot_data as _list_screenshot_data,
+    delete_screenshots as _delete_screenshots,
+    take_screenshot as _take_screenshot,
+)
 
 app = Flask(__name__)
 app.config.from_object(Config)
@@ -99,539 +120,46 @@ def _db_loaded() -> bool:
 
     return bool(app.config.get('DATABASE') and os.path.exists(app.config['DATABASE']))
 
-def set_import_progress(status: str, message: str = '', current: int = 0, total: int = 0) -> None:
-    progress_mod.set_progress(IMPORT_PROGRESS_FILE, status, message, current, total)
-
-
-def get_import_progress() -> Dict[str, Any]:
-    return progress_mod.get_progress(IMPORT_PROGRESS_FILE)
-
-
-def clear_import_progress() -> None:
-    progress_mod.clear_progress(IMPORT_PROGRESS_FILE)
-
-
-def load_saved_tags() -> List[str]:
-    return saved_tags_mod.load_tags(SAVED_TAGS_FILE)
-
-
-def save_saved_tags(tags: List[str]) -> None:
-    saved_tags_mod.save_tags(SAVED_TAGS_FILE, tags)
-
-
-def get_notes(url_id: int) -> List[sqlite3.Row]:
-    return notes_utils.get_notes(url_id)
-
-
-def add_note(url_id: int, content: str) -> int:
-    return notes_utils.add_note(url_id, content)
-
-
-def update_note(note_id: int, content: str) -> None:
-    notes_utils.update_note(note_id, content)
-
-
-def delete_note_entry(note_id: int) -> None:
-    notes_utils.delete_note_entry(note_id)
-
-
-def delete_all_notes(url_id: int) -> None:
-    notes_utils.delete_all_notes(url_id)
-
-
-def export_notes_data() -> List[Dict[str, Any]]:
-    return notes_utils.export_notes_data()
-
-
-def log_jwt_entry(token: str, header: Dict[str, Any], payload: Dict[str, Any], notes: str) -> None:
-    jwt_utils.log_entry(token, header, payload, notes)
-
-
-def delete_jwt_cookies(ids: List[int]) -> None:
-    jwt_utils.delete_cookies(ids)
-
-
-def update_jwt_cookie(jid: int, notes: str) -> None:
-    jwt_utils.update_cookie(jid, notes)
-
-
-def export_jwt_cookie_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
-    return jwt_utils.export_cookie_data(ids)
-
-
 SCREENSHOT_DIR = os.path.join(app.root_path, 'static', 'screenshots')
 executablePath: Optional[str] = None
 
 
-def save_screenshot_record(url: str, path: str, thumb: str, method: str = 'GET') -> int:
-    return screenshot_utils.save_record(SCREENSHOT_DIR, url, path, thumb, method)
+def set_import_progress(status: str, message: str = '', current: int = 0, total: int = 0) -> None:
+    _set_progress(IMPORT_PROGRESS_FILE, status, message, current, total)
 
 
-def list_screenshot_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
-    return screenshot_utils.list_data(ids)
+def get_import_progress() -> Dict[str, Any]:
+    return _get_progress(IMPORT_PROGRESS_FILE)
 
 
-def delete_screenshots(ids: List[int]) -> None:
-    screenshot_utils.delete_records(SCREENSHOT_DIR, ids)
+def clear_import_progress() -> None:
+    _clear_progress(IMPORT_PROGRESS_FILE)
 
 
 def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False) -> bytes:
-    return screenshot_utils.take_screenshot(url, user_agent, spoof_referrer, executablePath)
+    return _take_screenshot(url, user_agent, spoof_referrer, executablePath)
 
 
-@app.route('/', methods=['GET'])
-def index() -> str:
-    """Render the main search page."""
-    q = request.args.get('q', '').strip()
-    try:
-        page = int(request.args.get('page', 1))
-    except ValueError:
-        page = 1
+def save_screenshot_record(url: str, path: str, thumb: str, method: str = 'GET') -> int:
+    return _save_screenshot_record(SCREENSHOT_DIR, url, path, thumb, method)
 
-    tool = request.args.get('tool')
-    if request.path == '/tools/jwt':
-        tool = 'jwt'
-    elif request.path == '/tools/screenshotter':
-        tool = 'screenshot'
 
-    sort = request.args.get('sort', 'id')
-    direction = request.args.get('dir', 'desc').lower()
-    if direction not in ['asc', 'desc']:
-        direction = 'desc'
+def list_screenshot_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
+    return _list_screenshot_data(ids)
 
-    try:
-        items_per_page = int(session.get('items_per_page', ITEMS_PER_PAGE))
-    except ValueError:
-        items_per_page = ITEMS_PER_PAGE
-    if items_per_page not in ITEMS_PER_PAGE_OPTIONS:
-        items_per_page = ITEMS_PER_PAGE
 
-    if _db_loaded():
-        where_clauses = []
-        params = []
-        if q:
-            try:
-                search_sql, search_params = search_utils.build_search_sql(q)
-                where_clauses.append(search_sql)
-                params.extend(search_params)
-            except Exception:
-                where_clauses.append(
-                    "("
-                    "url LIKE ? OR tags LIKE ? OR "
-                    "CAST(timestamp AS TEXT) LIKE ? OR "
-                    "CAST(status_code AS TEXT) LIKE ? OR "
-                    "mime_type LIKE ?"
-                    ")"
-                )
-                params.extend([f"%{q}%"] * 5)
-        where_sql = ""
-        if where_clauses:
-            where_sql = "WHERE " + " AND ".join(where_clauses)
-
-        sort_map = {
-            'url': 'url',
-            'timestamp': 'timestamp',
-            'status_code': 'status_code',
-            'mime_type': 'mime_type',
-            'id': 'id'
-        }
-        sort_col = sort_map.get(sort, 'id')
-
-        count_sql = f"SELECT COUNT(*) AS cnt FROM urls {where_sql}"
-        count_row = query_db(count_sql, params, one=True)
-        total_count = count_row['cnt'] if count_row else 0
-
-        total_pages = max(1, (total_count + items_per_page - 1) // items_per_page)
-
-        if page < 1:
-            page = 1
-        elif page > total_pages:
-            page = total_pages
-
-        offset = (page - 1) * items_per_page
-        select_sql = f"""
-            SELECT id, url, timestamp, status_code, mime_type, tags
-            FROM urls
-            {where_sql}
-            ORDER BY {sort_col} {direction.upper()}
-            LIMIT ? OFFSET ?
-        """
-        rows = query_db(select_sql, params + [items_per_page, offset])
-    else:
-        rows = []
-        total_pages = 1
-        total_count = 0
-
-    if _db_loaded():
-        actual_name = os.path.basename(app.config['DATABASE'])
-    else:
-        actual_name = '(none)'
-    if session.get('db_display_name') != actual_name:
-        session['db_display_name'] = actual_name
-    db_name = session['db_display_name']
-
-    default_theme = 'nostalgia.css' if 'nostalgia.css' in AVAILABLE_THEMES else (AVAILABLE_THEMES[0] if AVAILABLE_THEMES else '')
-    current_theme = session.get('theme', default_theme)
-
-    default_background = 'background.jpg' if 'background.jpg' in AVAILABLE_BACKGROUNDS else (AVAILABLE_BACKGROUNDS[0] if AVAILABLE_BACKGROUNDS else '')
-    current_background = session.get('background', default_background)
-
-    panel_opacity = float(session.get('panel_opacity', 0.75))
-
-    search_history = session.get('search_history', [])
-    if q:
-        if q in search_history:
-            search_history.remove(q)
-        search_history.insert(0, q)
-        session['search_history'] = search_history[:10]
-
-    return render_template(
-        'index.html',
-        urls=rows,
-        page=page,
-        total_pages=total_pages,
-        q=q,
-        themes=AVAILABLE_THEMES,
-        theme_swatches=THEME_SWATCHES,
-        current_theme=current_theme,
-        backgrounds=AVAILABLE_BACKGROUNDS,
-        current_background=current_background,
-        panel_opacity=panel_opacity,
-        total_count=total_count,
-        items_per_page=items_per_page,
-        db_name=db_name,
-        search_history=search_history,
-        current_sort=sort,
-        current_dir=direction,
-        open_tool=tool
-    )
-
-@app.route('/fetch_cdx', methods=['POST'])
-def fetch_cdx() -> Response:
-    """Fetch CDX data for a domain and insert new URLs."""
-    domain = request.form.get('domain', '').strip().lower()
-    if not domain:
-        flash("No domain provided for CDX fetch.", "error")
-        return redirect(url_for('index'))
-    if not re.match(r'^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
-        flash("Invalid domain value.", "error")
-        return redirect(url_for('index'))
-    if not _db_loaded():
-        flash("No database loaded.", "error")
-        return redirect(url_for('index'))
-
-    cdx_api = (
-        'http://web.archive.org/cdx/search/cdx'
-        '?url={domain}/*&output=json&fl=original,timestamp,statuscode,mimetype'
-        '&collapse=urlkey&limit=1000'
-    ).format(domain=domain)
-
-    try:
-        resp = requests.get(cdx_api, timeout=20)
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as e:
-        flash(f"Error fetching CDX data: {e}", "error")
-        return redirect(url_for('index'))
-
-    inserted = 0
-    for idx, row in enumerate(data):
-        if idx == 0:
-            continue
-        original_url = row[0]
-        timestamp = row[1] if len(row) > 1 else None
-        if len(row) > 2:
-            status_raw = str(row[2])
-            status_code = int(status_raw) if status_raw.isdigit() else None
-        else:
-            status_code = None
-        mime_type = row[3] if len(row) > 3 else None
-        existing = query_db(
-            "SELECT id FROM urls WHERE url = ?",
-            [original_url],
-            one=True
-        )
-        if existing:
-            continue
-        entry_domain = urllib.parse.urlsplit(original_url).hostname or domain
-        execute_db(
-            "INSERT INTO urls (url, domain, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?, ?)",
-            [original_url, entry_domain, timestamp, status_code, mime_type, ""]
-        )
-        inserted += 1
-
-    flash(f"Fetched CDX for {domain}: inserted {inserted} new URLs.", "success")
-    return redirect(url_for('index'))
-
-def _background_import(file_content: bytes) -> None:
-    """Background thread handler for JSON/line-delimited imports."""
-    try:
-        content = file_content.decode('utf-8').strip()
-        records = []
-
-        # Try JSON array first
-        try:
-            data = json.loads(content)
-            if isinstance(data, list) and all(isinstance(item, str) for item in data):
-                records = [{"url": url, "tags": ""} for url in data]
-            elif isinstance(data, list) and all(isinstance(item, dict) for item in data):
-                records = [
-                    {
-                        "url": rec.get('url', '').strip(),
-                        "timestamp": rec.get('timestamp'),
-                        "status_code": rec.get('status_code'),
-                        "mime_type": rec.get('mime_type'),
-                        "tags": rec.get('tags', '').strip()
-                    }
-                    for rec in data if rec.get('url', '').strip()
-                ]
-        except Exception:
-            for line in content.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                    url = rec.get('url', '').strip()
-                    if url:
-                        records.append({
-                            "url": url,
-                            "timestamp": rec.get('timestamp'),
-                            "status_code": rec.get('status_code'),
-                            "mime_type": rec.get('mime_type'),
-                            "tags": rec.get('tags', '').strip()
-                        })
-                except Exception:
-                    continue
-
-        total = len(records)
-        set_import_progress('in_progress', '', 0, total)
-        db = sqlite3.connect(app.config['DATABASE'])
-        c = db.cursor()
-        inserted = 0
-        for idx, rec in enumerate(records):
-            try:
-                c.execute(
-                    "INSERT OR IGNORE INTO urls (url, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?)",
-                    (
-                        rec['url'],
-                        rec.get('timestamp'),
-                        rec.get('status_code'),
-                        rec.get('mime_type'),
-                        rec['tags']
-                    )
-                )
-            except Exception:
-                continue
-            inserted += 1
-            # Update progress every 10 or on last
-            if idx % 10 == 0 or idx + 1 == total:
-                set_import_progress('in_progress', '', idx + 1, total)
-        db.commit()
-        db.close()
-        set_import_progress('done', f"Imported {inserted} of {total} records.", inserted, total)
-    except Exception as e:
-        set_import_progress('failed', str(e), 0, 0)
-
-@app.route('/import_file', methods=['POST'])
-@app.route('/import_json', methods=['POST'])
-def import_file() -> Response:
-    """Import a JSON list or load a SQLite database depending on file type."""
-    file = (
-        request.files.get('import_file')
-        or request.files.get('json_file')
-        or request.files.get('db_file')
-    )
-    if not file:
-        flash("No file uploaded for import.", "error")
-        return redirect(url_for('index'))
-
-    filename = file.filename or ''
-    ext = filename.rsplit('.', 1)[-1].lower()
-
-    if ext == 'json':
-        if not _db_loaded():
-            flash("No database loaded.", "error")
-            return redirect(url_for('index'))
-        clear_import_progress()
-        file_content = file.read()
-        set_import_progress('starting', 'Starting import...', 0, 0)
-        thread = threading.Thread(target=_background_import, args=(file_content,))
-        thread.start()
-        flash("Import started! Progress will be shown below.", "success")
-        return redirect(url_for('index'))
-
-    if ext == 'db':
-        filename = _sanitize_db_name(filename)
-        if not filename:
-            flash('Invalid database file.', 'error')
-            return redirect(url_for('index'))
-        db_path = os.path.join(app.root_path, filename)
-        close_connection(None)
-        try:
-            file.save(db_path)
-            app.config['DATABASE'] = db_path
-            ensure_schema()
-            session['db_display_name'] = filename
-            flash("Database loaded.", "success")
-        except Exception as e:
-            flash(f"Error loading database: {e}", "error")
-        return redirect(url_for('index'))
-
-    flash('Unsupported file type.', 'error')
-    return redirect(url_for('index'))
-
-@app.route('/import_progress', methods=['GET'])
-def import_progress() -> Response:
-    """Return JSON describing the current import progress."""
-    prog = get_import_progress()
-    if request.args.get('clear') == '1' and prog.get('status') in ('done', 'failed'):
-        clear_import_progress()
-    # Always supply progress and total, and message for UI
-    return jsonify({
-        'status': prog.get('status', 'idle'),
-        'progress': prog.get('current', 0),
-        'total': prog.get('total', 0),
-        'detail': prog.get('message', '')
-    })
-
-@app.route('/add_tag', methods=['POST'])
-def add_tag() -> Response:
-    """Append a tag to the selected URL entry."""
-    if not _db_loaded():
-        flash('No database loaded.', 'error')
-        return redirect(url_for('index'))
-    entry_id = request.form.get('entry_id')
-    new_tag = request.form.get('new_tag', '').strip()
-    if not entry_id or not new_tag:
-        flash("Missing URL ID or tag for adding.", "error")
-        return redirect(url_for('index'))
-
-    row = query_db("SELECT tags FROM urls WHERE id = ?", [entry_id], one=True)
-    if not row:
-        flash("URL not found.", "error")
-        return redirect(url_for('index'))
-
-    old_tags = row['tags'] or ""
-    tag_list = [t.strip() for t in old_tags.split(',') if t.strip()]
-    if new_tag not in tag_list:
-        tag_list.append(new_tag)
-    updated_tags = ','.join(tag_list)
-
-    execute_db("UPDATE urls SET tags = ? WHERE id = ?", [updated_tags, entry_id])
-    flash(f"Added tag '{new_tag}' to entry {entry_id}.", "success")
-    return redirect(url_for('index'))
-
-@app.route('/bulk_action', methods=['POST'])
-def bulk_action() -> Response:
-    """Apply a bulk action (tag or delete) to selected URLs."""
-    if not _db_loaded():
-        flash('No database loaded.', 'error')
-        return redirect(url_for('index'))
-    action = request.form.get('action', '')
-    tag = request.form.get('tag', '').strip()
-    selected_ids = request.form.getlist('selected_ids')
-    select_all_matching = (request.form.get('select_all_matching', 'false').lower() == 'true')
-
-    if select_all_matching:
-        q = request.form.get('q', '').strip()
-
-        where_clauses = []
-        params = []
-        if q:
-            url_match = re.match(r'^url:"?(.*?)"?$', q, re.IGNORECASE)
-            if url_match:
-                val = url_match.group(1)
-                where_clauses.append("url LIKE ?")
-                params.append(f"%{val}%")
-            elif '#' in q:
-                tag_expr = search_utils.quote_hashtags(q)
-                tag_expr = tag_expr.replace('#', '')
-                try:
-                    tag_sql, tag_params = search_utils.build_tag_filter_sql(tag_expr)
-                    where_clauses.append(tag_sql)
-                    params.extend(tag_params)
-                except Exception:
-                    where_clauses.append("tags LIKE ?")
-                    params.append(f"%{tag_expr}%")
-            else:
-                where_clauses.append("(" 
-                    "url LIKE ? OR tags LIKE ? OR "
-                    "CAST(timestamp AS TEXT) LIKE ? OR "
-                    "CAST(status_code AS TEXT) LIKE ?"
-                ")")
-                params.extend([f"%{q}%"] * 4)
-        where_sql = ""
-        if where_clauses:
-            where_sql = "WHERE " + " AND ".join(where_clauses)
-
-        rows = query_db(f"SELECT id FROM urls {where_sql}", params)
-        selected_ids = [str(r['id']) for r in rows]
-
-    if not selected_ids:
-        flash("No entries selected for bulk action.", "error")
-        return redirect(url_for('index'))
-
-    if action == 'add_tag':
-        if not tag:
-            flash("No tag provided for bulk add.", "error")
-            return redirect(url_for('index'))
-        count = 0
-        for sid in selected_ids:
-            row = query_db("SELECT tags FROM urls WHERE id = ?", [sid], one=True)
-            if not row:
-                continue
-            old_tags = row['tags'] or ""
-            tag_list = [t.strip() for t in old_tags.split(',') if t.strip()]
-            if tag not in tag_list:
-                tag_list.append(tag)
-                updated_tags = ','.join(tag_list)
-                execute_db("UPDATE urls SET tags = ? WHERE id = ?", [updated_tags, sid])
-                count += 1
-        flash(f"Added tag '{tag}' to {count} entries.", "success")
-
-    elif action == 'remove_tag':
-        if not tag:
-            flash("No tag provided for removal.", "error")
-            return redirect(url_for('index'))
-        count = 0
-        for sid in selected_ids:
-            row = query_db("SELECT tags FROM urls WHERE id = ?", [sid], one=True)
-            if not row:
-                continue
-            old_tags = row['tags'] or ""
-            tag_list = [t.strip() for t in old_tags.split(',') if t.strip() and t.strip() != tag]
-            updated_tags = ','.join(tag_list)
-            execute_db("UPDATE urls SET tags = ? WHERE id = ?", [updated_tags, sid])
-            count += 1
-        flash(f"Removed tag '{tag}' from {count} entries.", "success")
-
-    elif action == 'clear_tags':
-        count = 0
-        for sid in selected_ids:
-            execute_db("UPDATE urls SET tags = '' WHERE id = ?", [sid])
-            count += 1
-        flash(f"Cleared tags from {count} entries.", "success")
-
-    elif action == 'delete':
-        count = 0
-        for sid in selected_ids:
-            execute_db("DELETE FROM urls WHERE id = ?", [sid])
-            count += 1
-        flash(f"Deleted {count} entries.", "success")
-
-    else:
-        flash(f"Unknown bulk action: {action}", "error")
-
-    return redirect(url_for('index'))
+def delete_screenshots(ids: List[int]) -> None:
+    _delete_screenshots(SCREENSHOT_DIR, ids)
 
 
 
-from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp
+from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, urls_bp
+from retrorecon.routes.urls import index
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
 app.register_blueprint(db_bp)
 app.register_blueprint(settings_bp)
+app.register_blueprint(urls_bp)
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -2,5 +2,6 @@ from .notes import bp as notes_bp
 from .tools import bp as tools_bp
 from .db import bp as db_bp
 from .settings import bp as settings_bp
+from .urls import bp as urls_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'urls_bp']

--- a/retrorecon/routes/settings.py
+++ b/retrorecon/routes/settings.py
@@ -86,4 +86,4 @@ def set_items_per_page():
     if count not in app.ITEMS_PER_PAGE_OPTIONS:
         return ('Invalid value', 400)
     session['items_per_page'] = count
-    return redirect(url_for('index'))
+    return redirect(url_for('urls.index'))

--- a/retrorecon/routes/urls.py
+++ b/retrorecon/routes/urls.py
@@ -1,0 +1,476 @@
+import json
+import os
+import re
+import sqlite3
+import threading
+import urllib.parse
+import requests
+
+import app
+from flask import (
+    Blueprint, render_template, request, redirect, url_for, flash,
+    session, jsonify, Response
+)
+from database import (
+    query_db, execute_db, close_connection, ensure_schema, _sanitize_db_name
+)
+from retrorecon import search_utils
+from retrorecon.services import (
+    set_import_progress,
+    get_import_progress,
+    clear_import_progress,
+)
+
+bp = Blueprint('urls', __name__)
+
+
+@bp.route('/', methods=['GET'])
+def index() -> str:
+    """Render the main search page."""
+    q = request.args.get('q', '').strip()
+    try:
+        page = int(request.args.get('page', 1))
+    except ValueError:
+        page = 1
+
+    tool = request.args.get('tool')
+    if request.path == '/tools/jwt':
+        tool = 'jwt'
+    elif request.path == '/tools/screenshotter':
+        tool = 'screenshot'
+
+    sort = request.args.get('sort', 'id')
+    direction = request.args.get('dir', 'desc').lower()
+    if direction not in ['asc', 'desc']:
+        direction = 'desc'
+
+    try:
+        items_per_page = int(session.get('items_per_page', app.ITEMS_PER_PAGE))
+    except ValueError:
+        items_per_page = app.ITEMS_PER_PAGE
+    if items_per_page not in app.ITEMS_PER_PAGE_OPTIONS:
+        items_per_page = app.ITEMS_PER_PAGE
+
+    if app._db_loaded():
+        where_clauses = []
+        params = []
+        if q:
+            try:
+                search_sql, search_params = search_utils.build_search_sql(q)
+                where_clauses.append(search_sql)
+                params.extend(search_params)
+            except Exception:
+                where_clauses.append(
+                    "("
+                    "url LIKE ? OR tags LIKE ? OR "
+                    "CAST(timestamp AS TEXT) LIKE ? OR "
+                    "CAST(status_code AS TEXT) LIKE ? OR "
+                    "mime_type LIKE ?"
+                    ")"
+                )
+                params.extend([f"%{q}%"] * 5)
+        where_sql = ""
+        if where_clauses:
+            where_sql = "WHERE " + " AND ".join(where_clauses)
+
+        sort_map = {
+            'url': 'url',
+            'timestamp': 'timestamp',
+            'status_code': 'status_code',
+            'mime_type': 'mime_type',
+            'id': 'id'
+        }
+        sort_col = sort_map.get(sort, 'id')
+
+        count_sql = f"SELECT COUNT(*) AS cnt FROM urls {where_sql}"
+        count_row = query_db(count_sql, params, one=True)
+        total_count = count_row['cnt'] if count_row else 0
+
+        total_pages = max(1, (total_count + items_per_page - 1) // items_per_page)
+
+        if page < 1:
+            page = 1
+        elif page > total_pages:
+            page = total_pages
+
+        offset = (page - 1) * items_per_page
+        select_sql = f"""
+            SELECT id, url, timestamp, status_code, mime_type, tags
+            FROM urls
+            {where_sql}
+            ORDER BY {sort_col} {direction.upper()}
+            LIMIT ? OFFSET ?
+        """
+        rows = query_db(select_sql, params + [items_per_page, offset])
+    else:
+        rows = []
+        total_pages = 1
+        total_count = 0
+
+    if app._db_loaded():
+        actual_name = os.path.basename(app.app.config['DATABASE'])
+    else:
+        actual_name = '(none)'
+    if session.get('db_display_name') != actual_name:
+        session['db_display_name'] = actual_name
+    db_name = session['db_display_name']
+
+    default_theme = 'nostalgia.css' if 'nostalgia.css' in app.AVAILABLE_THEMES else (app.AVAILABLE_THEMES[0] if app.AVAILABLE_THEMES else '')
+    current_theme = session.get('theme', default_theme)
+
+    default_background = 'background.jpg' if 'background.jpg' in app.AVAILABLE_BACKGROUNDS else (app.AVAILABLE_BACKGROUNDS[0] if app.AVAILABLE_BACKGROUNDS else '')
+    current_background = session.get('background', default_background)
+
+    panel_opacity = float(session.get('panel_opacity', 0.75))
+
+    search_history = session.get('search_history', [])
+    if q:
+        if q in search_history:
+            search_history.remove(q)
+        search_history.insert(0, q)
+        session['search_history'] = search_history[:10]
+
+    return render_template(
+        'index.html',
+        urls=rows,
+        page=page,
+        total_pages=total_pages,
+        q=q,
+        themes=app.AVAILABLE_THEMES,
+        theme_swatches=app.THEME_SWATCHES,
+        current_theme=current_theme,
+        backgrounds=app.AVAILABLE_BACKGROUNDS,
+        current_background=current_background,
+        panel_opacity=panel_opacity,
+        total_count=total_count,
+        items_per_page=items_per_page,
+        db_name=db_name,
+        search_history=search_history,
+        current_sort=sort,
+        current_dir=direction,
+        open_tool=tool
+    )
+
+
+def _background_import(file_content: bytes) -> None:
+    """Background thread handler for JSON/line-delimited imports."""
+    try:
+        content = file_content.decode('utf-8').strip()
+        records = []
+
+        # Try JSON array first
+        try:
+            data = json.loads(content)
+            if isinstance(data, list) and all(isinstance(item, str) for item in data):
+                records = [{"url": url, "tags": ""} for url in data]
+            elif isinstance(data, list) and all(isinstance(item, dict) for item in data):
+                records = [
+                    {
+                        "url": rec.get('url', '').strip(),
+                        "timestamp": rec.get('timestamp'),
+                        "status_code": rec.get('status_code'),
+                        "mime_type": rec.get('mime_type'),
+                        "tags": rec.get('tags', '').strip()
+                    }
+                    for rec in data if rec.get('url', '').strip()
+                ]
+        except Exception:
+            for line in content.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    url = rec.get('url', '').strip()
+                    if url:
+                        records.append({
+                            "url": url,
+                            "timestamp": rec.get('timestamp'),
+                            "status_code": rec.get('status_code'),
+                            "mime_type": rec.get('mime_type'),
+                            "tags": rec.get('tags', '').strip()
+                        })
+                except Exception:
+                    continue
+
+        total = len(records)
+        set_import_progress(app.IMPORT_PROGRESS_FILE, 'in_progress', '', 0, total)
+        db = sqlite3.connect(app.app.config['DATABASE'])
+        c = db.cursor()
+        inserted = 0
+        for idx, rec in enumerate(records):
+            try:
+                c.execute(
+                    "INSERT OR IGNORE INTO urls (url, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?)",
+                    (
+                        rec['url'],
+                        rec.get('timestamp'),
+                        rec.get('status_code'),
+                        rec.get('mime_type'),
+                        rec['tags']
+                    )
+                )
+            except Exception:
+                continue
+            inserted += 1
+            # Update progress every 10 or on last
+            if idx % 10 == 0 or idx + 1 == total:
+                set_import_progress(app.IMPORT_PROGRESS_FILE, 'in_progress', '', idx + 1, total)
+        db.commit()
+        db.close()
+        set_import_progress(app.IMPORT_PROGRESS_FILE, 'done', f"Imported {inserted} of {total} records.", inserted, total)
+    except Exception as e:
+        set_import_progress(app.IMPORT_PROGRESS_FILE, 'failed', str(e), 0, 0)
+
+
+@bp.route('/fetch_cdx', methods=['POST'])
+def fetch_cdx() -> Response:
+    """Fetch CDX data for a domain and insert new URLs."""
+    domain = request.form.get('domain', '').strip().lower()
+    if not domain:
+        flash("No domain provided for CDX fetch.", "error")
+        return redirect(url_for('urls.index'))
+    if not re.match(r'^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
+        flash("Invalid domain value.", "error")
+        return redirect(url_for('urls.index'))
+    if not app._db_loaded():
+        flash("No database loaded.", "error")
+        return redirect(url_for('urls.index'))
+
+    cdx_api = (
+        'http://web.archive.org/cdx/search/cdx'
+        '?url={domain}/*&output=json&fl=original,timestamp,statuscode,mimetype'
+        '&collapse=urlkey&limit=1000'
+    ).format(domain=domain)
+
+    try:
+        resp = requests.get(cdx_api, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        flash(f"Error fetching CDX data: {e}", "error")
+        return redirect(url_for('urls.index'))
+
+    inserted = 0
+    for idx, row in enumerate(data):
+        if idx == 0:
+            continue
+        original_url = row[0]
+        timestamp = row[1] if len(row) > 1 else None
+        if len(row) > 2:
+            status_raw = str(row[2])
+            status_code = int(status_raw) if status_raw.isdigit() else None
+        else:
+            status_code = None
+        mime_type = row[3] if len(row) > 3 else None
+        existing = query_db(
+            "SELECT id FROM urls WHERE url = ?",
+            [original_url],
+            one=True
+        )
+        if existing:
+            continue
+        entry_domain = urllib.parse.urlsplit(original_url).hostname or domain
+        execute_db(
+            "INSERT INTO urls (url, domain, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?, ?)",
+            [original_url, entry_domain, timestamp, status_code, mime_type, ""]
+        )
+        inserted += 1
+
+    flash(f"Fetched CDX for {domain}: inserted {inserted} new URLs.", "success")
+    return redirect(url_for('urls.index'))
+
+
+@bp.route('/import_file', methods=['POST'])
+@bp.route('/import_json', methods=['POST'])
+def import_file() -> Response:
+    """Import a JSON list or load a SQLite database depending on file type."""
+    file = (
+        request.files.get('import_file')
+        or request.files.get('json_file')
+        or request.files.get('db_file')
+    )
+    if not file:
+        flash("No file uploaded for import.", "error")
+        return redirect(url_for('urls.index'))
+
+    filename = file.filename or ''
+    ext = filename.rsplit('.', 1)[-1].lower()
+
+    if ext == 'json':
+        if not app._db_loaded():
+            flash("No database loaded.", "error")
+            return redirect(url_for('urls.index'))
+        clear_import_progress(app.IMPORT_PROGRESS_FILE)
+        file_content = file.read()
+        set_import_progress(app.IMPORT_PROGRESS_FILE, 'starting', 'Starting import...', 0, 0)
+        thread = threading.Thread(target=_background_import, args=(file_content,))
+        thread.start()
+        flash("Import started! Progress will be shown below.", "success")
+        return redirect(url_for('urls.index'))
+
+    if ext == 'db':
+        filename = _sanitize_db_name(filename)
+        if not filename:
+            flash('Invalid database file.', 'error')
+            return redirect(url_for('urls.index'))
+        db_path = os.path.join(app.app.root_path, filename)
+        close_connection(None)
+        try:
+            file.save(db_path)
+            app.app.config['DATABASE'] = db_path
+            ensure_schema()
+            session['db_display_name'] = filename
+            flash("Database loaded.", "success")
+        except Exception as e:
+            flash(f"Error loading database: {e}", "error")
+        return redirect(url_for('urls.index'))
+
+    flash('Unsupported file type.', 'error')
+    return redirect(url_for('urls.index'))
+
+
+@bp.route('/import_progress', methods=['GET'])
+def import_progress() -> Response:
+    """Return JSON describing the current import progress."""
+    prog = get_import_progress(app.IMPORT_PROGRESS_FILE)
+    if request.args.get('clear') == '1' and prog.get('status') in ('done', 'failed'):
+        clear_import_progress(app.IMPORT_PROGRESS_FILE)
+    return jsonify({
+        'status': prog.get('status', 'idle'),
+        'progress': prog.get('current', 0),
+        'total': prog.get('total', 0),
+        'detail': prog.get('message', '')
+    })
+
+
+@bp.route('/add_tag', methods=['POST'])
+def add_tag() -> Response:
+    """Append a tag to the selected URL entry."""
+    if not app._db_loaded():
+        flash('No database loaded.', 'error')
+        return redirect(url_for('urls.index'))
+    entry_id = request.form.get('entry_id')
+    new_tag = request.form.get('new_tag', '').strip()
+    if not entry_id or not new_tag:
+        flash("Missing URL ID or tag for adding.", "error")
+        return redirect(url_for('urls.index'))
+
+    row = query_db("SELECT tags FROM urls WHERE id = ?", [entry_id], one=True)
+    if not row:
+        flash("URL not found.", "error")
+        return redirect(url_for('urls.index'))
+
+    old_tags = row['tags'] or ""
+    tag_list = [t.strip() for t in old_tags.split(',') if t.strip()]
+    if new_tag not in tag_list:
+        tag_list.append(new_tag)
+    updated_tags = ','.join(tag_list)
+
+    execute_db("UPDATE urls SET tags = ? WHERE id = ?", [updated_tags, entry_id])
+    flash(f"Added tag '{new_tag}' to entry {entry_id}.", "success")
+    return redirect(url_for('urls.index'))
+
+
+@bp.route('/bulk_action', methods=['POST'])
+def bulk_action() -> Response:
+    """Apply a bulk action (tag or delete) to selected URLs."""
+    if not app._db_loaded():
+        flash('No database loaded.', 'error')
+        return redirect(url_for('urls.index'))
+    action = request.form.get('action', '')
+    tag = request.form.get('tag', '').strip()
+    selected_ids = request.form.getlist('selected_ids')
+    select_all_matching = (request.form.get('select_all_matching', 'false').lower() == 'true')
+
+    if select_all_matching:
+        q = request.form.get('q', '').strip()
+
+        where_clauses = []
+        params = []
+        if q:
+            url_match = re.match(r'^url:"?(.*?)"?$', q, re.IGNORECASE)
+            if url_match:
+                val = url_match.group(1)
+                where_clauses.append("url LIKE ?")
+                params.append(f"%{val}%")
+            elif '#' in q:
+                tag_expr = search_utils.quote_hashtags(q)
+                tag_expr = tag_expr.replace('#', '')
+                try:
+                    tag_sql, tag_params = search_utils.build_tag_filter_sql(tag_expr)
+                    where_clauses.append(tag_sql)
+                    params.extend(tag_params)
+                except Exception:
+                    where_clauses.append("tags LIKE ?")
+                    params.append(f"%{tag_expr}%")
+            else:
+                where_clauses.append("("
+                    "url LIKE ? OR tags LIKE ? OR "
+                    "CAST(timestamp AS TEXT) LIKE ? OR "
+                    "CAST(status_code AS TEXT) LIKE ?"
+                ")")
+                params.extend([f"%{q}%"] * 4)
+        where_sql = ""
+        if where_clauses:
+            where_sql = "WHERE " + " AND ".join(where_clauses)
+
+        rows = query_db(f"SELECT id FROM urls {where_sql}", params)
+        selected_ids = [str(r['id']) for r in rows]
+
+    if not selected_ids:
+        flash("No entries selected for bulk action.", "error")
+        return redirect(url_for('urls.index'))
+
+    if action == 'add_tag':
+        if not tag:
+            flash("No tag provided for bulk add.", "error")
+            return redirect(url_for('urls.index'))
+        count = 0
+        for sid in selected_ids:
+            row = query_db("SELECT tags FROM urls WHERE id = ?", [sid], one=True)
+            if not row:
+                continue
+            old_tags = row['tags'] or ""
+            tag_list = [t.strip() for t in old_tags.split(',') if t.strip()]
+            if tag not in tag_list:
+                tag_list.append(tag)
+                updated_tags = ','.join(tag_list)
+                execute_db("UPDATE urls SET tags = ? WHERE id = ?", [updated_tags, sid])
+                count += 1
+        flash(f"Added tag '{tag}' to {count} entries.", "success")
+
+    elif action == 'remove_tag':
+        if not tag:
+            flash("No tag provided for removal.", "error")
+            return redirect(url_for('urls.index'))
+        count = 0
+        for sid in selected_ids:
+            row = query_db("SELECT tags FROM urls WHERE id = ?", [sid], one=True)
+            if not row:
+                continue
+            old_tags = row['tags'] or ""
+            tag_list = [t.strip() for t in old_tags.split(',') if t.strip() and t.strip() != tag]
+            updated_tags = ','.join(tag_list)
+            execute_db("UPDATE urls SET tags = ? WHERE id = ?", [updated_tags, sid])
+            count += 1
+        flash(f"Removed tag '{tag}' from {count} entries.", "success")
+
+    elif action == 'clear_tags':
+        count = 0
+        for sid in selected_ids:
+            execute_db("UPDATE urls SET tags = '' WHERE id = ?", [sid])
+            count += 1
+        flash(f"Cleared tags from {count} entries.", "success")
+
+    elif action == 'delete':
+        count = 0
+        for sid in selected_ids:
+            execute_db("DELETE FROM urls WHERE id = ?", [sid])
+            count += 1
+        flash(f"Deleted {count} entries.", "success")
+
+    else:
+        flash(f"Unknown bulk action: {action}", "error")
+
+    return redirect(url_for('urls.index'))

--- a/retrorecon/services/__init__.py
+++ b/retrorecon/services/__init__.py
@@ -1,0 +1,35 @@
+from .notes_service import (
+    load_saved_tags,
+    save_saved_tags,
+    get_notes,
+    add_note,
+    update_note,
+    delete_note_entry,
+    delete_all_notes,
+    export_notes_data,
+)
+from .jwt_service import (
+    log_jwt_entry,
+    delete_jwt_cookies,
+    update_jwt_cookie,
+    export_jwt_cookie_data,
+)
+from .screenshot_service import (
+    save_screenshot_record,
+    list_screenshot_data,
+    delete_screenshots,
+    take_screenshot,
+)
+from .progress_service import (
+    set_import_progress,
+    get_import_progress,
+    clear_import_progress,
+)
+
+__all__ = [
+    'load_saved_tags', 'save_saved_tags', 'get_notes', 'add_note', 'update_note',
+    'delete_note_entry', 'delete_all_notes', 'export_notes_data',
+    'log_jwt_entry', 'delete_jwt_cookies', 'update_jwt_cookie', 'export_jwt_cookie_data',
+    'save_screenshot_record', 'list_screenshot_data', 'delete_screenshots', 'take_screenshot',
+    'set_import_progress', 'get_import_progress', 'clear_import_progress',
+]

--- a/retrorecon/services/jwt_service.py
+++ b/retrorecon/services/jwt_service.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict, List, Optional
+from retrorecon import jwt_utils
+
+
+def log_jwt_entry(token: str, header: Dict[str, Any], payload: Dict[str, Any], notes: str) -> None:
+    jwt_utils.log_entry(token, header, payload, notes)
+
+
+def delete_jwt_cookies(ids: List[int]) -> None:
+    jwt_utils.delete_cookies(ids)
+
+
+def update_jwt_cookie(jid: int, notes: str) -> None:
+    jwt_utils.update_cookie(jid, notes)
+
+
+def export_jwt_cookie_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
+    return jwt_utils.export_cookie_data(ids)

--- a/retrorecon/services/notes_service.py
+++ b/retrorecon/services/notes_service.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, List
+import sqlite3
+from retrorecon import notes_utils, saved_tags as saved_tags_mod
+
+
+def load_saved_tags(file_path: str) -> List[str]:
+    """Load the list of saved tags from ``file_path``."""
+    return saved_tags_mod.load_tags(file_path)
+
+
+def save_saved_tags(file_path: str, tags: List[str]) -> None:
+    """Persist ``tags`` to ``file_path``."""
+    saved_tags_mod.save_tags(file_path, tags)
+
+
+def get_notes(url_id: int) -> List[sqlite3.Row]:
+    return notes_utils.get_notes(url_id)
+
+
+def add_note(url_id: int, content: str) -> int:
+    return notes_utils.add_note(url_id, content)
+
+
+def update_note(note_id: int, content: str) -> None:
+    notes_utils.update_note(note_id, content)
+
+
+def delete_note_entry(note_id: int) -> None:
+    notes_utils.delete_note_entry(note_id)
+
+
+def delete_all_notes(url_id: int) -> None:
+    notes_utils.delete_all_notes(url_id)
+
+
+def export_notes_data() -> List[Dict[str, Any]]:
+    return notes_utils.export_notes_data()

--- a/retrorecon/services/progress_service.py
+++ b/retrorecon/services/progress_service.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict
+from retrorecon import progress as progress_mod
+
+
+def set_import_progress(file_path: str, status: str, message: str = '', current: int = 0, total: int = 0) -> None:
+    """Proxy to ``progress.set_progress``."""
+    progress_mod.set_progress(file_path, status, message, current, total)
+
+
+def get_import_progress(file_path: str) -> Dict[str, Any]:
+    """Proxy to ``progress.get_progress``."""
+    return progress_mod.get_progress(file_path)
+
+
+def clear_import_progress(file_path: str) -> None:
+    """Proxy to ``progress.clear_progress``."""
+    progress_mod.clear_progress(file_path)

--- a/retrorecon/services/screenshot_service.py
+++ b/retrorecon/services/screenshot_service.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict, List, Optional
+from retrorecon import screenshot_utils
+
+
+def save_screenshot_record(dir_path: str, url: str, path: str, thumb: str, method: str = 'GET') -> int:
+    return screenshot_utils.save_record(dir_path, url, path, thumb, method)
+
+
+def list_screenshot_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
+    return screenshot_utils.list_data(ids)
+
+
+def delete_screenshots(dir_path: str, ids: List[int]) -> None:
+    screenshot_utils.delete_records(dir_path, ids)
+
+
+def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False, executable_path: Optional[str] = None) -> bytes:
+    return screenshot_utils.take_screenshot(url, user_agent, spoof_referrer, executable_path)


### PR DESCRIPTION
## Summary
- extract notes, JWT, screenshot and progress helpers into `retrorecon.services`
- move URL related routes to new blueprint `urls.py`
- register new blueprint and expose original helpers
- update settings routes to use the new URL endpoint

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9c0c94c08332af63afe5ed23a693