### PR TITLE
Fix circular import in routes

### DIFF
--- a/retrorecon/routes/db.py
+++ b/retrorecon/routes/db.py
@@ -1,11 +1,11 @@
 import os
-import app
 from flask import Blueprint, request, redirect, url_for, flash, send_file, session
 
 bp = Blueprint('db', __name__)
 
 @bp.route('/new_db', methods=['POST'])
 def new_db():
+    import app
     name = request.form.get('db_name', '').strip()
     safe = app._sanitize_db_name(name)
     if not safe:
@@ -23,6 +23,7 @@ def new_db():
 
 @bp.route('/load_db', methods=['POST'])
 def load_db_route():
+    import app
     file = request.files.get('db_file')
     if not file:
         flash("No database file uploaded.", "error")
@@ -46,6 +47,7 @@ def load_db_route():
 
 @bp.route('/save_db', methods=['GET'])
 def save_db():
+    import app
     if not app._db_loaded():
         flash('No database loaded.', 'error')
         return redirect(url_for('index'))
@@ -63,6 +65,7 @@ def save_db():
 
 @bp.route('/rename_db', methods=['POST'])
 def rename_db():
+    import app
     new_name = request.form.get('new_name', '').strip()
     safe = app._sanitize_db_name(new_name or '')
     if not safe:

