### PR TITLE
Enable verbose logging via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ python scripts/init_db.py  # initialize wabax.db
 python app.py
 # Optionally set RETRORECON_DB to open a specific database on launch
 # RETRORECON_DB=dsprings.db python app.py
+# Enable verbose logging by setting RETRORECON_LOG_LEVEL
+# RETRORECON_LOG_LEVEL=DEBUG python app.py
 ```
 On Windows you can run `launch_app.bat` to automatically update the repository,
 set up a `venv` and start the server:

--- a/app.py
+++ b/app.py
@@ -53,6 +53,9 @@ from retrorecon import (
 app = Flask(__name__)
 sys.modules.setdefault('app', sys.modules[__name__])
 app.config.from_object(Config)
+log_level_name = app.config.get('LOG_LEVEL', 'WARNING').upper()
+numeric_level = getattr(logging, log_level_name, logging.WARNING)
+logging.basicConfig(level=numeric_level, format='%(levelname)s:%(name)s:%(message)s')
 logger = logging.getLogger(__name__)
 app.jwt = jwt
 env_db = app.config.get('DB_ENV')

--- a/config.py
+++ b/config.py
@@ -6,3 +6,4 @@ class Config:
     SECRET_KEY = os.environ.get('RETRORECON_SECRET', 'CHANGE_THIS_TO_A_RANDOM_SECRET_KEY')
     DB_ENV = os.environ.get('RETRORECON_DB')
     DATABASE = None  # Will be set in app.py after app root is known
+    LOG_LEVEL = os.environ.get('RETRORECON_LOG_LEVEL', 'WARNING')

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -10,4 +10,6 @@ if not exist venv (
 venv\Scripts\python -m pip install --upgrade pip
 venv\Scripts\pip install -r requirements.txt
 
+set RETRORECON_LOG_LEVEL=DEBUG
+
 venv\Scripts\python app.py


### PR DESCRIPTION
## Summary
- support `RETRORECON_LOG_LEVEL` in config
- configure logging in `app.py`
- expose verbose flag in Windows launcher and docs

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68511aada5788332917976015a2ba538