### PR TITLE
Add docker layer listing via async API

### DIFF
--- a/app.py
+++ b/app.py
@@ -661,12 +661,13 @@ def bulk_action() -> Response:
 
 
 
-from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, domains_bp
+from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, domains_bp, docker_bp
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
 app.register_blueprint(db_bp)
 app.register_blueprint(settings_bp)
 app.register_blueprint(domains_bp)
+app.register_blueprint(docker_bp)
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask>=2.0
 requests
+aiohttp
 beautifulsoup4
 cssutils
 pytest

--- a/retrorecon/docker_layers.py
+++ b/retrorecon/docker_layers.py
@@ -1,0 +1,150 @@
+import asyncio
+import io
+import tarfile
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from .layerslayer_utils import parse_image_ref, registry_base_url
+
+
+class DockerRegistryClient:
+    """Async Docker registry client with simple token caching."""
+
+    def __init__(self) -> None:
+        self.session: Optional[aiohttp.ClientSession] = None
+        self.token_cache: Dict[str, str] = {}
+
+    async def close(self) -> None:
+        if self.session:
+            await self.session.close()
+
+    async def _fetch_token(self, user: str, repo: str) -> Optional[str]:
+        auth_url = (
+            f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{user}/{repo}:pull"
+        )
+        async with aiohttp.ClientSession() as sess:
+            async with sess.get(auth_url) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json()
+                token = data.get("token")
+                if token:
+                    self.token_cache[f"{user}/{repo}"] = token
+                return token
+
+    async def _auth_headers(self, user: str, repo: str) -> Dict[str, str]:
+        token = self.token_cache.get(f"{user}/{repo}")
+        if not token:
+            token = await self._fetch_token(user, repo)
+        headers = {
+            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    async def fetch_json(self, url: str, user: str, repo: str) -> Dict[str, Any]:
+        headers = await self._auth_headers(user, repo)
+        if self.session is None:
+            self.session = aiohttp.ClientSession()
+        async with self.session.get(url, headers=headers) as resp:
+            if resp.status == 401:
+                token = await self._fetch_token(user, repo)
+                if token:
+                    headers["Authorization"] = f"Bearer {token}"
+                    async with self.session.get(url, headers=headers) as resp2:
+                        resp2.raise_for_status()
+                        return await resp2.json()
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def fetch_bytes(self, url: str, user: str, repo: str) -> bytes:
+        headers = await self._auth_headers(user, repo)
+        if self.session is None:
+            self.session = aiohttp.ClientSession()
+        async with self.session.get(url, headers=headers) as resp:
+            if resp.status == 401:
+                token = await self._fetch_token(user, repo)
+                if token:
+                    headers["Authorization"] = f"Bearer {token}"
+                    async with self.session.get(url, headers=headers) as resp2:
+                        resp2.raise_for_status()
+                        return await resp2.read()
+            resp.raise_for_status()
+            return await resp.read()
+
+
+_client: Optional[DockerRegistryClient] = None
+
+
+def get_client() -> DockerRegistryClient:
+    global _client
+    if _client is None:
+        _client = DockerRegistryClient()
+    return _client
+
+
+async def get_manifest(image_ref: str, specific_digest: Optional[str] = None) -> Dict[str, Any]:
+    user, repo, tag = parse_image_ref(image_ref)
+    ref = specific_digest or tag
+    url = f"{registry_base_url(user, repo)}/manifests/{ref}"
+    return await get_client().fetch_json(url, user, repo)
+
+
+async def list_layer_files(image_ref: str, digest: str) -> List[str]:
+    user, repo, _ = parse_image_ref(image_ref)
+    url = f"{registry_base_url(user, repo)}/blobs/{digest}"
+    data = await get_client().fetch_bytes(url, user, repo)
+    tar_bytes = io.BytesIO(data)
+    files: List[str] = []
+    with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
+        for member in tar.getmembers():
+            files.append(member.name)
+    return files
+
+
+async def _layers_details(image_ref: str, manifest: Dict[str, Any]) -> List[Dict[str, Any]]:
+    layers = manifest.get("layers", [])
+    tasks = [list_layer_files(image_ref, layer["digest"]) for layer in layers]
+    files_list = await asyncio.gather(*tasks)
+    details = []
+    for layer, files in zip(layers, files_list):
+        details.append(
+            {
+                "digest": layer["digest"],
+                "size": layer.get("size"),
+                "files": files,
+            }
+        )
+    return details
+
+
+async def gather_layers_info(image_ref: str) -> List[Dict[str, Any]]:
+    manifest_index = await get_manifest(image_ref)
+    result: List[Dict[str, Any]] = []
+    if manifest_index.get("manifests"):
+        platforms = manifest_index["manifests"]
+        for m in platforms:
+            plat = m.get("platform", {})
+            digest = m["digest"]
+            manifest = await get_manifest(image_ref, specific_digest=digest)
+            layers = await _layers_details(image_ref, manifest)
+            result.append(
+                {
+                    "os": plat.get("os"),
+                    "architecture": plat.get("architecture"),
+                    "layers": layers,
+                }
+            )
+    else:
+        layers = await _layers_details(image_ref, manifest_index)
+        result.append(
+            {
+                "os": manifest_index.get("os"),
+                "architecture": manifest_index.get("architecture"),
+                "layers": layers,
+            }
+        )
+    return result
+

--- a/retrorecon/layerslayer_utils.py
+++ b/retrorecon/layerslayer_utils.py
@@ -1,0 +1,41 @@
+"""Utility helpers from the layerslayer project."""
+
+import os
+from typing import Optional
+
+
+def parse_image_ref(image_ref: str):
+    if ":" in image_ref:
+        repo, tag = image_ref.split(":", 1)
+    else:
+        repo = image_ref
+        tag = "latest"
+    if "/" in repo:
+        user, repo = repo.split("/", 1)
+    else:
+        user = "library"
+    return user, repo, tag
+
+
+def registry_base_url(user: str, repo: str) -> str:
+    return f"https://registry-1.docker.io/v2/{user}/{repo}"
+
+
+def human_readable_size(size: int) -> str:
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{size:.1f} TB"
+
+
+def load_token(filename: str) -> Optional[str]:
+    if os.path.exists(filename):
+        with open(filename, "r") as f:
+            return f.read().strip()
+    return None
+
+
+def save_token(token: str, filename: str = "token.txt") -> None:
+    with open(filename, "w") as f:
+        f.write(token)

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -3,5 +3,6 @@ from .tools import bp as tools_bp
 from .db import bp as db_bp
 from .settings import bp as settings_bp
 from .domains import bp as domains_bp
+from .docker import bp as docker_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp']

--- a/retrorecon/routes/docker.py
+++ b/retrorecon/routes/docker.py
@@ -1,0 +1,33 @@
+from flask import Blueprint, request, jsonify, send_file
+import io
+import asyncio
+
+from ..docker_layers import gather_layers_info, get_client
+from ..layerslayer_utils import parse_image_ref, registry_base_url
+
+bp = Blueprint('docker', __name__)
+
+
+@bp.route('/docker_layers', methods=['GET'])
+def docker_layers_route():
+    image = request.args.get('image')
+    if not image:
+        return jsonify({'error': 'missing_image'}), 400
+    data = asyncio.run(gather_layers_info(image))
+    for plat in data:
+        for layer in plat['layers']:
+            layer['download'] = request.url_root.rstrip('/') + '/download_layer?image=' + image + '&digest=' + layer['digest']
+    return jsonify(data)
+
+
+@bp.route('/download_layer', methods=['GET'])
+def download_layer_route():
+    image = request.args.get('image')
+    digest = request.args.get('digest')
+    if not image or not digest:
+        return ('', 400)
+    user, repo, _ = parse_image_ref(image)
+    url = f"{registry_base_url(user, repo)}/blobs/{digest}"
+    data = asyncio.run(get_client().fetch_bytes(url, user, repo))
+    filename = digest.replace(':', '_') + '.tar.gz'
+    return send_file(io.BytesIO(data), as_attachment=True, download_name=filename, mimetype='application/gzip')

--- a/tests/test_docker_layers.py
+++ b/tests/test_docker_layers.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_docker_layers_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    sample = [
+        {
+            "os": "linux",
+            "architecture": "amd64",
+            "layers": [
+                {"digest": "sha256:a", "size": 1, "files": ["f"]}
+            ],
+        }
+    ]
+    import retrorecon.routes.docker as docker_mod
+
+    async def fake_gather(img):
+        return sample
+
+    monkeypatch.setattr(docker_mod, "gather_layers_info", fake_gather)
+    with app.app.test_client() as client:
+        resp = client.get('/docker_layers?image=test/test:latest')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data[0]["layers"][0]["digest"] == "sha256:a"


### PR DESCRIPTION
## Summary
- integrate layerslayer logic via new async utils
- add Docker registry blueprint for layer browsing
- register new blueprint in Flask app
- include aiohttp in requirements
- test docker layer route

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850992d945c8332b3b89d9266d61675