### PR TITLE
Move version info from navbar to footer

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -59,7 +59,6 @@
 .retrorecon-root .d-none { display: none; }
 .retrorecon-root .cursor-pointer { cursor: pointer; }
 .retrorecon-root .fw-bold { font-weight: bold; }
-.retrorecon-root .version-text { font-size: 0.7em; color: var(--accent-color); }
 .retrorecon-root .db-info {
   font-size: 1em;
   letter-spacing: 0.04em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -171,7 +171,7 @@
   </div>
   <div class="navbar__title">
       <h1>
-        <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon <span class="version-text">v1.2.0</span></a>
+        <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline">retrorecon</a>
       </h1>
       <div id="import-status-block" class="db-info">
         <span class="glow cursor-pointer" id="db-display">loaded&gt; {{ db_name }}</span>
@@ -313,7 +313,7 @@
       <td>
         <div class="footer">
           <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline text-muted">
-            retrorecon - Archive Explorer by @savant42 &copy; 2025
+            retrorecon - v1.2.0 by @savant42 &copy; 2025
           </a>
         </div>
       </td>


### PR DESCRIPTION
## Summary
- remove version text from navbar
- show version info in footer instead

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850d1105ac48332818577145e1f9787