### PR TITLE
Refactor Subdomonster crt.sh output

### DIFF
--- a/retrorecon/subdomain_utils.py
+++ b/retrorecon/subdomain_utils.py
@@ -43,10 +43,10 @@ def insert_records(root_domain: str, subs: List[str], source: str = "crtsh") -> 
 def list_subdomains(root_domain: str) -> List[Dict[str, str]]:
     """Return all subdomains for ``root_domain``."""
     rows = query_db(
-        "SELECT subdomain, source, fetched_at FROM domains WHERE root_domain = ? ORDER BY subdomain",
+        "SELECT subdomain, root_domain as domain, source FROM domains WHERE root_domain = ? ORDER BY subdomain",
         [root_domain],
     )
     return [
-        {"subdomain": r["subdomain"], "source": r["source"], "fetched_at": r["fetched_at"]}
+        {"subdomain": r["subdomain"], "domain": r["domain"], "source": r["source"]}
         for r in rows
     ]

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -9,10 +9,10 @@ function initSubdomonster(){
 
   function render(rows){
     let html = '<table class="table url-table w-100"><thead><tr>'+
-      '<th>Subdomain</th><th>Source</th><th>Fetched</th>'+
+      '<th>Subdomain</th><th>Domain</th><th>Source</th>'+
       '</tr></thead><tbody>';
     for(const r of rows){
-      html += `<tr><td>${r.subdomain}</td><td>${r.source}</td><td>${r.fetched_at}</td></tr>`;
+      html += `<tr><td>${r.subdomain}</td><td>${r.domain}</td><td>${r.source}</td></tr>`;
     }
     html += '</tbody></table>';
     tableDiv.innerHTML = html;

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -58,6 +58,7 @@ def test_subdomain_insert(tmp_path, monkeypatch):
             'c.example.com',
             'd.example.com',
         }
+        assert all(r['domain'] == 'example.com' for r in data)
         assert all('*' not in s for s in subs)
 
 


### PR DESCRIPTION
## Summary
- add domain field to `list_subdomains` and stop sending `fetched_at`
- update Subdomonster UI to display Domain instead of Fetched
- verify returned domain in subdomonster test

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507532aaac8332ad638b1bfb0aa102