### PR TITLE
Improve LayerPeek efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ The response includes layer digests and file lists. If the registry
 is unreachable or a timeout occurs, the JSON `error` field describes the
 problem.
 
+Set `LAYERPEEK_RANGE` to control how many bytes are fetched at a time when
+listing layer contents. The default is 2&nbsp;MB which keeps bandwidth usage
+low while still decoding most archives.
+
 ## License
 MIT
 


### PR DESCRIPTION
## Summary
- fetch Docker layer files with range requests
- format layer sizes in human-readable format
- document new `LAYERPEEK_RANGE` variable

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850fcb61108833294745f93daf1d379