### PR TITLE
Add navbar status bar for import progress

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -320,7 +320,7 @@
 /* Navbar layout */
 .retrorecon-root .navbar {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   margin: 0 10px;
 }
@@ -330,6 +330,10 @@
 }
 .retrorecon-root .navbar__title {
   text-align: center;
+}
+.retrorecon-root .navbar__status {
+  justify-self: end;
+  font-size: 0.9em;
 }
 .retrorecon-root .navbar__info {
   margin-left: 0;
@@ -973,6 +977,30 @@
   margin-left: 1em;
   color: var(--fg-color);
   font-weight: bold;
+}
+
+/* Import status bar */
+.retrorecon-root #import-status-block {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+.retrorecon-root #import-progress-bar-container {
+  width: 120px;
+  height: 8px;
+  background: var(--bg-color);
+  border: 1px solid #fff;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.retrorecon-root #import-progress-bar {
+  height: 100%;
+  width: 0;
+  background: var(--accent-color);
+}
+.retrorecon-root #import-progress-numbers {
+  margin-left: 0.4em;
+  font-size: 0.9em;
 }
 
 /* Footer text style */

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,13 +167,24 @@
       </div>
     </div>
   </div>
-    <div class="navbar__title">
+  <div class="navbar__title">
       <h1>
         <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.2.0</span></a>
         <span class="db-info glow cursor-pointer" id="db-display">loaded&gt; {{ db_name }}</span>
       </h1>
     </div>
-  <div class="navbar__spacer"></div>
+  <div class="navbar__status">
+      <div id="import-status-block" class="d-none">
+        <strong>Status:</strong>
+        <span id="import-status-text"></span>
+        <div id="import-progress-bar-container">
+          <div id="import-progress-bar"></div>
+        </div>
+        <div id="import-progress-numbers" class="mt-05">
+          <span id="import-progress-numbers-span"></span>
+        </div>
+      </div>
+  </div>
   </nav>
 
   <!-- Table B : Search bar and buttons -->
@@ -205,16 +216,6 @@
     <tr>
       <td>
         <div class="results-grid">
-          <div id="import-status-block" class="d-none">
-            <strong>Import status:</strong>
-            <span id="import-status-text"></span>
-            <div id="import-progress-bar-container">
-              <div id="import-progress-bar"></div>
-            </div>
-            <div id="import-progress-numbers" class="mt-05">
-              <span id="import-progress-numbers-span"></span>
-            </div>
-          </div>
 
           {% if urls %}
           <form method="POST" action="/bulk_action" id="bulk-form">


### PR DESCRIPTION
## Summary
- move import progress display into the navbar
- style navbar status bar and progress elements

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685048dfaa08833294b40b04d68b6774