### PR TITLE
Enhance LayerPeek UI and integrate layerslayer library

### DIFF
--- a/layerslayer/__init__.py
+++ b/layerslayer/__init__.py
@@ -1,0 +1,9 @@
+from .utils import parse_image_ref, registry_base_url, human_readable_size, load_token, save_token
+
+__all__ = [
+    "parse_image_ref",
+    "registry_base_url",
+    "human_readable_size",
+    "load_token",
+    "save_token",
+]

--- a/layerslayer/fetcher.py
+++ b/layerslayer/fetcher.py
@@ -1,0 +1,165 @@
+# fetcher.py
+# 🛡️ Layerslayer registry fetch helpers with resilient token handling
+
+import os
+import requests
+import tarfile
+import io
+from .utils import (
+    parse_image_ref,
+    registry_base_url,
+    human_readable_size,
+    save_token,
+)
+
+# Persistent session to reuse headers & TCP connections for registry calls
+session = requests.Session()
+session.headers.update({
+    "Accept": "application/vnd.docker.distribution.manifest.v2+json"
+})
+
+def fetch_pull_token(user, repo):
+    """
+    Retrieve a Docker Hub pull token (anonymous or authenticated).
+    Bypasses the shared session so no extra headers confuse the auth endpoint.
+    """
+    auth_url = (
+        f"https://auth.docker.io/token"
+        f"?service=registry.docker.io&scope=repository:{user}/{repo}:pull"
+    )
+    try:
+        # Use plain requests.get() here—no Accept or stale Auth headers
+        resp = requests.get(auth_url)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        print(f"⚠️ Warning: pull-token endpoint error: {e}")
+        return None
+
+    token = resp.json().get("token")
+    if not token:
+        print("⚠️ Warning: token endpoint returned no token")
+        return None
+
+    save_token(token, filename="token_pull.txt")
+    print("💾 Saved pull token to token_pull.txt.")
+    # Now inject the fresh token into our session for all registry calls
+    session.headers["Authorization"] = f"Bearer {token}"
+    return token
+
+def get_manifest(image_ref, token=None, specific_digest=None):
+    """
+    Fetch either a multi-arch manifest list or a single-arch manifest.
+    On 401, attempts one token refresh; if still 401, exits with a friendly message.
+    """
+    user, repo, tag = parse_image_ref(image_ref)
+    ref = specific_digest or tag
+    url = f"{registry_base_url(user, repo)}/manifests/{ref}"
+
+    # If caller provided a token, set it before the request
+    if token:
+        session.headers["Authorization"] = f"Bearer {token}"
+
+    resp = session.get(url)
+    if resp.status_code == 401:
+        print("🔄 Unauthorized. Fetching fresh pull token...")
+        new_token = fetch_pull_token(user, repo)
+        if new_token:
+            resp = session.get(url)
+        else:
+            print("⚠️ Proceeding without refreshed token.")
+
+    if resp.status_code == 401:
+        # Final unauthorized → clean exit
+        print(f"❌ Error: Unauthorized fetching manifest for {image_ref}.")
+        print("   • Ensure the image exists and token.txt (if used) is valid.")
+        raise SystemExit(1)
+
+    resp.raise_for_status()
+    return resp.json()
+
+def fetch_build_steps(image_ref, config_digest, token=None):
+    """
+    Download the image config blob and parse Dockerfile 'created_by' history.
+    """
+    user, repo, _ = parse_image_ref(image_ref)
+    url = f"{registry_base_url(user, repo)}/blobs/{config_digest}"
+
+    resp = session.get(url)
+    if resp.status_code == 401:
+        print("🔄 Unauthorized. Fetching fresh pull token...")
+        new_token = fetch_pull_token(user, repo)
+        if new_token:
+            resp = session.get(url)
+        else:
+            print("⚠️ Proceeding without refreshed token.")
+
+    resp.raise_for_status()
+    config = resp.json()
+
+    steps = []
+    for entry in config.get("history", []):
+        step = entry.get("created_by", "").strip()
+        if entry.get("empty_layer", False):
+            step += " (metadata only)"
+        steps.append(step)
+    return steps
+
+def download_layer_blob(image_ref, digest, size, token=None):
+    """
+    Stream a layer blob to disk as a .tar.gz file.
+    """
+    user, repo, _ = parse_image_ref(image_ref)
+    url = f"{registry_base_url(user, repo)}/blobs/{digest}"
+
+    resp = session.get(url, stream=True)
+    if resp.status_code == 401:
+        print("🔄 Unauthorized. Fetching fresh pull token...")
+        new_token = fetch_pull_token(user, repo)
+        if new_token:
+            resp = session.get(url, stream=True)
+        else:
+            print("⚠️ Proceeding without refreshed token.")
+
+    resp.raise_for_status()
+
+    user_repo = f"{user}_{repo}"
+    output_dir = os.path.join("downloads", user_repo, "latest")
+    os.makedirs(output_dir, exist_ok=True)
+
+    filename = digest.replace(":", "_") + ".tar.gz"
+    path = os.path.join(output_dir, filename)
+
+    with open(path, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+
+    print(f"✅ Saved layer {digest} to {path}")
+
+def peek_layer_blob(image_ref, digest, token=None):
+    """
+    Download a layer blob into memory and list its contents.
+    """
+    user, repo, _ = parse_image_ref(image_ref)
+    url = f"{registry_base_url(user, repo)}/blobs/{digest}"
+
+    resp = session.get(url, stream=True)
+    if resp.status_code == 401:
+        print("🔄 Unauthorized. Fetching fresh pull token...")
+        new_token = fetch_pull_token(user, repo)
+        if new_token:
+            resp = session.get(url, stream=True)
+        else:
+            print("⚠️ Proceeding without refreshed token.")
+
+    resp.raise_for_status()
+
+    tar_bytes = io.BytesIO(resp.content)
+    with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
+        print("\n📦 Layer contents:\n")
+        for member in tar.getmembers():
+            if member.isdir():
+                print(f"📂 {member.name}/")
+            else:
+                size = human_readable_size(member.size)
+                print(f"  📄 {member.name} ({size})")

--- a/layerslayer/parser.py
+++ b/layerslayer/parser.py
@@ -1,0 +1,32 @@
+# parser.py
+# Parses manifest and config data
+
+from .fetcher import get_manifest_by_digest
+
+def parse_index(index_json, image_ref, token=None):
+    """Handles an OCI image index with multiple architectures."""
+    print("\nAvailable Platforms:")
+    platforms = index_json.get('manifests', [])
+    for i, platform in enumerate(platforms):
+        plat = platform.get('platform', {})
+        print(f"[{i}] {plat.get('os', 'unknown')}/{plat.get('architecture', 'unknown')}")
+
+    choice = int(input("\nSelect platform index: "))
+    chosen = platforms[choice]
+    digest = chosen['digest']
+    return get_manifest_by_digest(image_ref, digest, token=token)
+
+def parse_manifest(manifest_json):
+    """Parses a manifest to list its layers."""
+    layers = manifest_json.get('layers', [])
+    layer_info = []
+    print("\nLayers:")
+    for idx, layer in enumerate(layers):
+        size = layer.get('size', 0)
+        digest = layer.get('digest')
+        print(f"[{idx}] {digest} - {size/1024:.1f} KB")
+        layer_info.append({
+            'digest': digest,
+            'size': size
+        })
+    return layer_info

--- a/layerslayer/utils.py
+++ b/layerslayer/utils.py
@@ -1,12 +1,11 @@
-"""Utility helpers from the layerslayer project."""
+# utils.py
+# 🛡️ Layerslayer utilities
 
 import os
-from typing import Optional
 
-
-def parse_image_ref(image_ref: str):
+def parse_image_ref(image_ref):
     if ":" in image_ref:
-        repo, tag = image_ref.split(":", 1)
+        repo, tag = image_ref.split(":")
     else:
         repo = image_ref
         tag = "latest"
@@ -16,26 +15,28 @@ def parse_image_ref(image_ref: str):
         user = "library"
     return user, repo, tag
 
-
-def registry_base_url(user: str, repo: str) -> str:
+def registry_base_url(user, repo):
     return f"https://registry-1.docker.io/v2/{user}/{repo}"
 
+def auth_headers(token=None):
+    headers = {"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
-def human_readable_size(size: int) -> str:
+def human_readable_size(size):
     for unit in ["B", "KB", "MB", "GB"]:
         if size < 1024.0:
             return f"{size:.1f} {unit}"
         size /= 1024.0
     return f"{size:.1f} TB"
 
-
-def load_token(filename: str) -> Optional[str]:
+def load_token(filename):
     if os.path.exists(filename):
         with open(filename, "r") as f:
             return f.read().strip()
     return None
 
-
-def save_token(token: str, filename: str = "token.txt") -> None:
+def save_token(token, filename="token.txt"):
     with open(filename, "w") as f:
         f.write(token)

--- a/static/layerpeek.js
+++ b/static/layerpeek.js
@@ -9,19 +9,33 @@ function initLayerpeek(){
   const imageInput = document.getElementById('layerslayer-image');
   const fetchBtn = document.getElementById('layerslayer-fetch-btn');
   const tableDiv = document.getElementById('layerslayer-table');
+  const infoDiv = document.getElementById('layerslayer-info');
   const closeBtn = document.getElementById('layerslayer-close-btn');
 
   function render(data){
     console.log('[Layerpeek] rendering data', data);
+    const plats = Array.isArray(data) ? data : data.platforms;
+    let headerHtml = '';
+    if(!Array.isArray(data)){
+      const ownerUrl = `https://hub.docker.com/u/${data.owner}`;
+      const repoUrl = `https://hub.docker.com/r/${data.owner}/${data.repo}/tags`;
+      const manifestUrl = `https://hub.docker.com/layers/${data.owner}/${data.repo}/${data.tag}/images/${data.manifest}`;
+      headerHtml = `Owner: <a href="${ownerUrl}" target="_blank">${data.owner}</a> | ` +
+                   `Image: <a href="${repoUrl}" target="_blank">${data.repo}</a> | ` +
+                   `Tag: <a href="${repoUrl}" target="_blank">${data.tag}</a> | ` +
+                   `Manifest: <a href="${manifestUrl}" target="_blank">${data.manifest}</a>`;
+    }
+    infoDiv.innerHTML = headerHtml;
     let html = '';
-    for(const plat of data){
+    for(const plat of plats){
       console.log('[Layerpeek] platform', plat.os, plat.architecture);
       html += `<h4>${plat.os}/${plat.architecture}</h4>`;
       html += '<table class="table url-table w-100"><thead><tr><th>Digest</th><th>Size</th><th>Files</th><th>Download</th></tr></thead><tbody>';
       for(const layer of plat.layers){
         console.log('[Layerpeek] layer', layer.digest);
         const files = layer.files.map(f=>`<li>${f}</li>`).join('');
-        html += `<tr><td class="w-25em"><div class="cell-content">${layer.digest}</div></td><td>${layer.size}</td><td><ul>${files}</ul></td><td><a href="${layer.download}">Get</a></td></tr>`;
+        const filesHtml = `<details><summary>${layer.files.length} files</summary><ul>${files}</ul></details>`;
+        html += `<tr><td class="w-25em"><div class="cell-content">${layer.digest}</div></td><td>${layer.size}</td><td>${filesHtml}</td><td><a href="${layer.download}">Get</a></td></tr>`;
       }
       html += '</tbody></table>';
     }

--- a/templates/layerslayer.html
+++ b/templates/layerslayer.html
@@ -5,5 +5,6 @@
     <button type="button" class="btn" id="layerslayer-fetch-btn">Fetch</button>
     <button type="button" class="btn" id="layerslayer-close-btn">Close</button>
   </div>
+  <div id="layerslayer-info" class="mb-05"></div>
   <div id="layerslayer-table" class="mt-05"></div>
 </div>

--- a/tests/test_docker_layers.py
+++ b/tests/test_docker_layers.py
@@ -32,12 +32,18 @@ def test_docker_layers_route(tmp_path, monkeypatch):
     async def fake_gather(img):
         return sample
 
+    async def fake_digest(img):
+        return "sha256:d1"
+
     monkeypatch.setattr(docker_mod, "gather_layers_info", fake_gather)
+    monkeypatch.setattr(docker_mod, "get_manifest_digest", fake_digest)
     with app.app.test_client() as client:
         resp = client.get('/docker_layers?image=test/test:latest')
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data[0]["layers"][0]["digest"] == "sha256:a"
+        assert data["owner"] == "test"
+        assert data["tag"] == "latest"
+        assert data["platforms"][0]["layers"][0]["digest"] == "sha256:a"
 
 
 def test_docker_layers_timeout(tmp_path, monkeypatch):

--- a/tests/test_layerslayer_lib.py
+++ b/tests/test_layerslayer_lib.py
@@ -1,0 +1,12 @@
+from layerslayer import parse_image_ref, human_readable_size
+
+
+def test_parse_image_ref():
+    user, repo, tag = parse_image_ref("user/repo:tag")
+    assert user == "user"
+    assert repo == "repo"
+    assert tag == "tag"
+
+
+def test_human_readable_size():
+    assert human_readable_size(2048) == "2.0 KB"


### PR DESCRIPTION
## Summary
- integrate `layerslayer` project as an importable library
- extend Docker routes to return owner/image/tag/manifest metadata
- add manifest digest retrieval
- show repository details and collapsible file lists in LayerPeek
- update tests and add a basic layerslayer unit test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851069da5208332b2b70bda86478897