### PR TITLE
Throttle status polling

### DIFF
--- a/docs/status_state_machine.md
+++ b/docs/status_state_machine.md
@@ -10,5 +10,6 @@ Status events are retrieved via the `/status` API and shown in the UI.
 - `cdx_api_download_complete` – finished downloading the CDX data.
 - `cdx_import_complete` – all CDX records processed and inserted.
 
-The client polls `/status` every second and displays the most recent message.
-After a short delay the display resets to `idle`.
+The client polls `/status` frequently when new messages are being emitted and
+gradually backs off to a slower pace when idle, up to 30 seconds between
+requests. After a short delay the display resets to `idle`.

--- a/templates/index.html
+++ b/templates/index.html
@@ -606,6 +606,7 @@
 
     let statusTimer = null;
     let statusClear = null;
+    let statusDelay = 1000;
     function showStatus(msg){
       const text = document.getElementById('import-status-text');
       text.textContent = msg;
@@ -619,10 +620,16 @@
         .then(data => {
           if(data.code){
             showStatus(data.message || data.code);
+            statusDelay = 1000;
+          } else {
+            statusDelay = Math.min(statusDelay * 2, 30000);
           }
-          statusTimer = setTimeout(pollStatus, 1000);
+          statusTimer = setTimeout(pollStatus, statusDelay);
         })
-        .catch(() => { statusTimer = setTimeout(pollStatus, 5000); });
+        .catch(() => {
+          statusDelay = 5000;
+          statusTimer = setTimeout(pollStatus, statusDelay);
+        });
     }
 
     pollStatus();


### PR DESCRIPTION
## Summary
- adjust the status polling script so polling backs off when idle
- document backoff behavior in the state machine docs

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850c7cf6ab083329fe6599de6d285e8