### PR TITLE
Fix screenshotter timeout

### DIFF
--- a/retrorecon/screenshot_utils.py
+++ b/retrorecon/screenshot_utils.py
@@ -91,7 +91,10 @@ def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False
                 if spoof_referrer:
                     context.set_extra_http_headers({"Referer": url})
                 page = context.new_page()
-                page.goto(url, wait_until="networkidle")
+                # Avoid long hangs by waiting only for the load event with a
+                # reasonable timeout. Some sites never reach a true
+                # "networkidle" state which caused timeouts.
+                page.goto(url, wait_until="load", timeout=15000)
                 data = page.screenshot(full_page=True)
                 browser.close()
                 return data

--- a/tests/test_screenshotter.py
+++ b/tests/test_screenshotter.py
@@ -53,8 +53,8 @@ def test_take_screenshot_env_path_passed(monkeypatch, tmp_path):
     called = {}
 
     class DummyPage:
-        def goto(self, url, wait_until=None):
-            called['goto'] = (url, wait_until)
+        def goto(self, url, wait_until=None, **kw):
+            called['goto'] = (url, wait_until, kw.get('timeout'))
         def screenshot(self, full_page=True):
             return b'PNGDATA'
 
@@ -103,8 +103,8 @@ def test_take_screenshot_variable_path(monkeypatch, tmp_path):
     called = {}
 
     class DummyPage:
-        def goto(self, url, wait_until=None):
-            called['goto'] = (url, wait_until)
+        def goto(self, url, wait_until=None, **kw):
+            called['goto'] = (url, wait_until, kw.get('timeout'))
         def screenshot(self, full_page=True):
             return b'PNGDATA'
 


### PR DESCRIPTION
## Summary
- avoid waiting for `networkidle` to prevent screenshot capture timeouts
- adjust screenshot tests to accept extra timeout param

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a60987048332968d43ab6d8fd756