### PR TITLE
Rename layerslayer routes

### DIFF
--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -296,12 +296,12 @@ def site2zip_page():
 def site2zip_full_page():
     return app.index()
 
-@bp.route('/layerslayer', methods=['GET'])
-def layerslayer_page():
+@bp.route('/layerpeek', methods=['GET'])
+def layerpeek_page():
     return render_template('layerslayer.html')
 
-@bp.route('/tools/layerslayer', methods=['GET'])
-def layerslayer_full_page():
+@bp.route('/tools/layerpeek', methods=['GET'])
+def layerpeek_full_page():
     return app.index()
 
 

--- a/static/layerpeek.js
+++ b/static/layerpeek.js
@@ -1,5 +1,5 @@
-/* File: static/layerslayer.js */
-function initLayerslayer(){
+/* File: static/layerpeek.js */
+function initLayerpeek(){
   const overlay = document.getElementById('layerslayer-overlay');
   if(!overlay) return;
   const imageInput = document.getElementById('layerslayer-image');
@@ -35,14 +35,14 @@ function initLayerslayer(){
 
   closeBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');
-    if(location.pathname === '/tools/layerslayer'){
+    if(location.pathname === '/tools/layerpeek'){
       history.pushState({}, '', '/');
     }
   });
 }
 
 if(document.readyState==='loading'){
-  document.addEventListener('DOMContentLoaded', initLayerslayer);
+  document.addEventListener('DOMContentLoaded', initLayerpeek);
 }else{
-  initLayerslayer();
+  initLayerpeek();
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -165,7 +165,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="jwt-tools-link">JWT Tools</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">ScreenShotter</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
-          <div class="menu-row"><a href="#" class="menu-btn" id="layerslayer-link">DockerHub LayerPeek</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="layerpeek-link">DockerHub LayerPeek</a></div>
       </div>
     </div>
   </div>
@@ -896,35 +896,35 @@
         });
       }
 
-      const layerslayerLink = document.getElementById('layerslayer-link');
-      let layerslayerLoaded = false;
+      const layerpeekLink = document.getElementById('layerpeek-link');
+      let layerpeekLoaded = false;
 
-      async function showLayerslayer(skipPush){
-        if(!layerslayerLoaded){
-          const resp = await fetch('/layerslayer');
+      async function showLayerpeek(skipPush){
+        if(!layerpeekLoaded){
+          const resp = await fetch('/layerpeek');
           const html = await resp.text();
           const root = document.querySelector('.retrorecon-root') || document.body;
           root.insertAdjacentHTML('beforeend', html);
           const script = document.createElement('script');
-          script.src = '/static/layerslayer.js';
+          script.src = '/static/layerpeek.js';
           document.body.appendChild(script);
-          layerslayerLoaded = true;
+          layerpeekLoaded = true;
         }
         document.getElementById('layerslayer-overlay').classList.remove('hidden');
         if(!skipPush){
-          history.pushState({tool:'layerslayer'}, '', '/tools/layerslayer');
+          history.pushState({tool:'layerpeek'}, '', '/tools/layerpeek');
         }
       }
 
-      function hideLayerslayer(){
+      function hideLayerpeek(){
         const ov = document.getElementById('layerslayer-overlay');
         if(ov) ov.classList.add('hidden');
       }
 
-      if(layerslayerLink){
-        layerslayerLink.addEventListener('click', async (e) => {
+      if(layerpeekLink){
+        layerpeekLink.addEventListener('click', async (e) => {
           e.preventDefault();
-          showLayerslayer();
+          showLayerpeek();
         });
       }
 
@@ -985,15 +985,15 @@
       }
 
       window.addEventListener('popstate', () => {
-        if(location.pathname === '/tools/layerslayer'){
-          showLayerslayer(true);
+        if(location.pathname === '/tools/layerpeek'){
+          showLayerpeek(true);
         } else {
-          hideLayerslayer();
+          hideLayerpeek();
         }
       });
 
-      if(location.pathname === '/tools/layerslayer' || openTool === 'layerslayer'){
-        showLayerslayer(true);
+      if(location.pathname === '/tools/layerpeek' || openTool === 'layerpeek'){
+        showLayerpeek(true);
       }
 
       window.addEventListener('popstate', () => {

--- a/tests/test_layerpeek.py
+++ b/tests/test_layerpeek.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_layerpeek_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/layerpeek')
+        assert resp.status_code == 200
+        assert b'id="layerslayer-overlay"' in resp.data


### PR DESCRIPTION
## Summary
- rename `layerslayer` routes to `layerpeek`
- update frontend script to load `/layerpeek` and rename script file
- adjust menu and JS navigation for LayerPeek
- add regression test for `/layerpeek` route

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b81b6d848332897a666779c489fc