### PR TITLE
Handle invalid import progress file

### DIFF
--- a/retrorecon/progress.py
+++ b/retrorecon/progress.py
@@ -23,7 +23,10 @@ def get_progress(file_path: str) -> Dict[str, Any]:
         if not os.path.exists(file_path):
             return {'status': 'idle', 'message': '', 'current': 0, 'total': 0}
         with open(file_path, 'r') as f:
-            return json.load(f)
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {'status': 'idle', 'message': '', 'current': 0, 'total': 0}
 
 def clear_progress(file_path: str) -> None:
     """Remove ``file_path`` if it exists."""

--- a/tests/test_import_progress.py
+++ b/tests/test_import_progress.py
@@ -20,3 +20,12 @@ def test_import_progress(tmp_path, monkeypatch):
 
     app.clear_import_progress()
     assert not progress_file.exists()
+
+
+def test_get_progress_bad_json(tmp_path, monkeypatch):
+    progress_file = tmp_path / "progress.json"
+    progress_file.write_text("nonsense")
+    monkeypatch.setattr(app, "IMPORT_PROGRESS_FILE", str(progress_file))
+
+    data = app.get_import_progress()
+    assert data == {"status": "idle", "message": "", "current": 0, "total": 0}


### PR DESCRIPTION
## Summary
- avoid JSON decode errors when reading `import_progress.json`
- add regression test for corrupted progress file

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fc8e24ca48332b1e729832d27bd4c