### PR TITLE
Fix LayerPeek large layer parsing

### DIFF
--- a/retrorecon/docker_layers.py
+++ b/retrorecon/docker_layers.py
@@ -150,7 +150,12 @@ async def list_layer_files(
                 break
             start += range_size
             continue
-    return []
+    try:
+        tar_bytes = io.BytesIO(data)
+        with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
+            return [m.name for m in tar.getmembers()]
+    except tarfile.ReadError:
+        return []
 
 
 async def _layers_details(


### PR DESCRIPTION
## Summary
- ensure list_layer_files tries to decode after downloading the final range

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685101c1ab148332a55478d1312399f9