### PR TITLE
Unify status UI with DB info style

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -984,6 +984,14 @@
   display: flex;
   align-items: center;
   gap: 0.4em;
+  font-size: 1em;
+  letter-spacing: 0.04em;
+  font-weight: bold;
+  color: var(--accent-color);
+  background: var(--bg-color);
+  margin-left: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 .retrorecon-root #import-progress-bar-container {
   width: 120px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -170,10 +170,10 @@
   <div class="navbar__title">
       <h1>
         <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.2.0</span></a>
-        <span class="db-info glow cursor-pointer" id="db-display">loaded&gt; {{ db_name }}</span>
       </h1>
-      <div id="import-status-block">
-        <strong>Status:</strong>
+      <div id="import-status-block" class="db-info">
+        <span class="glow cursor-pointer" id="db-display">loaded&gt; {{ db_name }}</span>
+        <span class="ml-01"><strong>Status:</strong></span>
         <span id="import-status-text">idle</span>
         <div id="import-progress-bar-container" class="d-none">
           <div id="import-progress-bar"></div>


### PR DESCRIPTION
## Summary
- merge `loaded>` display into the status menu
- restyle status menu using `db-info` look

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850534c3c408332b0c996c8c3fa5cf8