### PR TITLE
Fix JS URLs in index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ application's security posture.
 ```markdown
 - [ ] Load `app.secret_key` from an environment variable and document the requirement.
 - [ ] Implement CSRF protection across all POST forms (consider Flask-WTF).
-- [ ] Refactor `templates/index.html` to avoid placing `{{ url.url }}` inside JavaScript strings. 
+- [x] Refactor `templates/index.html` to avoid placing `{{ url.url }}` inside JavaScript strings.
   - Use `data-url` attributes and event listeners defined in JS.
   - Sanitize URLs before opening (e.g., verify `http/https`).
 - [ ] Validate `map_url` in `/tools/webpack-zip`:

--- a/static/index_page.js
+++ b/static/index_page.js
@@ -1,0 +1,30 @@
+// JS for main index page
+function sanitizeUrl(u){
+  try {
+    const url = new URL(u, window.location.href);
+    if(url.protocol === 'http:' || url.protocol === 'https:'){
+      return url.href;
+    }
+  } catch(e){}
+  return null;
+}
+
+document.addEventListener('DOMContentLoaded', function(){
+  document.querySelectorAll('.url-row-main[data-url]').forEach(row => {
+    row.addEventListener('click', () => {
+      const raw = row.getAttribute('data-url');
+      const url = sanitizeUrl(raw);
+      if(url) window.open(url, '_blank');
+    });
+  });
+  document.querySelectorAll('select.tool-select[data-url]').forEach(sel => {
+    sel.addEventListener('change', function(){
+      const raw = this.getAttribute('data-url');
+      const url = sanitizeUrl(raw);
+      if(!url){ this.selectedIndex = 0; return; }
+      if(typeof handleToolSelect === 'function'){
+        handleToolSelect(this, url);
+      }
+    });
+  });
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -244,7 +244,7 @@
               </thead>
               <tbody>
                 {% for url in urls %}
-                <tr class="url-row-main url-result cursor-pointer" onclick="window.open('{{ url.url }}', '_blank');">
+                <tr class="url-row-main url-result cursor-pointer" data-url="{{ url.url }}">
                   <td class="checkbox-col">
                     <input type="checkbox" class="row-checkbox" name="selected_ids" value="{{ url.id }}" onclick="event.stopPropagation()" />
                   </td>
@@ -257,7 +257,7 @@
                   <td></td>
                   <td colspan="4">
                     <div class="url-tools-row nowrap">
-                      <select class="form-select tool-select menu-btn" onchange="handleToolSelect(this, '{{ url.url }}')">
+                      <select class="form-select tool-select menu-btn" data-url="{{ url.url }}">
                         <option value="">Tools…</option>
                         <option value="archive">Web Archive</option>
                         <option value="shodan">Shodan.io</option>
@@ -1191,6 +1191,7 @@
     const urlTable = document.querySelector('.url-table');
     if(urlTable) makeResizable(urlTable, 'url-col-widths');
   </script>
-  </div>
+</div>
+<script src="{{ url_for('static', filename='index_page.js') }}"></script>
 </body>
 </html>

--- a/tests/test_index_sanitization.py
+++ b/tests/test_index_sanitization.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_no_inline_url_js(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db("test")
+        app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://a.com", ""])
+    with app.app.test_client() as client:
+        resp = client.get("/")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'onclick="window.open' not in html
+        assert 'onchange="handleToolSelect' not in html
+        assert 'data-url="http://a.com"' in html
+


### PR DESCRIPTION
## Summary
- refactor index HTML to use data-url attributes instead of inline handlers
- add JS file to attach sanitized event handlers
- test that HTML no longer includes URL values in inline JS
- mark APPSEC checklist item as complete

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c41050608332882a03187449b841