### PR TITLE
Implement Layerpeek progress messages

### DIFF
--- a/docs/status_state_machine.md
+++ b/docs/status_state_machine.md
@@ -9,6 +9,10 @@ Status events are retrieved via the `/status` API and shown in the UI.
 - `cdx_api_downloading` – currently downloading CDX records.
 - `cdx_api_download_complete` – finished downloading the CDX data.
 - `cdx_import_complete` – all CDX records processed and inserted.
+- `layerpeek_start` – layerpeek fetch initiated.
+- `layerpeek_fetch_manifest` – retrieving image manifest information.
+- `layerpeek_fetch_layers` – downloading layer details.
+- `layerpeek_done` – layerpeek inspection complete.
 
 The client polls `/status` frequently when new messages are being emitted and
 gradually backs off to a slower pace when idle, up to 30 seconds between

--- a/templates/layerslayer.html
+++ b/templates/layerslayer.html
@@ -6,5 +6,6 @@
     <button type="button" class="btn" id="layerslayer-close-btn">Close</button>
   </div>
   <div id="layerslayer-info" class="mb-05"></div>
+  <pre id="layerslayer-console" class="mb-05"></pre>
   <div id="layerslayer-table" class="mt-05"></div>
 </div>


### PR DESCRIPTION
## Summary
- track LayerPeek progress via status queue
- show a console in the LayerPeek overlay and poll status
- document the new `layerpeek_*` status codes

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685112852ba4833296a2f7ed9be368cb