--- a/retrorecon/routes/notes.py
+++ b/retrorecon/routes/notes.py
@@ -1,4 +1,3 @@
-import app
 from flask import Blueprint, request, jsonify
 from retrorecon.services import (
     load_saved_tags,
@@ -15,6 +14,7 @@ bp = Blueprint('notes', __name__)
 
 @bp.route('/saved_tags', methods=['GET', 'POST'])
 def saved_tags_route():
+    import app
     if request.method == 'GET':
         return jsonify({'tags': load_saved_tags(app.SAVED_TAGS_FILE)})
     tag = request.form.get('tag', '').strip()
@@ -30,6 +30,7 @@ def saved_tags_route():
 
 @bp.route('/delete_saved_tag', methods=['POST'])
 def delete_saved_tag():
+    import app
     tag = request.form.get('tag', '').strip()
     if not tag:
         return ('', 400)
@@ -43,6 +44,7 @@ def delete_saved_tag():
 
 @bp.route('/notes/<int:url_id>', methods=['GET'])
 def notes_get(url_id: int):
+    import app
     if not app._db_loaded():
         return jsonify([])
     rows = get_notes(url_id)
@@ -59,6 +61,7 @@ def notes_get(url_id: int):
 
 @bp.route('/notes', methods=['POST'])
 def notes_post():
+    import app
     if not app._db_loaded():
         return ('', 400)
     url_id = request.form.get('url_id', type=int)
@@ -74,6 +77,7 @@ def notes_post():
 
 @bp.route('/delete_note', methods=['POST'])
 def delete_note_route():
+    import app
     note_id = request.form.get('note_id', type=int)
     url_id = request.form.get('url_id', type=int)
     delete_all = request.form.get('all', '0') == '1'
@@ -87,6 +91,7 @@ def delete_note_route():
 
 @bp.route('/export_notes', methods=['GET'])
 def export_notes():
+    import app
     if not app._db_loaded():
         return jsonify([])
     data = export_notes_data()

--- a/retrorecon/routes/settings.py
+++ b/retrorecon/routes/settings.py
@@ -1,12 +1,12 @@
 import os
 import re
-import app
 from flask import Blueprint, request, redirect, url_for, flash, session
 
 bp = Blueprint('settings', __name__)
 
 @bp.route('/set_theme', methods=['POST'])
 def set_theme():
+    import app
     theme = request.form.get('theme', '')
     if theme in app.AVAILABLE_THEMES:
         session['theme'] = theme
@@ -18,6 +18,7 @@ def set_theme():
 
 @bp.route('/set_background', methods=['POST'])
 def set_background():
+    import app
     bg = request.form.get('background', '')
     if bg in app.AVAILABLE_BACKGROUNDS:
         session['background'] = bg
@@ -38,6 +39,7 @@ def set_panel_opacity():
 
 @bp.route('/set_font_size', methods=['POST'])
 def set_font_size():
+    import app
     try:
         size = int(request.form.get('size', '14'))
     except ValueError:
@@ -79,6 +81,7 @@ def set_font_size():
 
 @bp.route('/set_items_per_page', methods=['POST'])
 def set_items_per_page():
+    import app
     try:
         count = int(request.form.get('count', ''))
     except ValueError:

--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -6,7 +6,6 @@ import base64
 import urllib.parse
 import requests
 import zipfile
-import app
 from flask import Blueprint, request, Response, jsonify, render_template, redirect, url_for, flash, send_file
 from retrorecon.services import (
     log_jwt_entry,
@@ -27,6 +26,7 @@ def text_tools_page():
 
 
 def _get_text_param():
+    import app
     text = request.form.get('text', '')
     if len(text.encode('utf-8')) > app.TEXT_TOOLS_LIMIT:
         return None
@@ -83,11 +83,13 @@ def jwt_tools_page():
 
 @bp.route('/tools/jwt', methods=['GET'])
 def jwt_tools_full_page():
+    import app
     return app.index()
 
 
 @bp.route('/tools/jwt_decode', methods=['POST'])
 def jwt_decode_route():
+    import app
     token = request.form.get('token', '')
     if len(token.encode('utf-8')) > app.TEXT_TOOLS_LIMIT:
         return ('Request too large', 400)
@@ -157,6 +159,7 @@ def jwt_decode_route():
 
 @bp.route('/tools/jwt_encode', methods=['POST'])
 def jwt_encode_route():
+    import app
     raw = request.form.get('payload', '')
     if len(str(raw).encode('utf-8')) > app.TEXT_TOOLS_LIMIT:
         return ('Request too large', 400)
@@ -193,6 +196,7 @@ def jwt_encode_route():
 
 @bp.route('/jwt_cookies', methods=['GET'])
 def jwt_cookies_route():
+    import app
     if not app._db_loaded():
         return jsonify([])
     rows = export_jwt_cookie_data()[:50]
@@ -201,6 +205,7 @@ def jwt_cookies_route():
 
 @bp.route('/delete_jwt_cookies', methods=['POST'])
 def delete_jwt_cookies_route():
+    import app
     if not app._db_loaded():
         return ('', 400)
     ids = [int(i) for i in request.form.getlist('ids') if i.isdigit()]
@@ -212,6 +217,7 @@ def delete_jwt_cookies_route():
 
 @bp.route('/update_jwt_cookie', methods=['POST'])
 def update_jwt_cookie_route():
+    import app
     if not app._db_loaded():
         return ('', 400)
     jid = request.form.get('id', type=int)
@@ -224,6 +230,7 @@ def update_jwt_cookie_route():
 
 @bp.route('/export_jwt_cookies', methods=['GET'])
 def export_jwt_cookies_route():
+    import app
     if not app._db_loaded():
         return jsonify([])
     ids = [int(i) for i in request.args.getlist('id') if i.isdigit()]
@@ -238,11 +245,13 @@ def screenshotter_page():
 
 @bp.route('/tools/screenshotter', methods=['GET'])
 def screenshotter_full_page():
+    import app
     return app.index()
 
 
 @bp.route('/tools/screenshot', methods=['POST'])
 def screenshot_route():
+    import app
     if not app._db_loaded():
         return jsonify({'error': 'no_db'}), 400
     url = request.form.get('url', '').strip()
@@ -277,6 +286,7 @@ def screenshot_route():
 
 @bp.route('/screenshots', methods=['GET'])
 def screenshots_route():
+    import app
     if not app._db_loaded():
         return jsonify([])
     rows = list_screenshot_data()
@@ -288,6 +298,7 @@ def screenshots_route():
 
 @bp.route('/delete_screenshots', methods=['POST'])
 def delete_screenshots_route():
+    import app
     if not app._db_loaded():
         return ('', 400)
     ids = [int(i) for i in request.form.getlist('ids') if i.isdigit()]

--- a/retrorecon/routes/urls.py
+++ b/retrorecon/routes/urls.py
@@ -6,7 +6,6 @@ import threading
 import urllib.parse
 import requests
 
-import app
 from flask import (
     Blueprint, render_template, request, redirect, url_for, flash,
     session, jsonify, Response
@@ -26,6 +25,7 @@ bp = Blueprint('urls', __name__)
 
 @bp.route('/', methods=['GET'])
 def index() -> str:
+    import app
     """Render the main search page."""
     q = request.args.get('q', '').strip()
     try:
@@ -153,6 +153,7 @@ def index() -> str:
 
 
 def _background_import(file_content: bytes) -> None:
+    import app
     """Background thread handler for JSON/line-delimited imports."""
     try:
         content = file_content.decode('utf-8').strip()
@@ -225,6 +226,7 @@ def _background_import(file_content: bytes) -> None:
 
 @bp.route('/fetch_cdx', methods=['POST'])
 def fetch_cdx() -> Response:
+    import app
     """Fetch CDX data for a domain and insert new URLs."""
     domain = request.form.get('domain', '').strip().lower()
     if not domain:
@@ -284,6 +286,7 @@ def fetch_cdx() -> Response:
 @bp.route('/import_file', methods=['POST'])
 @bp.route('/import_json', methods=['POST'])
 def import_file() -> Response:
+    import app
     """Import a JSON list or load a SQLite database depending on file type."""
     file = (
         request.files.get('import_file')
@@ -332,6 +335,7 @@ def import_file() -> Response:
 
 @bp.route('/import_progress', methods=['GET'])
 def import_progress() -> Response:
+    import app
     """Return JSON describing the current import progress."""
     prog = get_import_progress(app.IMPORT_PROGRESS_FILE)
     if request.args.get('clear') == '1' and prog.get('status') in ('done', 'failed'):
@@ -346,6 +350,7 @@ def import_progress() -> Response:
 
 @bp.route('/add_tag', methods=['POST'])
 def add_tag() -> Response:
+    import app
     """Append a tag to the selected URL entry."""
     if not app._db_loaded():
         flash('No database loaded.', 'error')
@@ -374,6 +379,7 @@ def add_tag() -> Response:
 
 @bp.route('/bulk_action', methods=['POST'])
 def bulk_action() -> Response:
+    import app
     """Apply a bulk action (tag or delete) to selected URLs."""
     if not app._db_loaded():
         flash('No database loaded.', 'error')


### PR DESCRIPTION
## Summary
- avoid importing `app` at module load time in routes
- import `app` inside request handlers to prevent circular import

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa097065883329ad77d5feb42193c