### PR TITLE
Improve crt.sh subdomain parsing

### DIFF
--- a/retrorecon/subdomain_utils.py
+++ b/retrorecon/subdomain_utils.py
@@ -15,12 +15,13 @@ def fetch_from_crtsh(domain: str) -> List[str]:
     data = resp.json()
     subs = set()
     for entry in data:
-        names = entry.get("name_value", "")
-        for name in str(names).split("\n"):
-            name = name.strip().lower()
-            if not name or "*" in name:
-                continue
-            subs.add(name)
+        values = [entry.get("common_name", ""), entry.get("name_value", "")]
+        for field in values:
+            for name in str(field).replace("\\n", "\n").splitlines():
+                name = name.strip().lower()
+                if not name or "*" in name:
+                    continue
+                subs.add(name)
     return sorted(subs)
 
 

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -37,8 +37,14 @@ def test_subdomain_insert(tmp_path, monkeypatch):
     with app.app.app_context():
         app.create_new_db('subs')
     sample = [
-        {"name_value": "a.example.com\n*.wild.example.com"},
-        {"name_value": "b.example.com"}
+        {
+            "common_name": "*.skip.example.com",
+            "name_value": "a.example.com\\nb.example.com",
+        },
+        {
+            "common_name": "c.example.com",
+            "name_value": "c.example.com\\nd.example.com",
+        },
     ]
     monkeypatch.setattr(app.requests, 'get', lambda *a, **k: FakeResp(sample))
     with app.app.test_client() as client:
@@ -46,7 +52,12 @@ def test_subdomain_insert(tmp_path, monkeypatch):
         assert resp.status_code == 200
         data = resp.get_json()
         subs = [r['subdomain'] for r in data]
-        assert 'a.example.com' in subs and 'b.example.com' in subs
+        assert set(subs) == {
+            'a.example.com',
+            'b.example.com',
+            'c.example.com',
+            'd.example.com',
+        }
         assert all('*' not in s for s in subs)
 
 


### PR DESCRIPTION
## Summary
- extract `common_name` and `name_value` when querying crt.sh
- normalize `\n` escape sequences for crt.sh results
- update subdomonster tests for the expanded parsing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68507278fc5083329949b6910621ac2b