### PR TITLE
Add unsaved temp database on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,6 +99,23 @@ SAVED_TAGS_FILE = os.path.join(app.root_path, 'saved_tags.json')
 # Clear any stale import progress from previous runs
 progress_mod.clear_progress(IMPORT_PROGRESS_FILE)
 
+# Temporary database handling
+TEMP_DB_NAME = 'temp.db'
+TEMP_DISPLAY_NAME = 'UNSAVED'
+
+
+def _create_temp_db() -> None:
+    """Create a fresh temporary database for this session."""
+    app.config['DATABASE'] = os.path.join(app.root_path, TEMP_DB_NAME)
+    if os.path.exists(app.config['DATABASE']):
+        os.remove(app.config['DATABASE'])
+    init_db()
+
+
+if not env_db:
+    with app.app_context():
+        _create_temp_db()
+
 def _db_loaded() -> bool:
     """Return True if a database file is currently configured and exists."""
 
@@ -271,6 +288,8 @@ def index() -> str:
 
     if _db_loaded():
         actual_name = os.path.basename(app.config['DATABASE'])
+        if actual_name == TEMP_DB_NAME:
+            actual_name = TEMP_DISPLAY_NAME
     else:
         actual_name = '(none)'
     if session.get('db_display_name') != actual_name:

--- a/retrorecon/routes/db.py
+++ b/retrorecon/routes/db.py
@@ -12,6 +12,9 @@ def new_db():
         flash('Invalid database name.', 'error')
         return redirect(url_for('index'))
     app.close_connection(None)
+    temp_path = os.path.join(app.app.root_path, app.TEMP_DB_NAME)
+    if app.app.config.get('DATABASE') == temp_path and os.path.exists(temp_path):
+        os.remove(temp_path)
     try:
         db_name = app.create_new_db(safe)
         session['db_display_name'] = db_name
@@ -33,6 +36,9 @@ def load_db_route():
         return redirect(url_for('index'))
     db_path = os.path.join(app.app.root_path, filename)
     app.close_connection(None)
+    temp_path = os.path.join(app.app.root_path, app.TEMP_DB_NAME)
+    if app.app.config.get('DATABASE') == temp_path and os.path.exists(temp_path):
+        os.remove(temp_path)
     try:
         file.save(db_path)
         app.app.config['DATABASE'] = db_path


### PR DESCRIPTION
## Summary
- create a temporary database when the app starts
- show `UNSAVED` while using the temp DB
- remove the temp DB when creating or loading a database

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685074699d2c8332bc5d614c65223cf6