### PR TITLE
Add registry explorer module

### DIFF
--- a/app.py
+++ b/app.py
@@ -687,13 +687,14 @@ def bulk_action() -> Response:
 
 
 
-from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, domains_bp, docker_bp
+from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, domains_bp, docker_bp, registry_bp
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
 app.register_blueprint(db_bp)
 app.register_blueprint(settings_bp)
 app.register_blueprint(domains_bp)
 app.register_blueprint(docker_bp)
+app.register_blueprint(registry_bp)
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):

--- a/retrorecon/registry_explorer.py
+++ b/retrorecon/registry_explorer.py
@@ -1,0 +1,178 @@
+"""Registry Explorer API module ported from the Docker Registry Explorer extension."""
+from __future__ import annotations
+
+import asyncio
+import io
+import re
+import tarfile
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from layerslayer.utils import parse_image_ref
+
+DEFAULT_DOMAIN = "registry-1.docker.io"
+LEGACY_DEFAULT_DOMAIN = "index.docker.io"
+OFFICIAL_REPO_NAME = "library"
+
+DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=120)
+
+
+def split_docker_domain(name: str) -> tuple[str, str]:
+    """Return (domain, remainder) for a Docker image reference."""
+    i = name.find("/")
+    first = name[:i]
+    if i == -1 or ("." not in first and ":" not in first and first != "localhost"):
+        domain = DEFAULT_DOMAIN
+        remainder = name
+    else:
+        domain = first
+        remainder = name[i + 1 :]
+    if domain == LEGACY_DEFAULT_DOMAIN:
+        domain = DEFAULT_DOMAIN
+    if domain == DEFAULT_DOMAIN and "/" not in remainder:
+        remainder = f"{OFFICIAL_REPO_NAME}/{remainder}"
+    return domain, remainder
+
+
+async def fetch_token(repo: str, session: Optional[aiohttp.ClientSession] = None) -> str:
+    """Fetch an anonymous pull token for the given repository."""
+    domain, remainder = split_docker_domain(repo)
+    sess = session or aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT, trust_env=True)
+    async with sess.get(f"https://{domain}/v2/") as resp:
+        auth = resp.headers.get("www-authenticate")
+    realm = "https://auth.docker.io/token"
+    service = "registry.docker.io"
+    if auth:
+        m = re.search(r'realm="([^"]+)"', auth)
+        if m:
+            realm = m.group(1)
+        m = re.search(r'service="([^"]+)"', auth)
+        if m:
+            service = m.group(1)
+    async with sess.get(
+        f"{realm}?service={service}&scope=repository:{remainder}:pull"
+    ) as resp:
+        resp.raise_for_status()
+        data = await resp.json()
+        return data.get("token", "")
+
+
+ACCEPT_HEADERS = (
+    "application/vnd.oci.image.index.v1+json,"
+    "application/vnd.oci.image.manifest.v1+json,"
+    "application/vnd.docker.distribution.manifest.list.v2+json,"
+    "application/vnd.docker.distribution.manifest.v2+json"
+)
+
+
+async def fetch_index_or_manifest(
+    repo: str,
+    digest_or_tag: str,
+    token: str,
+    session: Optional[aiohttp.ClientSession] = None,
+) -> Dict[str, Any]:
+    domain, remainder = split_docker_domain(repo)
+    url = f"https://{domain}/v2/{remainder}/manifests/{digest_or_tag}"
+    headers = {"Accept": ACCEPT_HEADERS, "Authorization": f"Bearer {token}"}
+    sess = session or aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT, trust_env=True)
+    async with sess.get(url, headers=headers) as resp:
+        resp.raise_for_status()
+        body = await resp.json()
+        return {
+            "digest": resp.headers.get("docker-content-digest"),
+            "contentType": resp.headers.get("content-type"),
+            "_digestOrTag": digest_or_tag,
+            **body,
+        }
+
+
+async def fetch_blob(
+    repo: str,
+    digest: str,
+    token: str,
+    session: Optional[aiohttp.ClientSession] = None,
+) -> bytes:
+    domain, remainder = split_docker_domain(repo)
+    url = f"https://{domain}/v2/{remainder}/blobs/{digest}"
+    headers = {"Authorization": f"Bearer {token}"}
+    sess = session or aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT, trust_env=True)
+    async with sess.get(url, headers=headers) as resp:
+        resp.raise_for_status()
+        return await resp.read()
+
+
+async def list_layer_files(
+    repo: str,
+    digest: str,
+    token: str,
+    session: Optional[aiohttp.ClientSession] = None,
+) -> List[str]:
+    data = await fetch_blob(repo, digest, token, session)
+    tar_bytes = io.BytesIO(data)
+    try:
+        with tarfile.open(fileobj=tar_bytes, mode="r:*") as tar:
+            return [m.name for m in tar.getmembers()]
+    except tarfile.ReadError:
+        return []
+
+
+async def get_manifest_digest(
+    image_ref: str,
+    token: Optional[str] = None,
+    session: Optional[aiohttp.ClientSession] = None,
+) -> Optional[str]:
+    user, repo, tag = parse_image_ref(image_ref)
+    repo_full = f"{user}/{repo}"
+    token = token or await fetch_token(repo_full, session)
+    domain, remainder = split_docker_domain(repo_full)
+    url = f"https://{domain}/v2/{remainder}/manifests/{tag}"
+    headers = {
+        "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+        "Authorization": f"Bearer {token}",
+    }
+    sess = session or aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT, trust_env=True)
+    async with sess.head(url, headers=headers) as resp:
+        resp.raise_for_status()
+        return resp.headers.get("Docker-Content-Digest")
+
+
+async def _layers_details(repo: str, manifest: Dict[str, Any], token: str, session: aiohttp.ClientSession) -> List[Dict[str, Any]]:
+    layers = manifest.get("layers", [])
+    details: List[Dict[str, Any]] = []
+    for layer in layers:
+        files = await list_layer_files(repo, layer["digest"], token, session)
+        details.append({"digest": layer["digest"], "size": layer.get("size", 0), "files": files})
+    return details
+
+
+async def gather_image_info(image_ref: str) -> List[Dict[str, Any]]:
+    """Gather layer details for an image using direct registry calls."""
+    user, repo, tag = parse_image_ref(image_ref)
+    repo_full = f"{user}/{repo}"
+    async with aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT, trust_env=True) as session:
+        token = await fetch_token(repo_full, session)
+        root = await fetch_index_or_manifest(repo_full, tag, token, session)
+        result: List[Dict[str, Any]] = []
+        if root.get("manifests"):
+            for m in root["manifests"]:
+                plat = m.get("platform", {})
+                digest = m["digest"]
+                manifest = await fetch_index_or_manifest(repo_full, digest, token, session)
+                layers = await _layers_details(repo_full, manifest, token, session)
+                result.append({"os": plat.get("os"), "architecture": plat.get("architecture"), "layers": layers})
+        else:
+            layers = await _layers_details(repo_full, root, token, session)
+            result.append({"os": root.get("os"), "architecture": root.get("architecture"), "layers": layers})
+        return result
+
+
+async def gather_image_info_with_backend(image_ref: str, method: str = "layerslayer") -> List[Dict[str, Any]]:
+    """Wrapper returning layer info via different backends for testing."""
+    if method == "layerslayer":
+        from .docker_layers import gather_layers_info as gl
+        return await gl(image_ref)
+    elif method in {"layertools", "extension"}:
+        return await gather_image_info(image_ref)
+    else:
+        raise ValueError(f"unknown method: {method}")

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -4,5 +4,6 @@ from .db import bp as db_bp
 from .settings import bp as settings_bp
 from .domains import bp as domains_bp
 from .docker import bp as docker_bp
