### PR TITLE
Add Subdomonster subdomain tool

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,6 +198,8 @@ def index() -> str:
         tool = 'jwt'
     elif request.path == '/tools/screenshotter':
         tool = 'screenshot'
+    elif request.path == '/tools/subdomonster':
+        tool = 'subdomonster'
 
     sort = request.args.get('sort', 'id')
     direction = request.args.get('dir', 'desc').lower()
@@ -615,11 +617,12 @@ def bulk_action() -> Response:
 
 
 
-from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp
+from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, domains_bp
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
 app.register_blueprint(db_bp)
 app.register_blueprint(settings_bp)
+app.register_blueprint(domains_bp)
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -52,3 +52,12 @@ CREATE TABLE IF NOT EXISTS screenshots (
     thumbnail_path TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS domains (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    root_domain TEXT NOT NULL,
+    subdomain TEXT NOT NULL,
+    source TEXT NOT NULL,
+    fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(subdomain, source)
+);

--- a/reports/report.json
+++ b/reports/report.json
@@ -1,12 +1,12 @@
 {
   "coverage": {
     "button": {
-      "total": 47,
-      "styled": 47
+      "total": 49,
+      "styled": 49
     },
     "input": {
-      "total": 14,
-      "styled": 9
+      "total": 15,
+      "styled": 10
     },
     "select": {
       "total": 5,

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -2,5 +2,6 @@ from .notes import bp as notes_bp
 from .tools import bp as tools_bp
 from .db import bp as db_bp
 from .settings import bp as settings_bp
+from .domains import bp as domains_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp']

--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -1,0 +1,33 @@
+import re
+from flask import Blueprint, request, jsonify, render_template
+import app
+from retrorecon import subdomain_utils
+
+bp = Blueprint('domains', __name__)
+
+
+@bp.route('/subdomonster', methods=['GET'])
+def subdomonster_page():
+    return render_template('subdomonster.html')
+
+
+@bp.route('/tools/subdomonster', methods=['GET'])
+def subdomonster_full_page():
+    return app.index()
+
+
+@bp.route('/subdomains', methods=['POST'])
+def subdomains_route():
+    if not app._db_loaded():
+        return jsonify({'error': 'no_db'}), 400
+    domain = request.form.get('domain', '').strip().lower()
+    if not domain:
+        return ('Missing domain', 400)
+    if not re.match(r'^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
+        return ('Invalid domain', 400)
+    try:
+        subs = subdomain_utils.fetch_from_crtsh(domain)
+    except Exception as e:  # pragma: no cover - network errors
+        return (f'Error fetching: {e}', 500)
+    subdomain_utils.insert_records(domain, subs, 'crtsh')
+    return jsonify(subdomain_utils.list_subdomains(domain))

--- a/retrorecon/subdomain_utils.py
+++ b/retrorecon/subdomain_utils.py
@@ -1,0 +1,51 @@
+import logging
+import requests
+from typing import List, Dict
+
+from database import execute_db, query_db
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_from_crtsh(domain: str) -> List[str]:
+    """Return subdomains for *domain* fetched from crt.sh."""
+    url = f"https://crt.sh/json?identity={domain}"
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    subs = set()
+    for entry in data:
+        names = entry.get("name_value", "")
+        for name in str(names).split("\n"):
+            name = name.strip().lower()
+            if not name or "*" in name:
+                continue
+            subs.add(name)
+    return sorted(subs)
+
+
+def insert_records(root_domain: str, subs: List[str], source: str = "crtsh") -> int:
+    """Insert ``subs`` for ``root_domain`` and return count inserted."""
+    count = 0
+    for sub in subs:
+        try:
+            execute_db(
+                "INSERT OR IGNORE INTO domains (root_domain, subdomain, source) VALUES (?, ?, ?)",
+                [root_domain, sub, source],
+            )
+            count += 1
+        except Exception as exc:  # pragma: no cover - log only
+            logger.debug("insert failed: %s", exc)
+    return count
+
+
+def list_subdomains(root_domain: str) -> List[Dict[str, str]]:
+    """Return all subdomains for ``root_domain``."""
+    rows = query_db(
+        "SELECT subdomain, source, fetched_at FROM domains WHERE root_domain = ? ORDER BY subdomain",
+        [root_domain],
+    )
+    return [
+        {"subdomain": r["subdomain"], "source": r["source"], "fetched_at": r["fetched_at"]}
+        for r in rows
+    ]

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -1,0 +1,45 @@
+/* File: static/subdomonster.js */
+function initSubdomonster(){
+  const overlay = document.getElementById('subdomonster-overlay');
+  if(!overlay) return;
+  const domainInput = document.getElementById('subdomonster-domain');
+  const fetchBtn = document.getElementById('subdomonster-fetch-btn');
+  const tableDiv = document.getElementById('subdomonster-table');
+  const closeBtn = document.getElementById('subdomonster-close-btn');
+
+  function render(rows){
+    let html = '<table class="table url-table w-100"><thead><tr>'+
+      '<th>Subdomain</th><th>Source</th><th>Fetched</th>'+
+      '</tr></thead><tbody>';
+    for(const r of rows){
+      html += `<tr><td>${r.subdomain}</td><td>${r.source}</td><td>${r.fetched_at}</td></tr>`;
+    }
+    html += '</tbody></table>';
+    tableDiv.innerHTML = html;
+  }
+
+  fetchBtn.addEventListener('click', async () => {
+    const domain = domainInput.value.trim();
+    if(!domain) return;
+    const resp = await fetch('/subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({domain})});
+    if(resp.ok){
+      const data = await resp.json();
+      render(data);
+    } else {
+      alert(await resp.text());
+    }
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/subdomonster'){
+      history.pushState({}, '', '/');
+    }
+  });
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initSubdomonster);
+}else{
+  initSubdomonster();
+}

--- a/static/tools.css
+++ b/static/tools.css
@@ -96,3 +96,9 @@
   width: 80px;
   height: auto;
 }
+
+/* Subdomonster overlay */
+.retrorecon-root #subdomonster-table table {
+  table-layout: fixed;
+  font-size: 0.875em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -164,6 +164,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="text-tools-link">Text Tools</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="jwt-tools-link">JWT Tools</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">ScreenShotter</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
       </div>
     </div>
   </div>
@@ -853,6 +854,50 @@
           e.preventDefault();
           showScreenshot();
         });
+      }
+
+      const subLink = document.getElementById('subdomonster-link');
+      let subLoaded = false;
+
+      async function showSubdomonster(skipPush){
+        if(!subLoaded){
+          const resp = await fetch('/subdomonster');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/subdomonster.js';
+          document.body.appendChild(script);
+          subLoaded = true;
+        }
+        document.getElementById('subdomonster-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'subdomonster'}, '', '/tools/subdomonster');
+        }
+      }
+
+      function hideSubdomonster(){
+        const ov = document.getElementById('subdomonster-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
+      if(subLink){
+        subLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showSubdomonster();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/subdomonster'){
+          showSubdomonster(true);
+        } else {
+          hideSubdomonster();
+        }
+      });
+
+      if(location.pathname === '/tools/subdomonster' || openTool === 'subdomonster'){
+        showSubdomonster(true);
       }
 
       window.addEventListener('popstate', () => {

--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -1,0 +1,9 @@
+<!-- File: templates/subdomonster.html -->
+<div id="subdomonster-overlay" class="notes-overlay hidden">
+  <div class="mb-05">
+    <input type="text" id="subdomonster-domain" class="form-input mr-05" placeholder="example.com" />
+    <button type="button" class="btn" id="subdomonster-fetch-btn">Fetch</button>
+    <button type="button" class="btn" id="subdomonster-close-btn">Close</button>
+  </div>
+  <div id="subdomonster-table" class="mt-05"></div>
+</div>

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+
+def test_subdomonster_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/subdomonster')
+        assert resp.status_code == 200
+        assert b'id="subdomonster-overlay"' in resp.data
+
+
+def test_subdomain_insert(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db('subs')
+    sample = [
+        {"name_value": "a.example.com\n*.wild.example.com"},
+        {"name_value": "b.example.com"}
+    ]
+    monkeypatch.setattr(app.requests, 'get', lambda *a, **k: FakeResp(sample))
+    with app.app.test_client() as client:
+        resp = client.post('/subdomains', data={'domain': 'example.com'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        subs = [r['subdomain'] for r in data]
+        assert 'a.example.com' in subs and 'b.example.com' in subs
+        assert all('*' not in s for s in subs)
+
+
+def test_subdomain_invalid_domain(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    called = False
+    def fake_get(*a, **k):
+        nonlocal called
+        called = True
+        return FakeResp([])
+    monkeypatch.setattr(app.requests, 'get', fake_get)
+    with app.app.test_client() as client:
+        resp = client.post('/subdomains', data={'domain': 'http://bad'})
+        assert resp.status_code == 400
+    assert not called


### PR DESCRIPTION
## Summary
- add `domains` table to schema
- implement `subdomain_utils` to query crt.sh
- create `domains` blueprint with `/subdomonster` UI and `/subdomains` API
- add JS/CSS/HTML for Subdomonster overlay
- integrate Subdomonster into navigation and page logic
- include tests for new functionality

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_685069e58ec08332901e8259bd66d9e4