### PR TITLE
Fix crash when DB not loaded

### DIFF
--- a/retrorecon/routes/urls.py
+++ b/retrorecon/routes/urls.py
@@ -83,25 +83,36 @@ def index() -> str:
         sort_col = sort_map.get(sort, 'id')
 
         count_sql = f"SELECT COUNT(*) AS cnt FROM urls {where_sql}"
-        count_row = query_db(count_sql, params, one=True)
-        total_count = count_row['cnt'] if count_row else 0
+        try:
+            count_row = query_db(count_sql, params, one=True)
+            total_count = count_row['cnt'] if count_row else 0
 
-        total_pages = max(1, (total_count + items_per_page - 1) // items_per_page)
+            total_pages = max(1, (total_count + items_per_page - 1) // items_per_page)
 
-        if page < 1:
-            page = 1
-        elif page > total_pages:
-            page = total_pages
+            if page < 1:
+                page = 1
+            elif page > total_pages:
+                page = total_pages
 
-        offset = (page - 1) * items_per_page
-        select_sql = f"""
-            SELECT id, url, timestamp, status_code, mime_type, tags
-            FROM urls
-            {where_sql}
-            ORDER BY {sort_col} {direction.upper()}
-            LIMIT ? OFFSET ?
-        """
-        rows = query_db(select_sql, params + [items_per_page, offset])
+            offset = (page - 1) * items_per_page
+            select_sql = f"""
+                SELECT id, url, timestamp, status_code, mime_type, tags
+                FROM urls
+                {where_sql}
+                ORDER BY {sort_col} {direction.upper()}
+                LIMIT ? OFFSET ?
+            """
+            rows = query_db(select_sql, params + [items_per_page, offset])
+        except RuntimeError:
+            flash('No database loaded.', 'error')
+            rows = []
+            total_pages = 1
+            total_count = 0
+        except sqlite3.Error as e:
+            flash(f'Database error: {e}', 'error')
+            rows = []
+            total_pages = 1
+            total_count = 0
     else:
         rows = []
         total_pages = 1


### PR DESCRIPTION
## Summary
- prevent index route from crashing when the database isn't loaded

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa5304ab4833299f182f012c786c6