### PR TITLE
Improve Layerpeek overlay

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1079,6 +1079,8 @@ body.bg-hidden {
   padding: 1em;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .retrorecon-root .notes-overlay.hidden {
   display: none;

--- a/static/layerpeek.js
+++ b/static/layerpeek.js
@@ -1,20 +1,27 @@
 /* File: static/layerpeek.js */
 function initLayerpeek(){
+  console.log('[Layerpeek] initializing');
   const overlay = document.getElementById('layerslayer-overlay');
-  if(!overlay) return;
+  if(!overlay){
+    console.warn('[Layerpeek] overlay element not found');
+    return;
+  }
   const imageInput = document.getElementById('layerslayer-image');
   const fetchBtn = document.getElementById('layerslayer-fetch-btn');
   const tableDiv = document.getElementById('layerslayer-table');
   const closeBtn = document.getElementById('layerslayer-close-btn');
 
   function render(data){
+    console.log('[Layerpeek] rendering data', data);
     let html = '';
     for(const plat of data){
+      console.log('[Layerpeek] platform', plat.os, plat.architecture);
       html += `<h4>${plat.os}/${plat.architecture}</h4>`;
-      html += '<table class="table url-table w-100"><thead><tr><th>Digest</th><th>Size</th><th>Files</th></tr></thead><tbody>';
+      html += '<table class="table url-table w-100"><thead><tr><th>Digest</th><th>Size</th><th>Files</th><th>Download</th></tr></thead><tbody>';
       for(const layer of plat.layers){
+        console.log('[Layerpeek] layer', layer.digest);
         const files = layer.files.map(f=>`<li>${f}</li>`).join('');
-        html += `<tr><td class="w-25em"><div class="cell-content">${layer.digest}</div></td><td>${layer.size}</td><td><ul>${files}</ul></td></tr>`;
+        html += `<tr><td class="w-25em"><div class="cell-content">${layer.digest}</div></td><td>${layer.size}</td><td><ul>${files}</ul></td><td><a href="${layer.download}">Get</a></td></tr>`;
       }
       html += '</tbody></table>';
     }
@@ -24,6 +31,7 @@ function initLayerpeek(){
   fetchBtn.addEventListener('click', async () => {
     const img = imageInput.value.trim();
     if(!img) return;
+    console.log('[Layerpeek] fetch layers for', img);
     fetchBtn.disabled = true;
     const oldText = fetchBtn.textContent;
     fetchBtn.textContent = 'Fetching...';
@@ -33,6 +41,7 @@ function initLayerpeek(){
         const data = await resp.json();
         render(data);
       } else {
+        console.error('[Layerpeek] server responded', resp.status);
         let msg;
         try {
           const err = await resp.json();
@@ -40,9 +49,11 @@ function initLayerpeek(){
         } catch {
           msg = await resp.text();
         }
+        console.error('[Layerpeek] error', msg);
         alert(msg);
       }
     } catch(err){
+      console.error('[Layerpeek] fetch failed', err);
       alert('Error: ' + err);
     } finally {
       fetchBtn.disabled = false;
@@ -51,6 +62,7 @@ function initLayerpeek(){
   });
 
   closeBtn.addEventListener('click', () => {
+    console.log('[Layerpeek] closing overlay');
     overlay.classList.add('hidden');
     if(location.pathname === '/tools/layerpeek'){
       history.pushState({}, '', '/');


### PR DESCRIPTION
## Summary
- fix overlay scrolling by adding overflow rules to `.notes-overlay`
- show a Download column for Docker layers
- add verbose console logging for Layerpeek

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850ef8973d48332a097c5e7d4625ff2