### PR TITLE
Fix selection toggles and add DockerHub LayerPeek

### DIFF
--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -296,6 +296,14 @@ def site2zip_page():
 def site2zip_full_page():
     return app.index()
 
+@bp.route('/layerslayer', methods=['GET'])
+def layerslayer_page():
+    return render_template('layerslayer.html')
+
+@bp.route('/tools/layerslayer', methods=['GET'])
+def layerslayer_full_page():
+    return app.index()
+
 
 @bp.route('/tools/site2zip', methods=['POST'])
 def site2zip_route():

--- a/static/layerslayer.js
+++ b/static/layerslayer.js
@@ -1,0 +1,48 @@
+/* File: static/layerslayer.js */
+function initLayerslayer(){
+  const overlay = document.getElementById('layerslayer-overlay');
+  if(!overlay) return;
+  const imageInput = document.getElementById('layerslayer-image');
+  const fetchBtn = document.getElementById('layerslayer-fetch-btn');
+  const tableDiv = document.getElementById('layerslayer-table');
+  const closeBtn = document.getElementById('layerslayer-close-btn');
+
+  function render(data){
+    let html = '';
+    for(const plat of data){
+      html += `<h4>${plat.os}/${plat.architecture}</h4>`;
+      html += '<table class="table url-table w-100"><thead><tr><th>Digest</th><th>Size</th><th>Files</th></tr></thead><tbody>';
+      for(const layer of plat.layers){
+        const files = layer.files.map(f=>`<li>${f}</li>`).join('');
+        html += `<tr><td class="w-25em"><div class="cell-content">${layer.digest}</div></td><td>${layer.size}</td><td><ul>${files}</ul></td></tr>`;
+      }
+      html += '</tbody></table>';
+    }
+    tableDiv.innerHTML = html;
+  }
+
+  fetchBtn.addEventListener('click', async () => {
+    const img = imageInput.value.trim();
+    if(!img) return;
+    const resp = await fetch('/docker_layers?image=' + encodeURIComponent(img));
+    if(resp.ok){
+      const data = await resp.json();
+      render(data);
+    } else {
+      alert(await resp.text());
+    }
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/layerslayer'){
+      history.pushState({}, '', '/');
+    }
+  });
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initLayerslayer);
+}else{
+  initLayerslayer();
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,7 +102,7 @@
     <div class="dropdown">
       <button class="dropbtn" data-menu="edit-menu">Edit ▼</button>
       <div class="dropdown-content" id="edit-menu">
-          <div class="menu-row"><button class="menu-btn bulk-action-btn" type="button" onclick="toggleSelectAllPage({checked:true})">Select All (All visible results)</button></div>
+          <div class="menu-row"><button class="menu-btn bulk-action-btn" type="button" onclick="toggleSelectAllPage({})">Select All (All visible results)</button></div>
           <div class="menu-row"><button class="menu-btn bulk-action-btn" type="button" onclick="toggleSelectAllMatching({checked:true})">Select All (All matching results)</button></div>
           <div class="menu-row"><button class="menu-btn bulk-action-btn" type="submit" form="bulk-form" name="action" value="delete">Delete Selected</button></div>
           <div class="menu-row"><button class="menu-btn bulk-action-btn" type="submit" form="bulk-form" name="action" value="clear_tags">Reset tags Selected</button></div>
@@ -419,14 +419,21 @@
     });
 
     function toggleSelectAllPage(cb) {
-      document.querySelectorAll('.row-checkbox').forEach(c => c.checked = cb.checked);
-      document.getElementById('select-all-matching').checked = false;
+      const boxes = document.querySelectorAll('.row-checkbox');
+      let state = cb.checked;
+      if(state === undefined){
+        state = !Array.from(boxes).every(c => c.checked);
+      }
+      boxes.forEach(c => c.checked = state);
+      const matchCb = document.getElementById('select-all-matching');
+      if(matchCb) matchCb.checked = false;
       document.getElementById('select-all-matching-input').value = "false";
     }
 
     function toggleSelectAllMatching(cb) {
       document.getElementById('select-all-matching-input').value = cb.checked ? "true" : "false";
-      document.getElementById('select-all-page').checked = false;
+      const pageCb = document.getElementById('select-all-page');
+      if(pageCb) pageCb.checked = false;
       if (cb.checked) {
         document.querySelectorAll('.row-checkbox').forEach(c => c.checked = true);
       }
@@ -889,6 +896,38 @@
         });
       }
 
+      const layerslayerLink = document.getElementById('layerslayer-link');
+      let layerslayerLoaded = false;
+
+      async function showLayerslayer(skipPush){
+        if(!layerslayerLoaded){
+          const resp = await fetch('/layerslayer');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/layerslayer.js';
+          document.body.appendChild(script);
+          layerslayerLoaded = true;
+        }
+        document.getElementById('layerslayer-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'layerslayer'}, '', '/tools/layerslayer');
+        }
+      }
+
+      function hideLayerslayer(){
+        const ov = document.getElementById('layerslayer-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
+      if(layerslayerLink){
+        layerslayerLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showLayerslayer();
+        });
+      }
+
       const subLink = document.getElementById('subdomonster-link');
       let subLoaded = false;
 
@@ -943,6 +982,18 @@
 
       if(location.pathname === '/tools/site2zip' || openTool === 'site2zip'){
         showSite2zip(true);
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/layerslayer'){
+          showLayerslayer(true);
+        } else {
+          hideLayerslayer();
+        }
+      });
+
+      if(location.pathname === '/tools/layerslayer' || openTool === 'layerslayer'){
+        showLayerslayer(true);
       }
 
       window.addEventListener('popstate', () => {

--- a/templates/layerslayer.html
+++ b/templates/layerslayer.html
@@ -1,0 +1,9 @@
+<!-- File: templates/layerslayer.html -->
+<div id="layerslayer-overlay" class="notes-overlay hidden">
+  <div class="mb-05">
+    <input type="text" id="layerslayer-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
+    <button type="button" class="btn" id="layerslayer-fetch-btn">Fetch</button>
+    <button type="button" class="btn" id="layerslayer-close-btn">Close</button>
+  </div>
+  <div id="layerslayer-table" class="mt-05"></div>
+</div>


### PR DESCRIPTION
## Summary
- add DockerHub LayerPeek template and JS
- expose `/layerslayer` routes
- hook LayerPeek into the UI and history handlers
- improve bulk select JS functions
- allow toggling visible rows via Edit menu

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a5ed8a848332b833cc84139c66e9