### PR TITLE
Add style frequency report

### DIFF
--- a/reports/style_frequency.html
+++ b/reports/style_frequency.html
@@ -1,0 +1,61 @@
+<html><head><meta charset='utf-8'>
+<title>Style Frequency Report</title>
+<style>table{border-collapse:collapse;margin-bottom:1em;}td,th{border:1px solid #ccc;padding:4px;}</style>
+</head><body>
+<h1>Style Frequency Report</h1>
+<h2>Colors</h2>
+<table><tr><th>Value</th><th>Count</th><th>Sample</th></tr>
+<tr><td>#ffffff</td><td>35</td><td><span style='color:#ffffff;'>Sample</span></td></tr>
+<tr><td>#000000</td><td>8</td><td><span style='color:#000000;'>Sample</span></td></tr>
+<tr><td>transparent</td><td>4</td><td><span style='color:transparent;'>Sample</span></td></tr>
+<tr><td>#2cbaf3</td><td>2</td><td><span style='color:#2cbaf3;'>Sample</span></td></tr>
+<tr><td>#cccccc</td><td>2</td><td><span style='color:#cccccc;'>Sample</span></td></tr>
+<tr><td>#888888</td><td>1</td><td><span style='color:#888888;'>Sample</span></td></tr>
+<tr><td>blue</td><td>1</td><td><span style='color:blue;'>Sample</span></td></tr>
+<tr><td>green</td><td>1</td><td><span style='color:green;'>Sample</span></td></tr>
+<tr><td>orange</td><td>1</td><td><span style='color:orange;'>Sample</span></td></tr>
+<tr><td>red</td><td>1</td><td><span style='color:red;'>Sample</span></td></tr>
+<tr><td>#fafafa</td><td>1</td><td><span style='color:#fafafa;'>Sample</span></td></tr>
+<tr><td>#333333</td><td>1</td><td><span style='color:#333333;'>Sample</span></td></tr>
+<tr><td>#f3f3f3</td><td>1</td><td><span style='color:#f3f3f3;'>Sample</span></td></tr>
+<tr><td>#e0e0e0</td><td>1</td><td><span style='color:#e0e0e0;'>Sample</span></td></tr>
+<tr><td>#787878</td><td>1</td><td><span style='color:#787878;'>Sample</span></td></tr>
+<tr><td>#222222</td><td>1</td><td><span style='color:#222222;'>Sample</span></td></tr>
+</table>
+<h2>Fonts</h2>
+<table><tr><th>Value</th><th>Count</th><th>Sample</th></tr>
+<tr><td>inherit</td><td>2</td><td><span style='font-family:inherit;'>Sample</span></td></tr>
+<tr><td>"Segoe UI", "Arial", sans-serif</td><td>1</td><td><span style='font-family:"Segoe UI", "Arial", sans-serif;'>Sample</span></td></tr>
+<tr><td>monospace</td><td>1</td><td><span style='font-family:monospace;'>Sample</span></td></tr>
+<tr><td>"Share Tech Mono", "Consolas", monospace</td><td>1</td><td><span style='font-family:"Share Tech Mono", "Consolas", monospace;'>Sample</span></td></tr>
+</table>
+<h2>Font Sizes</h2>
+<table><tr><th>Value</th><th>Count</th><th>Sample</th></tr>
+<tr><td>1em</td><td>12</td><td><span style='font-size:1em;'>Sample</span></td></tr>
+<tr><td>1.2em</td><td>6</td><td><span style='font-size:1.2em;'>Sample</span></td></tr>
+<tr><td>13.333px</td><td>6</td><td><span style='font-size:13.333px;'>Sample</span></td></tr>
+<tr><td>0.9em</td><td>4</td><td><span style='font-size:0.9em;'>Sample</span></td></tr>
+<tr><td>1.05em</td><td>3</td><td><span style='font-size:1.05em;'>Sample</span></td></tr>
+<tr><td>0.98em</td><td>3</td><td><span style='font-size:0.98em;'>Sample</span></td></tr>
+<tr><td>0.97em</td><td>3</td><td><span style='font-size:0.97em;'>Sample</span></td></tr>
+<tr><td>0.65em</td><td>3</td><td><span style='font-size:0.65em;'>Sample</span></td></tr>
+<tr><td>0.8em</td><td>3</td><td><span style='font-size:0.8em;'>Sample</span></td></tr>
+<tr><td>0.7em</td><td>2</td><td><span style='font-size:0.7em;'>Sample</span></td></tr>
+<tr><td>1.8em</td><td>2</td><td><span style='font-size:1.8em;'>Sample</span></td></tr>
+<tr><td>0.95em</td><td>2</td><td><span style='font-size:0.95em;'>Sample</span></td></tr>
+<tr><td>0.96em</td><td>1</td><td><span style='font-size:0.96em;'>Sample</span></td></tr>
+<tr><td>1.6em</td><td>1</td><td><span style='font-size:1.6em;'>Sample</span></td></tr>
+<tr><td>1.08em</td><td>1</td><td><span style='font-size:1.08em;'>Sample</span></td></tr>
+<tr><td>0.875em</td><td>1</td><td><span style='font-size:0.875em;'>Sample</span></td></tr>
+</table>
+<h2>Text Effects</h2>
+<table><tr><th>Value</th><th>Count</th><th>Sample</th></tr>
+<tr><td>font-weight:bold</td><td>14</td><td><span style='font-weight:bold'>Sample</span></td></tr>
+<tr><td>text-align:center</td><td>12</td><td><span style='text-align:center'>Sample</span></td></tr>
+<tr><td>text-align:left</td><td>6</td><td><span style='text-align:left'>Sample</span></td></tr>
+<tr><td>letter-spacing:0.04em</td><td>4</td><td><span style='letter-spacing:0.04em'>Sample</span></td></tr>
+<tr><td>text-decoration:none</td><td>3</td><td><span style='text-decoration:none'>Sample</span></td></tr>
+<tr><td>font-weight:600</td><td>3</td><td><span style='font-weight:600'>Sample</span></td></tr>
+<tr><td>text-align:right</td><td>1</td><td><span style='text-align:right'>Sample</span></td></tr>
+</table>
+</body></html>

--- a/scripts/style_frequency_report.py
+++ b/scripts/style_frequency_report.py
@@ -1,0 +1,127 @@
+import os
+import re
+from collections import defaultdict
+from typing import Dict, List
+
+import cssutils
+
+cssutils.log.setLevel('FATAL')
+
+COLOR_PROPS = {
+    'color', 'background', 'background-color', 'border', 'border-color',
+    'border-top-color', 'border-right-color', 'border-bottom-color',
+    'border-left-color', 'outline-color', 'text-decoration-color',
+    'fill', 'stroke', 'box-shadow', 'text-shadow'
+}
+FONT_PROPS = {'font-family'}
+SIZE_PROPS = {'font-size'}
+TEXT_EFFECT_PROPS = {
+    'font-style', 'font-weight', 'text-decoration', 'text-transform',
+    'text-shadow', 'letter-spacing', 'text-align'
+}
+
+HEX_RE = re.compile(r'#([0-9a-fA-F]{3,6})')
+RGB_RE = re.compile(r'rgba?\(([^)]+)\)')
+NAME_MAP = {
+    'black': '#000000',
+    'white': '#ffffff',
+}
+
+def normalize_color(token: str) -> str:
+    token = token.strip().lower()
+    if token in NAME_MAP:
+        return NAME_MAP[token]
+    m = HEX_RE.fullmatch(token)
+    if m:
+        hexval = m.group(1)
+        if len(hexval) == 3:
+            hexval = ''.join(c*2 for c in hexval)
+        return f'#{hexval.lower()}'
+    m = RGB_RE.fullmatch(token)
+    if m:
+        parts = [p.strip() for p in m.group(1).split(',')]
+        if len(parts) >= 3:
+            try:
+                r = int(round(float(parts[0])))
+                g = int(round(float(parts[1])))
+                b = int(round(float(parts[2])))
+                return f'#{r:02x}{g:02x}{b:02x}'
+            except ValueError:
+                pass
+    return token
+
+def collect_css_files() -> List[str]:
+    files: List[str] = []
+    for root, _, fs in os.walk('static'):
+        for f in fs:
+            if f.endswith('.css'):
+                files.append(os.path.join(root, f))
+    return files
+
+def analyze() -> Dict[str, Dict[str, int]]:
+    colors: Dict[str, int] = defaultdict(int)
+    fonts: Dict[str, int] = defaultdict(int)
+    sizes: Dict[str, int] = defaultdict(int)
+    effects: Dict[str, int] = defaultdict(int)
+
+    token_re = re.compile(
+        r'#(?:[0-9a-fA-F]{3,8})'
+        r'|rgba?\([^)]*\)'
+        r'|hsla?\([^)]*\)'
+        r'|\b(?:transparent|currentcolor|black|white|red|green|blue|orange|purple|yellow|grey|gray|cyan|magenta)\b',
+        re.I,
+    )
+
+    for path in collect_css_files():
+        sheet = cssutils.parseFile(path)
+        for rule in sheet:
+            if rule.type != rule.STYLE_RULE:
+                continue
+            for prop in rule.style:
+                name = prop.name
+                value = prop.value
+                if name in COLOR_PROPS:
+                    for tok in token_re.findall(value):
+                        norm = normalize_color(tok)
+                        colors[norm] += 1
+                elif name in FONT_PROPS:
+                    fonts[value.strip()] += 1
+                elif name in SIZE_PROPS:
+                    sizes[value.strip()] += 1
+                elif name in TEXT_EFFECT_PROPS:
+                    effects[f'{name}:{value.strip()}'] += 1
+    return {
+        'colors': colors,
+        'fonts': fonts,
+        'sizes': sizes,
+        'effects': effects,
+    }
+
+
+def render_table(title: str, data: Dict[str, int], sample_style: str) -> str:
+    rows = [f"<h2>{title}</h2>", "<table><tr><th>Value</th><th>Count</th><th>Sample</th></tr>"]
+    for val, count in sorted(data.items(), key=lambda x: x[1], reverse=True):
+        style = sample_style.format(val)
+        rows.append(f"<tr><td>{val}</td><td>{count}</td><td><span style='{style}'>Sample</span></td></tr>")
+    rows.append("</table>")
+    return '\n'.join(rows)
+
+
+def main() -> None:
+    stats = analyze()
+    html = ["<html><head><meta charset='utf-8'>",
+            "<title>Style Frequency Report</title>",
+            "<style>table{border-collapse:collapse;margin-bottom:1em;}td,th{border:1px solid #ccc;padding:4px;}</style>",
+            "</head><body>",
+            "<h1>Style Frequency Report</h1>"]
+    html.append(render_table('Colors', stats['colors'], 'color:{0};'))
+    html.append(render_table('Fonts', stats['fonts'], 'font-family:{0};'))
+    html.append(render_table('Font Sizes', stats['sizes'], 'font-size:{0};'))
+    html.append(render_table('Text Effects', stats['effects'], '{0}'))
+    html.append("</body></html>")
+    os.makedirs('reports', exist_ok=True)
+    with open('reports/style_frequency.html', 'w', encoding='utf-8') as fh:
+        fh.write('\n'.join(html))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `style_frequency_report.py` to analyze CSS usage
- generate `style_frequency.html` with color, font, size and text effect counts

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685059387e30833289eb8ba2c95a1890