### PR TITLE
Add API client module

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,13 +153,21 @@ def delete_screenshots(ids: List[int]) -> None:
 
 
 
-from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, urls_bp
+from retrorecon.routes import (
+    notes_bp,
+    tools_bp,
+    db_bp,
+    settings_bp,
+    urls_bp,
+    api_client_bp,
+)
 from retrorecon.routes.urls import index
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
 app.register_blueprint(db_bp)
 app.register_blueprint(settings_bp)
 app.register_blueprint(urls_bp)
+app.register_blueprint(api_client_bp)
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):

--- a/reports/report.json
+++ b/reports/report.json
@@ -1,16 +1,16 @@
 {
   "coverage": {
     "button": {
-      "total": 47,
-      "styled": 47
+      "total": 51,
+      "styled": 51
     },
     "input": {
-      "total": 14,
-      "styled": 9
+      "total": 16,
+      "styled": 11
     },
     "select": {
-      "total": 5,
-      "styled": 5
+      "total": 7,
+      "styled": 7
     },
     "checkbox": {
       "total": 4,

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -3,5 +3,6 @@ from .tools import bp as tools_bp
 from .db import bp as db_bp
 from .settings import bp as settings_bp
 from .urls import bp as urls_bp
+from .api_client import bp as api_client_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'urls_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'urls_bp', 'api_client_bp']

--- a/retrorecon/routes/api_client.py
+++ b/retrorecon/routes/api_client.py
@@ -1,0 +1,57 @@
+import requests
+from flask import Blueprint, request, jsonify, render_template
+
+bp = Blueprint('api_client', __name__)
+
+
+def _parse_headers(text: str) -> dict:
+    headers = {}
+    for line in text.splitlines():
+        if ':' in line:
+            key, val = line.split(':', 1)
+            headers[key.strip()] = val.strip()
+    return headers
+
+
+@bp.route('/api_client', methods=['GET'])
+def api_client_page():
+    return render_template('api_client.html')
+
+
+@bp.route('/api_client/openapi', methods=['GET'])
+def load_openapi():
+    url = request.args.get('url', '')
+    if not url:
+        return jsonify([])
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        spec = resp.json()
+    except Exception:
+        return jsonify([])
+    paths = spec.get('paths', {})
+    endpoints = []
+    for path, methods in paths.items():
+        if isinstance(methods, dict):
+            for method in methods.keys():
+                endpoints.append({'method': method.upper(), 'path': path})
+    return jsonify(endpoints)
+
+
+@bp.route('/api_client/send', methods=['POST'])
+def send_request():
+    method = request.form.get('method', 'GET').upper()
+    url = request.form.get('url', '')
+    headers_text = request.form.get('headers', '')
+    body = request.form.get('body', '')
+    headers = _parse_headers(headers_text)
+    try:
+        resp = requests.request(method, url, headers=headers, data=body, timeout=15)
+    except Exception as e:
+        return jsonify({'error': str(e)})
+    result = {
+        'status': resp.status_code,
+        'headers': dict(resp.headers),
+        'body': resp.text,
+    }
+    return jsonify(result)

--- a/static/api_client.css
+++ b/static/api_client.css
@@ -1,0 +1,22 @@
+/* File: static/api_client.css */
+.retrorecon-root .api-client {
+  display: flex;
+  gap: 1em;
+  align-items: flex-start;
+}
+.retrorecon-root .api-client__form,
+.retrorecon-root .api-client__response {
+  flex: 1 1 0;
+}
+.retrorecon-root .api-client__textarea {
+  width: 100%;
+  min-height: 8em;
+}
+.retrorecon-root .api-client__response-body {
+  white-space: pre-wrap;
+  background: rgba(var(--bg-rgb) / var(--panel-opacity));
+  border: 1px solid #fff;
+  padding: 0.5em;
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/static/api_client.js
+++ b/static/api_client.js
@@ -1,0 +1,76 @@
+document.addEventListener('DOMContentLoaded', function(){
+  const openapiUrl = document.getElementById('openapi-url');
+  const loadBtn = document.getElementById('load-openapi');
+  const epSelect = document.getElementById('endpoint-select');
+  const form = document.getElementById('api-request-form');
+  const methodSel = document.getElementById('method');
+  const urlInput = document.getElementById('request-url');
+  const headersInput = document.getElementById('headers');
+  const bodyInput = document.getElementById('body');
+  const respPre = document.getElementById('response-display');
+  const expReq = document.getElementById('export-request');
+  const expResp = document.getElementById('export-response');
+
+  if(loadBtn){
+    loadBtn.addEventListener('click', async ()=>{
+      if(!openapiUrl.value) return;
+      const resp = await fetch('/api_client/openapi?url='+encodeURIComponent(openapiUrl.value));
+      const data = await resp.json();
+      epSelect.innerHTML = '';
+      data.forEach(ep => {
+        const opt = document.createElement('option');
+        opt.value = ep.method + ' ' + ep.path;
+        opt.textContent = ep.method + ' ' + ep.path;
+        epSelect.appendChild(opt);
+      });
+    });
+  }
+
+  if(epSelect){
+    epSelect.addEventListener('change', ()=>{
+      const val = epSelect.value.split(' ');
+      if(val.length>=2){
+        methodSel.value = val[0];
+        urlInput.value = val.slice(1).join(' ');
+      }
+    });
+  }
+
+  if(form){
+    form.addEventListener('submit', async e=>{
+      e.preventDefault();
+      const params = new URLSearchParams();
+      params.append('method', methodSel.value);
+      params.append('url', urlInput.value);
+      params.append('headers', headersInput.value);
+      params.append('body', bodyInput.value);
+      const resp = await fetch('/api_client/send', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:params});
+      const data = await resp.json();
+      respPre.textContent = JSON.stringify(data, null, 2);
+    });
+  }
+
+  function saveText(filename, text){
+    const blob = new Blob([text], {type:'text/plain'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(a.href);
+  }
+
+  if(expReq){
+    expReq.addEventListener('click', ()=>{
+      const reqData = [methodSel.value + ' ' + urlInput.value, headersInput.value, '', bodyInput.value].join('\n');
+      saveText('request.txt', reqData);
+    });
+  }
+
+  if(expResp){
+    expResp.addEventListener('click', ()=>{
+      saveText('response.json', respPre.textContent);
+    });
+  }
+});

--- a/templates/api_client.html
+++ b/templates/api_client.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>API Client</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='api_client.css') }}" />
+</head>
+<body class="app">
+  <div class="retrorecon-root">
+    <h2>REST API Client</h2>
+    <div class="api-client">
+      <div class="api-client__form">
+        <div class="mb-4px">
+          <input type="text" id="openapi-url" class="form-input w-95" placeholder="OpenAPI URL" />
+          <button type="button" id="load-openapi" class="btn ml-4px">Load</button>
+        </div>
+        <select id="endpoint-select" class="form-select w-95 mb-4px"></select>
+        <form id="api-request-form">
+          <div class="mb-4px">
+            <select id="method" class="form-select w-6em mr-03">
+              <option>GET</option>
+              <option>POST</option>
+              <option>PUT</option>
+              <option>DELETE</option>
+              <option>PATCH</option>
+              <option>HEAD</option>
+            </select>
+            <input type="text" id="request-url" class="form-input w-95" placeholder="Request URL" />
+          </div>
+          <textarea id="headers" class="form-input api-client__textarea" placeholder="Header: value"></textarea>
+          <textarea id="body" class="form-input api-client__textarea" placeholder="Body"></textarea>
+          <button type="submit" class="btn mt-05">Send</button>
+          <button type="button" id="export-request" class="btn mt-05 ml-05">Export Request</button>
+        </form>
+      </div>
+      <div class="api-client__response">
+        <pre id="response-display" class="api-client__response-body"></pre>
+        <button type="button" id="export-response" class="btn mt-05">Export Response</button>
+      </div>
+    </div>
+  </div>
+  <script src="{{ url_for('static', filename='api_client.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a blueprint for an API client
- register blueprint in the app
- add REST API client page template with JS and CSS
- update CSS audit report

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_684f9fdca3f08332a04c38bd67791de9