### PR TITLE
Standardize CSS colors and fonts

### DIFF
--- a/docs/theme_style_guide.md
+++ b/docs/theme_style_guide.md
@@ -8,10 +8,15 @@ Retrorecon's CSS is built around a small set of variables. The base file `static
 
 ```css
 :root {
-  --bg-color: #0d011e00;
-  --bg-rgb: 13 1 30;
-  --fg-color: #ffffff;
-  --accent-color: #1ea1ff;
+  --color-base: #000000;
+  --color-contrast: #ffffff;
+  --color-accent: #8be9fd;
+  --font-main: 'Share Tech Mono', 'Consolas', monospace;
+
+  --bg-color: var(--color-base);
+  --bg-rgb: 0 0 0;
+  --fg-color: var(--color-contrast);
+  --accent-color: var(--color-accent);
   --panel-opacity: 0.25;
 }
 ```
@@ -32,17 +37,17 @@ The `neon` theme (`static/themes/theme-neon.css`) overrides these variables and 
 
 ```css
 :root {
-  --bg-main: #0d011e00;
+  --bg-main: #00000000;
   --bg-panel: rgb(0 0 0 / 0%);
-  --font-main: #e1e9ff;
+  --font-main: #ffffff;
   --font-accent: #8be9fd;
   --border-color: rgba(139, 233, 253, 0.4);
   --input-bg: rgb(34 39 50 / 0%);
   --input-border: #8be9fd;
 
   /* compatibility with base styles */
-  --bg-color: #1412224f;
-  --bg-rgb: 20 18 34;
+  --bg-color: rgba(0, 0, 0, 0.31);
+  --bg-rgb: 0 0 0;
   --panel-opacity: 0.92;
   --fg-color: var(--font-main);
   --accent-color: var(--font-accent);

--- a/static/base.css
+++ b/static/base.css
@@ -1,8 +1,14 @@
 :root {
-  --bg-color: #0d011e00;
-  --bg-rgb: 13 1 30;
-  --fg-color: #ffffff;
-  --accent-color: #1ea1ff;
+  --color-base: #000000;
+  --color-contrast: #ffffff;
+  --color-accent: #8be9fd;
+  --font-main: 'Share Tech Mono', 'Consolas', monospace;
+
+  /* Backwards compatible variables */
+  --bg-color: var(--color-base);
+  --bg-rgb: 0 0 0;
+  --fg-color: var(--color-contrast);
+  --accent-color: var(--color-accent);
   --panel-opacity: 0.25;
 }
 
@@ -37,7 +43,10 @@
 .retrorecon-root .text-left { text-align: left; }
 .retrorecon-root .text-center { text-align: center; }
 .retrorecon-root .text-right { text-align: right; }
-.retrorecon-root .text-muted { color: #888; }
+.retrorecon-root .text-muted {
+  color: var(--color-contrast);
+  opacity: 0.7;
+}
 .retrorecon-root .no-underline { text-decoration: none; }
 .retrorecon-root .d-inline { display: inline; }
 .retrorecon-root .d-inline-block { display: inline-block; }
@@ -60,7 +69,7 @@
 
 /* Generic form styles */
 .retrorecon-root .btn {
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
   padding: 2px 10px;
@@ -75,7 +84,7 @@
 .retrorecon-root .form-input,
 .retrorecon-root .form-file,
 .retrorecon-root .form-select {
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -94,7 +103,7 @@
 
 /* Ensure file inputs inherit base form styling */
 .retrorecon-root input[type="file"] {
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -112,7 +121,7 @@
 /* Glowing style for all buttons */
 .retrorecon-root button {
   background: var(--fg-color);
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   color: var(--fg-color);
   border-radius: 7px;
   padding: 2px 11px;
@@ -132,7 +141,7 @@
 .retrorecon-root input[type="text"],
 .retrorecon-root input[type="file"],
 .retrorecon-root select {
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -156,7 +165,8 @@
 .retrorecon-root {
   background: var(--bg-color) url("/static/img/background.jpg") no-repeat center center fixed;
   background-size: cover;
-  font-family: "Segoe UI", "Arial", sans-serif; /* Use system UI fonts for modern look */
+  font-family: var(--font-main);
+  font-size: 1em;
   margin: 0;
   min-height: 100vh;
   padding: 0 0 4em 0;
@@ -246,7 +256,7 @@
   font-size: 1.2em;
   padding: 6px 10px;
   border-radius: 5px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
   flex: 2;
@@ -264,7 +274,7 @@
   font-size: 1.05em;
   padding: 5px 10px;
   border-radius: 5px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
   cursor: pointer;
@@ -308,7 +318,7 @@
   margin: 0;
 }
 .retrorecon-root .db-buttons button{
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
   padding: 2px 10px;
@@ -353,7 +363,7 @@
   font-size: 1em;
   cursor: pointer;
   transition: opacity 0.2s;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 0;
 }
 .retrorecon-root .dropbtn:hover,
@@ -364,15 +374,15 @@
 .retrorecon-root .dropdown-content {
   display: none;
   position: absolute;
-  background-color: #000000fc;
+  background-color: rgba(var(--bg-rgb) / 0.99);
   min-width: 260px;
-  box-shadow: 0 8px 20px #00000033;
+  box-shadow: 0 8px 20px rgba(var(--bg-rgb) / 0.2);
   z-index: 1;
   padding: 8px 12px;
   border-radius: 0;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   margin-top: 6px;
-  color: #fff;
+  color: var(--color-contrast);
 }
 /* Square styling for all navbar controls */
 .retrorecon-root .navbar input,
@@ -429,7 +439,7 @@
 .retrorecon-root .menu-row a.menu-btn {
   background: transparent;
   border: none;
-  color: #fff;
+  color: var(--color-contrast);
   padding: 0.2em 0.4em;
   text-align: left;
   width: 100%;
@@ -441,7 +451,7 @@
 .retrorecon-root .dropdown-content a.menu-btn {
   background: transparent;
   border: none;
-  color: #fff;
+  color: var(--color-contrast);
   padding: 0.2em 0.4em;
   text-align: left;
   width: 100%;
@@ -461,13 +471,13 @@
 
 /* Consistent styling for select dropdowns used as menu buttons */
 .retrorecon-root select.menu-btn {
-  background: #000;
+  background: var(--bg-color);
   color: var(--fg-color);
   border: 1px solid var(--accent-color);
   padding: 0.2em 0.4em;
 }
 .retrorecon-root select.menu-btn option {
-  background: #000;
+  background: var(--bg-color);
   color: var(--fg-color);
 }
 
@@ -486,7 +496,7 @@
 .retrorecon-root .import-row input[type="text"], .retrorecon-root .import-row input[type="file"]{
   width: 100%;
   max-width: 250px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -494,7 +504,7 @@
 }
 
 .retrorecon-root .import-row button {
-    border: 1px solid #fff;
+    border: 1px solid var(--color-contrast);
     background: var(--bg-color);
     color: var(--fg-color);
     padding: 2px 10px;
@@ -508,7 +518,7 @@
 .retrorecon-root #map-url-input {
   width: 250px;
   max-width: 100%;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -520,7 +530,7 @@
 }
 
 .retrorecon-root .theme-row button {
-    border: 1px solid #fff;
+    border: 1px solid var(--color-contrast);
     background: var(--bg-color);
     color: var(--fg-color);
     padding: 2px 10px;
@@ -532,7 +542,7 @@
 .retrorecon-root #mapUrlInput {
   flex: 1;
   font-size: 1em;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -557,8 +567,8 @@
 
 /* Styling for the "no results" message */
 .retrorecon-root .results-grid__no-results {
-  background: #000;
-  color: #fff;
+  background: var(--bg-color);
+  color: var(--color-contrast);
   font-weight: bold;
   text-shadow: 0 0 6px var(--accent-color);
   padding: 1em;
@@ -620,7 +630,7 @@
   font-size: 0.98em;
   padding: 2px 8px;
   border-radius: 5px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
 }
@@ -629,7 +639,7 @@
   font-size: 0.98em;
   padding: 2px 8px;
   border-radius: 5px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
 }
@@ -658,15 +668,15 @@
 .retrorecon-root .url-table {
   width: 100%;
   border-collapse: collapse;
-  background: #1412225c;
+  background: rgb(var(--bg-rgb)/0.36);
   margin-bottom: 0.7em;
   box-shadow: 0 1px 8px var(--fg-color);
 }
 
 /* Table header style this seems wrong to me JB*/
 .retrorecon-root .url-table thead {
-  background: #000;
-  color: #fff;
+  background: var(--bg-color);
+  color: var(--color-contrast);
   opacity: 1;
 }
 .retrorecon-root .url-table th {
@@ -776,7 +786,7 @@
 .retrorecon-root .url-tools-row input[type="text"] {
   font-size: 0.9em;
   padding: 2px 6px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -788,7 +798,7 @@
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
@@ -814,7 +824,7 @@
   background: var(--bg-color);
   opacity: 1;
   border-radius: 999px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   margin-right: 4px;
   font-size: 0.65em;
   font-weight: 600;
@@ -841,9 +851,9 @@
 .retrorecon-root .google-btn,
 .retrorecon-root .crtsh-btn {
   background: var(--bg-color);
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 7px;
-  color: #2cbaf3;
+  color: var(--color-accent);
   font-size: 1em;
   line-height: 1.15em;
   padding: 2px 11px;
@@ -888,7 +898,7 @@
     margin: 1em;
     border-radius: 4px;
     transition: background 0.2s;
-    /* border: 1px solid #fff; */
+    /* border: 1px solid var(--color-contrast); */
     color: var(--fg-color);
     background: var(--bg-color);
     display: flex;
@@ -922,7 +932,7 @@
   font-size: 0.9em;
   padding: 1px 4px;
   text-align: center;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 5px;
   background: var(--bg-color);
   color: var(--fg-color);
@@ -997,7 +1007,7 @@
   width: 120px;
   height: 8px;
   background: var(--bg-color);
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -1032,23 +1042,25 @@
 }
 
 /* Status code colors */
-.retrorecon-root .status-2 { color: blue; }
-.retrorecon-root .status-3 { color: green; }
-.retrorecon-root .status-4 { color: orange; }
-.retrorecon-root .status-5 { color: red; }
+.retrorecon-root .status-2,
+.retrorecon-root .status-3,
+.retrorecon-root .status-4,
+.retrorecon-root .status-5 {
+  color: var(--color-accent);
+}
 
 /* Solid background for layout tables */
 .retrorecon-root #layout-a td,
 .retrorecon-root #layout-c td,
 .retrorecon-root #layout-d td {
-  background: #14122200;
+  background: transparent;
   color: inherit;
 }
 
 /* --- End of update --- */
 body.bg-hidden {
   background-image: none !important;
-  background-color: #000 !important;
+  background-color: var(--color-base) !important;
 }
 
 .retrorecon-root .notes-overlay {

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -1,16 +1,16 @@
 /* Neon midnight dark theme */
 :root {
-  --bg-main: #0d011e00;
+  --bg-main: #00000000;
   --bg-panel: rgb(0 0 0 / 0%);
-  --font-main: #e1e9ff;
+  --font-main: #ffffff;
   --font-accent: #8be9fd;
   --border-color: rgba(139, 233, 253, 0.4);
   --input-bg: rgb(34 39 50 / 0%);
   --input-border: #8be9fd;
 
   /* compatibility with base styles */
-  --bg-color: #1412224f;
-  --bg-rgb: 20 18 34;
+  --bg-color: rgba(0, 0, 0, 0.31);
+  --bg-rgb: 0 0 0;
   --panel-opacity: 0.92;
   --fg-color: var(--font-main);
   --accent-color: var(--font-accent);
@@ -24,7 +24,7 @@
 
 body.bg-hidden {
   background-image: none !important;
-  background-color: #000 !important;
+  background-color: var(--color-base) !important;
 }
 
 .retrorecon-root .panel,
@@ -39,7 +39,7 @@ body.bg-hidden {
 
 .retrorecon-root .url-table th,
 .retrorecon-root .url-table td {
-  background: #14122200;
+  background: transparent;
   color: var(--font-main);
   border-bottom: 1px solid var(--border-color);
   font-size: 13.333px;
@@ -67,7 +67,7 @@ body.bg-hidden {
 
 .retrorecon-root input:focus,
 .retrorecon-root button:focus {
-  border-color: #fff;
+  border-color: var(--color-contrast);
 }
 
 .retrorecon-root a,
@@ -82,7 +82,7 @@ body.bg-hidden {
 .retrorecon-root h3,
 .retrorecon-root .glow {
   color: var(--font-accent);
-  text-shadow: 0 0 12px var(--font-accent), 0 0 24px #222;
+  text-shadow: 0 0 12px var(--font-accent), 0 0 24px var(--color-base);
 }
 
 /*--- Overrides migrated from base.css to give the theme priority ---*/
@@ -145,7 +145,7 @@ body.bg-hidden {
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   margin-right: 4px;
   font-size: 0.95em;
   margin-bottom: 4px;
@@ -177,7 +177,7 @@ body.bg-hidden {
   background: var(--bg-color);
   opacity: 1;
   border-radius: 999px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   margin-right: 4px;
   font-size: 0.65em;
   font-weight: 600;
@@ -212,7 +212,7 @@ body.bg-hidden {
   background: var(--bg-color);
   opacity: 1;
   border-radius: 999px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   margin-right: 4px;
   font-size: 0.65em;
   font-weight: 600;
@@ -235,7 +235,7 @@ body.bg-hidden {
   font-size: 1.05em;
   padding: 5px 10px;
   border-radius: 5px;
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
   cursor: pointer;
@@ -260,7 +260,7 @@ body.bg-hidden {
 .retrorecon-root .url-table {
   width: 100%;
   border-collapse: collapse;
-  background: #1412225c;
+  background: rgba(0, 0, 0, 0.36);
   margin-bottom: 0.7em;
   box-shadow: 0 1px 8px var(--fg-color);
 }
@@ -275,9 +275,9 @@ body.bg-hidden {
 .retrorecon-root .google-btn,
 .retrorecon-root .crtsh-btn {
   background: var(--bg-color);
-  border: 1px solid #fff;
+  border: 1px solid var(--color-contrast);
   border-radius: 7px;
-  color: #2cbaf3;
+  color: var(--color-accent);
   font-size: 1em;
   line-height: 1.15em;
   padding: 2px 11px;
@@ -336,7 +336,7 @@ body.bg-hidden {
 
 /* Standardize dropdown menu styling */
 .retrorecon-root .dropdown-content {
-  background-color: #000;
+  background-color: var(--color-base);
   color: var(--font-main);
   border: 1px solid var(--font-accent);
 }
@@ -347,5 +347,5 @@ body.bg-hidden {
 .retrorecon-root .dropdown-content .menu-btn:hover,
 .retrorecon-root .dropdown-content a.menu-btn:hover {
   background: var(--font-accent);
-  color: #000;
+  color: var(--color-base);
 }

--- a/static/tools.css
+++ b/static/tools.css
@@ -1,8 +1,8 @@
 /* File: static/tools.css */
 .retrorecon-root .webpack-exploder-panel {
   padding: 1em;
-  background: #fafafa;
-  border: 1px solid #ccc;
+  background: var(--bg-color);
+  border: 1px solid var(--color-contrast);
   margin: 1em 0;
   border-radius: 6px;
 }
@@ -10,7 +10,7 @@
 .retrorecon-root .webpack-exploder-panel h2 {
   margin-top: 0;
   font-size: 1.2em;
-  color: #333;
+  color: var(--color-contrast);
 }
 
 .retrorecon-root .webpack-exploder-panel form {
@@ -25,26 +25,26 @@
   width: 250px;
   padding: 0.5em;
   font-size: 1em;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-contrast);
   border-radius: 4px;
 }
 
 .retrorecon-root .webpack-exploder-panel button {
   padding: 0.5em 1em;
   font-size: 1em;
-  background-color: #f3f3f3;
-  border: 1px solid #fff;
+  background-color: var(--bg-color);
+  border: 1px solid var(--color-contrast);
   border-radius: 4px;
   cursor: pointer;
 }
 .retrorecon-root .webpack-exploder-panel button:hover {
-  background-color: #e0e0e0;
+  background-color: var(--bg-color);
 }
 
 .retrorecon-root #exploder-results {
   margin-top: 1em;
   white-space: pre-wrap;
-  font-family: monospace;
+  font-family: var(--font-main);
   max-height: 400px;
   overflow-y: auto;
 }
@@ -78,13 +78,13 @@
   white-space: nowrap;
   overflow-x: auto;
   scrollbar-width: thin;
-  scrollbar-color: rgba(120,120,120,0.5) transparent;
+  scrollbar-color: rgba(255,255,255,0.5) transparent;
 }
 .retrorecon-root #jwt-cookie-jar .cell-content::-webkit-scrollbar {
   height: 6px;
 }
 .retrorecon-root #jwt-cookie-jar .cell-content::-webkit-scrollbar-thumb {
-  background-color: rgba(120,120,120,0.5);
+  background-color: rgba(255,255,255,0.5);
   border-radius: 3px;
 }
 .retrorecon-root #jwt-cookie-jar .cell-content::-webkit-scrollbar-track {


### PR DESCRIPTION
## Summary
- migrate to black/white/accent color palette
- use Share Tech Mono font everywhere
- update theme style guide to be source of truth

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68505f86720c8332af634470f35f4711