### PR TITLE
Refactor DB import flow

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -39,13 +39,12 @@ curl -X POST -d "domain=example.com" http://localhost:5000/fetch_cdx
 ```
 
 ### `POST /import_file` (`/import_json`)
-Import URLs from a JSON file or load a database file. The route is accessible via both `/import_file` and `/import_json`.
+Import URLs from a JSON file. The route is accessible via both `/import_file` and `/import_json`.
 
-Parameters depend on the uploaded file:
-- `import_file` or `json_file` – JSON array/lines of records.
-- `db_file` – SQLite `.db` file to load.
+Parameters:
+- `import_file` or `json_file` – JSON array or newline-delimited records.
 
-Example (JSON import):
+Example:
 ```
 curl -X POST -F "import_file=@records.json" http://localhost:5000/import_file
 ```

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,16 +77,16 @@
             <button type="submit" class="menu-btn">New Database</button>
           </form>
           <form method="POST" action="/load_db" enctype="multipart/form-data" class="menu-row" id="load-db-form">
-            <input type="file" name="db_file" accept=".db,.json" required class="form-file d-none" id="load-db-file" />
-            <button type="button" class="menu-btn" id="load-db-btn">Open Database</button>
+            <input type="file" name="db_file" accept=".db" required class="form-file d-none" id="load-db-file" />
+            <button type="button" class="menu-btn" id="load-db-btn">Open SQLite Database</button>
           </form>
           <form method="POST" action="/rename_db" class="menu-row" id="rename-db-form">
             <input type="hidden" name="new_name" id="rename-db-name" />
             <button type="submit" class="menu-btn">Rename Database</button>
           </form>
           <form method="POST" action="/import_file" enctype="multipart/form-data" class="menu-row" id="import-form">
-            <input type="file" name="import_file" accept=".json,.db" required class="form-file d-none" id="import-file-input" />
-            <button type="button" class="menu-btn" id="import-file-btn">Import Database</button>
+            <input type="file" name="import_file" accept=".json" required class="form-file d-none" id="import-file-input" />
+            <button type="button" class="menu-btn" id="import-file-btn">Import JSON Records</button>
           </form>
           <form method="POST" action="/fetch_cdx" class="menu-row" id="fetch-cdx-form">
             <input id="domain-input" type="hidden" name="domain" />

--- a/tests/test_db_workflow.py
+++ b/tests/test_db_workflow.py
@@ -101,7 +101,7 @@ def test_load_json_populates_db(tmp_path, monkeypatch):
             assert rows and rows[0]['timestamp'] == '20240101010101'
 
 
-def test_import_db_file(tmp_path, monkeypatch):
+def test_load_db_file(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     # create a sample database that will be uploaded
     with app.app.app_context():
@@ -110,7 +110,7 @@ def test_import_db_file(tmp_path, monkeypatch):
     sample_bytes = (tmp_path / sample_name).read_bytes()
 
     with app.app.test_client() as client:
-        resp = client.post('/import_file', data={'import_file': (io.BytesIO(sample_bytes), 'upload.db')})
+        resp = client.post('/load_db', data={'db_file': (io.BytesIO(sample_bytes), 'upload.db')})
         assert resp.status_code == 302
         with client.session_transaction() as sess:
             assert sess['db_display_name'] == 'upload.db'


### PR DESCRIPTION
## Summary
- filter open/import file pickers by extension and rename buttons
- restrict `/import_file` route to JSON imports only
- update API docs
- adjust tests for `/load_db` route

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850448a7c98833285f1b9fc6f61997a