### PR TITLE
Improve LayerPeek error feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 -  with a persistent JWT cookie jar
 - **ScreenShotter** capture website screenshots in a headless browser (requires `playwright`; falls back to a Pillow placeholder)
 - **Site2Zip** crawl a URL, generate a sitemap and download all assets as a ZIP
+- **LayerPeek** inspect Docker image layers from Docker Hub
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor
@@ -186,6 +187,16 @@ curl -X POST -d "payload={\"sub\":1}" -d "secret=mykey" \
 # View logged JWT decodes
 curl http://localhost:5000/jwt_cookies
 ```
+
+### Docker LayerPeek API
+
+```bash
+curl -G --data-urlencode "image=ubuntu:latest" \
+  http://localhost:5000/docker_layers
+```
+The response includes layer digests and file lists. If the registry
+is unreachable or a timeout occurs, the JSON `error` field describes the
+problem.
 
 ## License
 MIT

--- a/static/layerpeek.js
+++ b/static/layerpeek.js
@@ -24,12 +24,29 @@ function initLayerpeek(){
   fetchBtn.addEventListener('click', async () => {
     const img = imageInput.value.trim();
     if(!img) return;
-    const resp = await fetch('/docker_layers?image=' + encodeURIComponent(img));
-    if(resp.ok){
-      const data = await resp.json();
-      render(data);
-    } else {
-      alert(await resp.text());
+    fetchBtn.disabled = true;
+    const oldText = fetchBtn.textContent;
+    fetchBtn.textContent = 'Fetching...';
+    try {
+      const resp = await fetch('/docker_layers?image=' + encodeURIComponent(img));
+      if(resp.ok){
+        const data = await resp.json();
+        render(data);
+      } else {
+        let msg;
+        try {
+          const err = await resp.json();
+          msg = err.details ? `${err.error}: ${err.details}` : err.error;
+        } catch {
+          msg = await resp.text();
+        }
+        alert(msg);
+      }
+    } catch(err){
+      alert('Error: ' + err);
+    } finally {
+      fetchBtn.disabled = false;
+      fetchBtn.textContent = oldText;
     }
   });
 


### PR DESCRIPTION
## Summary
- show a friendly message when `/docker_layers` fails
- disable the Fetch button while loading
- document LayerPeek in README

## Testing
- `npm install`
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d46a39708332aaa6ae7c22e6c7b4