### PR TITLE
Return 204 for empty /status

### DIFF
--- a/app.py
+++ b/app.py
@@ -552,7 +552,7 @@ def status_route() -> Response:
             break
         last = nxt
     if not last:
-        return jsonify({'code': '', 'message': ''})
+        return ('', 204)
     return jsonify({'code': last[0], 'message': last[1]})
 
 @app.route('/add_tag', methods=['POST'])

--- a/tests/test_status_machine.py
+++ b/tests/test_status_machine.py
@@ -29,3 +29,15 @@ def test_status_route_clears_queue(tmp_path, monkeypatch):
         resp = client.get('/status')
         assert resp.get_json() == {'code': 'code2', 'message': 'msg2'}
     assert status.pop_status() is None
+
+
+def test_status_route_returns_204_when_empty(tmp_path, monkeypatch):
+    while status.pop_status() is not None:
+        pass
+    monkeypatch.setattr(app.app, 'root_path', str(tmp_path))
+    monkeypatch.setitem(app.app.config, 'DATABASE', None)
+    (tmp_path / 'db').mkdir()
+    (tmp_path / 'db' / 'schema.sql').write_text((Path(__file__).resolve().parents[1] / 'db' / 'schema.sql').read_text())
+    with app.app.test_client() as client:
+        resp = client.get('/status')
+        assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- return 204 No Content when `/status` has no pending events
- test the empty `/status` case

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685106e1efc483328a7a3ccc67a2d08b