+from .registry import bp as registry_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp']

--- a/retrorecon/routes/registry.py
+++ b/retrorecon/routes/registry.py
@@ -1,0 +1,44 @@
+from flask import Blueprint, request, jsonify
+import asyncio
+from aiohttp import ClientError
+
+from layerslayer.utils import parse_image_ref
+from .. import registry_explorer as rex
+
+bp = Blueprint('registry', __name__)
+
+
+@bp.route('/registry_explorer', methods=['GET'])
+def registry_explorer_route():
+    image = request.args.get('image')
+    method = request.args.get('method', 'extension')
+    if not image:
+        return jsonify({'error': 'missing_image'}), 400
+
+    async def _gather() -> list:
+        return await rex.gather_image_info_with_backend(image, method)
+
+    async def _digest() -> str | None:
+        return await rex.get_manifest_digest(image)
+
+    try:
+        data = asyncio.run(_gather())
+        digest = asyncio.run(_digest())
+    except asyncio.TimeoutError:
+        return jsonify({'error': 'timeout'}), 504
+    except ClientError as exc:
+        return jsonify({'error': 'client_error', 'details': str(exc)}), 502
+    except Exception as exc:
+        return jsonify({'error': 'server_error', 'details': str(exc)}), 500
+
+    owner, repo, tag = parse_image_ref(image)
+    result = {
+        'owner': owner,
+        'repo': repo,
+        'tag': tag,
+        'manifest': digest,
+        'method': method,
+        'platforms': data,
+    }
+    return jsonify(result)
+

--- a/tests/test_registry_explorer.py
+++ b/tests/test_registry_explorer.py
@@ -1,0 +1,58 @@
+import asyncio
+from pathlib import Path
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_registry_explorer_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    sample = [
+        {
+            "os": "linux",
+            "architecture": "amd64",
+            "layers": [{"digest": "sha256:a", "size": 1, "files": ["f"]}],
+        }
+    ]
+    import retrorecon.routes.registry as reg
+
+    async def fake_gather(img, method="extension"):
+        assert method == "extension"
+        return sample
+
+    async def fake_digest(img):
+        return "sha256:d1"
+
+    monkeypatch.setattr(reg.rex, "gather_image_info_with_backend", fake_gather)
+    monkeypatch.setattr(reg.rex, "get_manifest_digest", fake_digest)
+
+    with app.app.test_client() as client:
+        resp = client.get("/registry_explorer?image=test/test:tag&method=extension")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["manifest"] == "sha256:d1"
+        assert data["platforms"][0]["layers"][0]["digest"] == "sha256:a"
+
+
+def test_registry_explorer_timeout(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.registry as reg
+
+    async def fail_gather(img, method="extension"):
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(reg.rex, "gather_image_info_with_backend", fail_gather)
+
+    with app.app.test_client() as client:
+        resp = client.get("/registry_explorer?image=test/test:tag")
+        assert resp.status_code == 504
+        assert resp.get_json()["error"] == "timeout"
+


### PR DESCRIPTION
## Summary
- port Docker Registry Explorer extension logic to Python
- expose new `/registry_explorer` API endpoint with pluggable backends
- register the new blueprint in the Flask app
- provide unit tests for the new route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511882da788332bd96a7d1d5707c7e