### PR TITLE
Improve docker layer error handling

### DIFF
--- a/retrorecon/docker_layers.py
+++ b/retrorecon/docker_layers.py
@@ -47,7 +47,9 @@ class DockerRegistryClient:
     async def fetch_json(self, url: str, user: str, repo: str) -> Dict[str, Any]:
         headers = await self._auth_headers(user, repo)
         if self.session is None:
-            self.session = aiohttp.ClientSession()
+            self.session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=20)
+            )
         async with self.session.get(url, headers=headers) as resp:
             if resp.status == 401:
                 token = await self._fetch_token(user, repo)
@@ -62,7 +64,9 @@ class DockerRegistryClient:
     async def fetch_bytes(self, url: str, user: str, repo: str) -> bytes:
         headers = await self._auth_headers(user, repo)
         if self.session is None:
-            self.session = aiohttp.ClientSession()
+            self.session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=20)
+            )
         async with self.session.get(url, headers=headers) as resp:
             if resp.status == 401:
                 token = await self._fetch_token(user, repo)


### PR DESCRIPTION
## Summary
- handle registry request failures in `docker_layers_route`
- set a timeout for `DockerRegistryClient` session
- test timeout behavior for the docker layers route

## Testing
- `npm install`
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b80def8083328f2da8a636e1736f