### PR TITLE
Implement status queue and polling

### DIFF
--- a/docs/status_state_machine.md
+++ b/docs/status_state_machine.md
@@ -1,0 +1,14 @@
+# Status State Machine
+
+This document lists the status codes emitted by Retrorecon and their meaning.
+Status events are retrieved via the `/status` API and shown in the UI.
+
+## Codes
+
+- `cdx_api_waiting` – waiting for a response from the Wayback CDX API.
+- `cdx_api_downloading` – currently downloading CDX records.
+- `cdx_api_download_complete` – finished downloading the CDX data.
+- `cdx_import_complete` – all CDX records processed and inserted.
+
+The client polls `/status` every second and displays the most recent message.
+After a short delay the display resets to `idle`.

--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -83,6 +83,22 @@
       }
     },
     {
+      "name": "GET /status",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/status",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "status"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /add_tag",
       "request": {
         "method": "POST",

--- a/retrorecon/status.py
+++ b/retrorecon/status.py
@@ -1,0 +1,20 @@
+import threading
+from collections import deque
+from typing import Optional, Tuple
+
+_STATUS_LOCK = threading.Lock()
+_STATUS_QUEUE: deque[Tuple[str, str]] = deque()
+
+
+def push_status(code: str, message: str = "") -> None:
+    """Append a status event to the queue."""
+    with _STATUS_LOCK:
+        _STATUS_QUEUE.append((code, message))
+
+
+def pop_status() -> Optional[Tuple[str, str]]:
+    """Pop the oldest status event or return ``None`` if empty."""
+    with _STATUS_LOCK:
+        if _STATUS_QUEUE:
+            return _STATUS_QUEUE.popleft()
+    return None

--- a/templates/index.html
+++ b/templates/index.html
@@ -604,6 +604,29 @@
       }
     }
 
+    let statusTimer = null;
+    let statusClear = null;
+    function showStatus(msg){
+      const text = document.getElementById('import-status-text');
+      text.textContent = msg;
+      if(statusClear) clearTimeout(statusClear);
+      statusClear = setTimeout(() => { text.textContent = 'idle'; }, 3000);
+    }
+
+    function pollStatus(){
+      fetch('/status')
+        .then(r => r.json())
+        .then(data => {
+          if(data.code){
+            showStatus(data.message || data.code);
+          }
+          statusTimer = setTimeout(pollStatus, 1000);
+        })
+        .catch(() => { statusTimer = setTimeout(pollStatus, 5000); });
+    }
+
+    pollStatus();
+
     // Check once on load and show current status
     fetch('/import_progress')
       .then(r => r.json())

--- a/tests/test_status_machine.py
+++ b/tests/test_status_machine.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+from retrorecon import status
+
+
+def test_status_queue_order():
+    while status.pop_status() is not None:
+        pass
+    status.push_status('a', 'first')
+    status.push_status('b', 'second')
+    assert status.pop_status() == ('a', 'first')
+    assert status.pop_status() == ('b', 'second')
+    assert status.pop_status() is None
+
+
+def test_status_route_clears_queue(tmp_path, monkeypatch):
+    while status.pop_status() is not None:
+        pass
+    monkeypatch.setattr(app.app, 'root_path', str(tmp_path))
+    monkeypatch.setitem(app.app.config, 'DATABASE', None)
+    (tmp_path / 'db').mkdir()
+    (tmp_path / 'db' / 'schema.sql').write_text((Path(__file__).resolve().parents[1] / 'db' / 'schema.sql').read_text())
+    status.push_status('code1', 'msg1')
+    status.push_status('code2', 'msg2')
+    with app.app.test_client() as client:
+        resp = client.get('/status')
+        assert resp.get_json() == {'code': 'code2', 'message': 'msg2'}
+    assert status.pop_status() is None


### PR DESCRIPTION
## Summary
- implement a thread-safe status queue
- expose `/status` API
- push status events during CDX fetch
- poll `/status` from the UI and auto-clear
- document status codes
- add Postman item and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c3f805148332b4ae522d762befde