### PR TITLE
Implement layerslayer packaging and UI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,17 @@ Set `LAYERPEEK_RANGE` to control how many bytes are fetched at a time when
 listing layer contents. The default is 2&nbsp;MB which keeps bandwidth usage
 low while still decoding most archives.
 
+### Using the `layerslayer` Library
+
+The Docker layer inspection logic is available as an importable library.
+
+```python
+from layerslayer.client import gather_layers_info
+
+data = asyncio.run(gather_layers_info("ubuntu:latest"))
+print(data[0]["layers"][0]["digest"])
+```
+
 ## License
 MIT
 

--- a/layerslayer/__init__.py
+++ b/layerslayer/__init__.py
@@ -1,4 +1,5 @@
 from .utils import parse_image_ref, registry_base_url, human_readable_size, load_token, save_token
+from .client import DockerRegistryClient, gather_layers_info, get_manifest, get_manifest_digest, list_layer_files
 
 __all__ = [
     "parse_image_ref",
@@ -6,4 +7,9 @@ __all__ = [
     "human_readable_size",
     "load_token",
     "save_token",
+    "DockerRegistryClient",
+    "gather_layers_info",
+    "get_manifest",
+    "get_manifest_digest",
+    "list_layer_files",
 ]

--- a/layerslayer/cli.py
+++ b/layerslayer/cli.py
@@ -1,0 +1,16 @@
+import argparse
+import asyncio
+import json
+from .client import gather_layers_info
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Inspect Docker image layers")
+    parser.add_argument("image", help="image reference, e.g. user/repo:tag")
+    args = parser.parse_args()
+    data = asyncio.run(gather_layers_info(args.image))
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/layerslayer/client.py
+++ b/layerslayer/client.py
@@ -1,0 +1,248 @@
+import asyncio
+import io
+import tarfile
+from typing import Any, Dict, List, Optional
+import os
+
+import aiohttp
+
+from .utils import parse_image_ref, registry_base_url, human_readable_size
+
+DEFAULT_TIMEOUT = aiohttp.ClientTimeout(
+    total=int(os.environ.get("REGISTRY_TIMEOUT", "120"))
+)
+
+
+class DockerRegistryClient:
+    """Async Docker registry client with simple token caching."""
+
+    def __init__(self) -> None:
+        self.session: Optional[aiohttp.ClientSession] = None
+        self.token_cache: Dict[str, str] = {}
+
+    async def __aenter__(self) -> "DockerRegistryClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self.session:
+            await self.session.close()
+
+    async def _fetch_token(self, user: str, repo: str) -> Optional[str]:
+        auth_url = (
+            f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{user}/{repo}:pull"
+        )
+        async with aiohttp.ClientSession(trust_env=True) as sess:
+            async with sess.get(auth_url) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json()
+                token = data.get("token")
+                if token:
+                    self.token_cache[f"{user}/{repo}"] = token
+                return token
+
+    async def _auth_headers(self, user: str, repo: str) -> Dict[str, str]:
+        token = self.token_cache.get(f"{user}/{repo}")
+        if not token:
+            token = await self._fetch_token(user, repo)
+        headers = {
+            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    async def fetch_json(self, url: str, user: str, repo: str) -> Dict[str, Any]:
+        headers = await self._auth_headers(user, repo)
+        if self.session is None:
+            self.session = aiohttp.ClientSession(
+                timeout=DEFAULT_TIMEOUT,
+                trust_env=True
+            )
+        async with self.session.get(url, headers=headers) as resp:
+            if resp.status == 401:
+                token = await self._fetch_token(user, repo)
+                if token:
+                    headers["Authorization"] = f"Bearer {token}"
+                    async with self.session.get(url, headers=headers) as resp2:
+                        resp2.raise_for_status()
+                        return await resp2.json()
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def fetch_bytes(self, url: str, user: str, repo: str) -> bytes:
+        headers = await self._auth_headers(user, repo)
+        headers["Accept"] = "*/*"
+        if self.session is None:
+            self.session = aiohttp.ClientSession(
+                timeout=DEFAULT_TIMEOUT,
+                trust_env=True
+            )
+        async with self.session.get(url, headers=headers) as resp:
+            if resp.status == 401:
+                token = await self._fetch_token(user, repo)
+                if token:
+                    headers["Authorization"] = f"Bearer {token}"
+                    async with self.session.get(url, headers=headers) as resp2:
+                        resp2.raise_for_status()
+                        return await resp2.read()
+            resp.raise_for_status()
+            return await resp.read()
+
+    async def fetch_digest(self, url: str, user: str, repo: str) -> Optional[str]:
+        headers = await self._auth_headers(user, repo)
+        if self.session is None:
+            self.session = aiohttp.ClientSession(
+                timeout=DEFAULT_TIMEOUT,
+                trust_env=True
+            )
+        async with self.session.head(url, headers=headers) as resp:
+            if resp.status == 401:
+                token = await self._fetch_token(user, repo)
+                if token:
+                    headers["Authorization"] = f"Bearer {token}"
+                    async with self.session.head(url, headers=headers) as resp2:
+                        resp2.raise_for_status()
+                        return resp2.headers.get("Docker-Content-Digest")
+            resp.raise_for_status()
+            return resp.headers.get("Docker-Content-Digest")
+
+
+def get_client() -> DockerRegistryClient:
+    """Return a fresh DockerRegistryClient instance."""
+    return DockerRegistryClient()
+
+
+async def get_manifest_digest(
+    image_ref: str,
+    client: Optional[DockerRegistryClient] = None,
+) -> Optional[str]:
+    user, repo, tag = parse_image_ref(image_ref)
+    url = f"{registry_base_url(user, repo)}/manifests/{tag}"
+    c = client or get_client()
+    return await c.fetch_digest(url, user, repo)
+
+
+async def get_manifest(
+    image_ref: str,
+    specific_digest: Optional[str] = None,
+    client: Optional[DockerRegistryClient] = None,
+) -> Dict[str, Any]:
+    user, repo, tag = parse_image_ref(image_ref)
+    ref = specific_digest or tag
+    url = f"{registry_base_url(user, repo)}/manifests/{ref}"
+    c = client or get_client()
+    return await c.fetch_json(url, user, repo)
+
+
+async def list_layer_files(
+    image_ref: str,
+    digest: str,
+    client: Optional[DockerRegistryClient] = None,
+) -> List[str]:
+    """Return the list of files contained in a layer blob."""
+    user, repo, _ = parse_image_ref(image_ref)
+    url = f"{registry_base_url(user, repo)}/blobs/{digest}"
+    c = client or get_client()
+
+    headers = await c._auth_headers(user, repo)
+    headers["Accept"] = "*/*"
+    if c.session is None:
+        c.session = aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT, trust_env=True)
+
+    range_size = int(os.environ.get("LAYERPEEK_RANGE", "2097152"))
+
+    def _parse(data: bytes) -> List[str]:
+        tar_bytes = io.BytesIO(data)
+        with tarfile.open(fileobj=tar_bytes, mode="r:*") as tar:
+            return [m.name for m in tar.getmembers()]
+
+    if range_size <= 0:
+        data = await c.fetch_bytes(url, user, repo)
+        return _parse(data)
+
+    start = 0
+    data = bytearray()
+    while True:
+        h = dict(headers)
+        h["Range"] = f"bytes={start}-{start + range_size - 1}"
+        async with c.session.get(url, headers=h) as resp:
+            if resp.status == 416:
+                break
+            resp.raise_for_status()
+            chunk = await resp.read()
+            if not chunk:
+                break
+            data.extend(chunk)
+        try:
+            return _parse(data)
+        except tarfile.ReadError:
+            if len(chunk) < range_size:
+                break
+            start += range_size
+            continue
+    try:
+        return _parse(data)
+    except tarfile.ReadError:
+        try:
+            data = await c.fetch_bytes(url, user, repo)
+            return _parse(data)
+        except Exception:
+            return []
+
+
+async def _layers_details(
+    image_ref: str,
+    manifest: Dict[str, Any],
+    client: DockerRegistryClient,
+) -> List[Dict[str, Any]]:
+    layers = manifest.get("layers", [])
+    details: List[Dict[str, Any]] = []
+    for layer in layers:
+        try:
+            files = await list_layer_files(image_ref, layer["digest"], client)
+        except Exception:
+            files = []
+        details.append(
+            {
+                "digest": layer["digest"],
+                "size": human_readable_size(layer.get("size", 0) or 0),
+                "files": files,
+            }
+        )
+    return details
+
+
+async def gather_layers_info(image_ref: str) -> List[Dict[str, Any]]:
+    async with DockerRegistryClient() as client:
+        manifest_index = await get_manifest(image_ref, client=client)
+        result: List[Dict[str, Any]] = []
+        if manifest_index.get("manifests"):
+            platforms = manifest_index["manifests"]
+            for m in platforms:
+                plat = m.get("platform", {})
+                digest = m["digest"]
+                manifest = await get_manifest(
+                    image_ref, specific_digest=digest, client=client
+                )
+                layers = await _layers_details(image_ref, manifest, client)
+                result.append(
+                    {
+                        "os": plat.get("os"),
+                        "architecture": plat.get("architecture"),
+                        "layers": layers,
+                    }
+                )
+        else:
+            layers = await _layers_details(image_ref, manifest_index, client)
+            result.append(
+                {
+                    "os": manifest_index.get("os"),
+                    "architecture": manifest_index.get("architecture"),
+                    "layers": layers,
+                }
+            )
+        return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "layerslayer"
+version = "0.1.0"
+description = "Docker layer inspection utilities"
+authors = [{name = "retrorecon", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[project.scripts]
+layerslayer = "layerslayer.cli:main"

--- a/retrorecon/docker_layers.py
+++ b/retrorecon/docker_layers.py
@@ -1,147 +1,24 @@
-import asyncio
-import io
-import tarfile
 from typing import Any, Dict, List, Optional
-import os
 
-import aiohttp
-
-DEFAULT_TIMEOUT = aiohttp.ClientTimeout(
-    total=int(os.environ.get("REGISTRY_TIMEOUT", "120"))
+from layerslayer.utils import human_readable_size
+from layerslayer.client import (
+    DockerRegistryClient,
+    get_client,
+    get_manifest,
+    get_manifest_digest,
+    list_layer_files as _list_layer_files,
 )
 
-from layerslayer.utils import (
-    parse_image_ref,
-    registry_base_url,
-    human_readable_size,
-)
 from retrorecon import status as status_mod
 
-
-class DockerRegistryClient:
-    """Async Docker registry client with simple token caching."""
-
-    def __init__(self) -> None:
-        self.session: Optional[aiohttp.ClientSession] = None
-        self.token_cache: Dict[str, str] = {}
-
-    async def __aenter__(self) -> "DockerRegistryClient":
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb) -> None:
-        await self.close()
-
-    async def close(self) -> None:
-        if self.session:
-            await self.session.close()
-
-    async def _fetch_token(self, user: str, repo: str) -> Optional[str]:
-        auth_url = (
-            f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{user}/{repo}:pull"
-        )
-        async with aiohttp.ClientSession(trust_env=True) as sess:
-            async with sess.get(auth_url) as resp:
-                if resp.status != 200:
-                    return None
-                data = await resp.json()
-                token = data.get("token")
-                if token:
-                    self.token_cache[f"{user}/{repo}"] = token
-                return token
-
-    async def _auth_headers(self, user: str, repo: str) -> Dict[str, str]:
-        token = self.token_cache.get(f"{user}/{repo}")
-        if not token:
-            token = await self._fetch_token(user, repo)
-        headers = {
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-        }
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        return headers
-
-    async def fetch_json(self, url: str, user: str, repo: str) -> Dict[str, Any]:
-        headers = await self._auth_headers(user, repo)
-        if self.session is None:
-            self.session = aiohttp.ClientSession(
-                timeout=DEFAULT_TIMEOUT,
-                trust_env=True
-            )
-        async with self.session.get(url, headers=headers) as resp:
-            if resp.status == 401:
-                token = await self._fetch_token(user, repo)
-                if token:
-                    headers["Authorization"] = f"Bearer {token}"
-                    async with self.session.get(url, headers=headers) as resp2:
-                        resp2.raise_for_status()
-                        return await resp2.json()
-            resp.raise_for_status()
-            return await resp.json()
-
-    async def fetch_bytes(self, url: str, user: str, repo: str) -> bytes:
-        headers = await self._auth_headers(user, repo)
-        headers["Accept"] = "*/*"
-        if self.session is None:
-            self.session = aiohttp.ClientSession(
-                timeout=DEFAULT_TIMEOUT,
-                trust_env=True
-            )
-        async with self.session.get(url, headers=headers) as resp:
-            if resp.status == 401:
-                token = await self._fetch_token(user, repo)
-                if token:
-                    headers["Authorization"] = f"Bearer {token}"
-                    async with self.session.get(url, headers=headers) as resp2:
-                        resp2.raise_for_status()
-                        return await resp2.read()
-            resp.raise_for_status()
-            return await resp.read()
-
-    async def fetch_digest(self, url: str, user: str, repo: str) -> Optional[str]:
-        headers = await self._auth_headers(user, repo)
-        if self.session is None:
-            self.session = aiohttp.ClientSession(
-                timeout=DEFAULT_TIMEOUT,
-                trust_env=True
-            )
-        async with self.session.head(url, headers=headers) as resp:
-            if resp.status == 401:
-                token = await self._fetch_token(user, repo)
-                if token:
-                    headers["Authorization"] = f"Bearer {token}"
-                    async with self.session.head(url, headers=headers) as resp2:
-                        resp2.raise_for_status()
-                        return resp2.headers.get("Docker-Content-Digest")
-            resp.raise_for_status()
-            return resp.headers.get("Docker-Content-Digest")
-
-
-
-def get_client() -> DockerRegistryClient:
-    """Return a fresh DockerRegistryClient instance."""
-    return DockerRegistryClient()
-
-
-async def get_manifest_digest(
-    image_ref: str,
-    client: Optional[DockerRegistryClient] = None,
-) -> Optional[str]:
-    user, repo, tag = parse_image_ref(image_ref)
-    url = f"{registry_base_url(user, repo)}/manifests/{tag}"
-    c = client or get_client()
-    return await c.fetch_digest(url, user, repo)
-
-
-async def get_manifest(
-    image_ref: str,
-    specific_digest: Optional[str] = None,
-    client: Optional[DockerRegistryClient] = None,
-) -> Dict[str, Any]:
-    user, repo, tag = parse_image_ref(image_ref)
-    ref = specific_digest or tag
-    url = f"{registry_base_url(user, repo)}/manifests/{ref}"
-    c = client or get_client()
-    return await c.fetch_json(url, user, repo)
+__all__ = [
+    "DockerRegistryClient",
+    "get_client",
+    "get_manifest",
+    "get_manifest_digest",
+    "list_layer_files",
+    "gather_layers_info",
+]
 
 
 async def list_layer_files(
@@ -149,62 +26,7 @@ async def list_layer_files(
     digest: str,
     client: Optional[DockerRegistryClient] = None,
 ) -> List[str]:
-    """Return the list of files contained in a layer blob.
-
-    The function first attempts ranged GET requests to avoid downloading large
-    layers in full. If the collected bytes cannot be parsed as a tar archive it
-    falls back to downloading the entire blob via ``fetch_bytes``.
-    """
-    user, repo, _ = parse_image_ref(image_ref)
-    url = f"{registry_base_url(user, repo)}/blobs/{digest}"
-    c = client or get_client()
-
-    headers = await c._auth_headers(user, repo)
-    headers["Accept"] = "*/*"
-    if c.session is None:
-        c.session = aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT, trust_env=True)
-
-    range_size = int(os.environ.get("LAYERPEEK_RANGE", "2097152"))
-
-    def _parse(data: bytes) -> List[str]:
-        tar_bytes = io.BytesIO(data)
-        with tarfile.open(fileobj=tar_bytes, mode="r:*") as tar:
-            return [m.name for m in tar.getmembers()]
-
-    # range_size <= 0 means fetch the whole blob immediately
-    if range_size <= 0:
-        data = await c.fetch_bytes(url, user, repo)
-        return _parse(data)
-
-    start = 0
-    data = bytearray()
-    while True:
-        h = dict(headers)
-        h["Range"] = f"bytes={start}-{start + range_size - 1}"
-        async with c.session.get(url, headers=h) as resp:
-            if resp.status == 416:
-                break
-            resp.raise_for_status()
-            chunk = await resp.read()
-            if not chunk:
-                break
-            data.extend(chunk)
-        try:
-            return _parse(data)
-        except tarfile.ReadError:
-            if len(chunk) < range_size:
-                break
-            start += range_size
-            continue
-    try:
-        return _parse(data)
-    except tarfile.ReadError:
-        # Final attempt failed → download the entire blob and parse
-        try:
-            data = await c.fetch_bytes(url, user, repo)
-            return _parse(data)
-        except Exception:
-            return []
+    return await _list_layer_files(image_ref, digest, client)
 
 
 async def _layers_details(
@@ -240,12 +62,8 @@ async def gather_layers_info(image_ref: str) -> List[Dict[str, Any]]:
             for m in platforms:
                 plat = m.get("platform", {})
                 digest = m["digest"]
-                status_mod.push_status(
-                    'layerpeek_fetch_manifest', f"{plat.get('os')}/{plat.get('architecture')}"
-                )
-                manifest = await get_manifest(
-                    image_ref, specific_digest=digest, client=client
-                )
+                status_mod.push_status('layerpeek_fetch_manifest', f"{plat.get('os')}/{plat.get('architecture')}")
+                manifest = await get_manifest(image_ref, specific_digest=digest, client=client)
                 status_mod.push_status('layerpeek_fetch_layers', digest)
                 layers = await _layers_details(image_ref, manifest, client)
                 result.append(
@@ -267,4 +85,3 @@ async def gather_layers_info(image_ref: str) -> List[Dict[str, Any]]:
             )
         status_mod.push_status('layerpeek_done', image_ref)
         return result
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -166,6 +166,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">ScreenShotter</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="layerpeek-link">DockerHub LayerPeek</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="layerpeek-b-link">LayerPeek B</a></div>
       </div>
     </div>
   </div>
@@ -938,6 +939,7 @@
       }
 
       const layerpeekLink = document.getElementById('layerpeek-link');
+      const layerpeekBLink = document.getElementById('layerpeek-b-link');
       let layerpeekLoaded = false;
 
       async function showLayerpeek(skipPush){
@@ -966,6 +968,20 @@
         layerpeekLink.addEventListener('click', async (e) => {
           e.preventDefault();
           showLayerpeek();
+        });
+      }
+
+      async function showLayerpeekB(skipPush){
+        await showLayerpeek(true);
+        if(!skipPush){
+          history.pushState({tool:'layerpeek-b'}, '', '/tools/layerpeek-b');
+        }
+      }
+
+      if(layerpeekBLink){
+        layerpeekBLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showLayerpeekB();
         });
       }
 
@@ -1033,8 +1049,20 @@
         }
       });
 
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/layerpeek-b'){
+          showLayerpeekB(true);
+        } else {
+          hideLayerpeek();
+        }
+      });
+
       if(location.pathname === '/tools/layerpeek' || openTool === 'layerpeek'){
         showLayerpeek(true);
+      }
+
+      if(location.pathname === '/tools/layerpeek-b' || openTool === 'layerpeek-b'){
+        showLayerpeekB(true);
       }
 
       window.addEventListener('popstate', () => {


### PR DESCRIPTION
## Summary
- add `pyproject.toml` packaging `layerslayer`
- move CLI to `layerslayer/cli.py`
- provide async client in `layerslayer.client`
- re-export client functions in `retrorecon.docker_layers`
- document library usage
- add A/B testing link for LayerPeek

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68511564c80c8332943f21b46c1427c3