### PR TITLE
Add Registry Explorer UI

### DIFF
--- a/retrorecon/routes/registry.py
+++ b/retrorecon/routes/registry.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, render_template
+import app
 import asyncio
 from aiohttp import ClientError
 
@@ -6,6 +7,16 @@ from layerslayer.utils import parse_image_ref
 from .. import registry_explorer as rex
 
 bp = Blueprint('registry', __name__)
+
+
+@bp.route('/registry_viewer', methods=['GET'])
+def registry_viewer_page():
+    return render_template('registry_explorer.html')
+
+
+@bp.route('/tools/registry_viewer', methods=['GET'])
+def registry_viewer_full_page():
+    return app.index()
 
 
 @bp.route('/registry_explorer', methods=['GET'])

--- a/static/registry_explorer.js
+++ b/static/registry_explorer.js
@@ -1,0 +1,161 @@
+/* File: static/registry_explorer.js */
+function initRegistryExplorer(){
+  const overlay = document.getElementById('registry-explorer-overlay');
+  if(!overlay) return;
+  const imageInput = document.getElementById('registry-image');
+  const methodChecks = overlay.querySelectorAll('input[name="registry-method"]');
+  const fetchBtn = document.getElementById('registry-fetch-btn');
+  const closeBtn = document.getElementById('registry-close-btn');
+  const tableDiv = document.getElementById('registry-table');
+  const infoDiv = document.getElementById('registry-info');
+
+  function makeResizable(table, key){
+    table.style.tableLayout = 'fixed';
+    const ths = table.querySelectorAll('th');
+    const cols = table.querySelectorAll('col');
+    let widths = {};
+    try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
+    ths.forEach((th, idx) => {
+      const id = idx;
+      if(widths[id]){
+        th.style.width = widths[id];
+        if(cols[id]) cols[id].style.width = widths[id];
+      }
+      const initial = th.style.width || th.offsetWidth + 'px';
+      th.style.width = initial;
+      if(cols[id]) cols[id].style.width = initial;
+      if(th.classList.contains('no-resize')) return;
+      const res = document.createElement('div');
+      res.className = 'col-resizer';
+      th.appendChild(res);
+      let startX = 0;
+      let startWidth = 0;
+      res.addEventListener('mousedown', e => {
+        startX = e.pageX;
+        startWidth = th.offsetWidth;
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', stop);
+        e.preventDefault();
+      });
+      function onMove(e){
+        const w = Math.max(30, startWidth + (e.pageX - startX));
+        th.style.width = w + 'px';
+        if(cols[id]) cols[id].style.width = w + 'px';
+        widths[id] = w + 'px';
+      }
+      function stop(){
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', stop);
+        localStorage.setItem(key, JSON.stringify(widths));
+      }
+    });
+  }
+
+  function attachSort(table){
+    const tbody = table.querySelector('tbody');
+    table.querySelectorAll('th.sortable').forEach(th => {
+      th.addEventListener('click', ev => {
+        if(ev.target.closest('.col-resizer')) return;
+        const idx = Array.from(th.parentNode.children).indexOf(th);
+        const dir = th.dataset.sort === 'asc' ? 'desc' : 'asc';
+        th.dataset.sort = dir;
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        rows.sort((a,b)=>{
+          const av = a.children[idx].textContent.trim();
+          const bv = b.children[idx].textContent.trim();
+          const nA = parseInt(av.replace(/[^0-9]/g,''));
+          const nB = parseInt(bv.replace(/[^0-9]/g,''));
+          if(!isNaN(nA) && !isNaN(nB)){
+            return dir==='asc'? nA-nB : nB-nA;
+          }
+          return dir==='asc'? av.localeCompare(bv):bv.localeCompare(av);
+        });
+        rows.forEach(r=>tbody.appendChild(r));
+      });
+    });
+  }
+
+  function buildTables(plats, img){
+    let html = '';
+    for(const plat of plats){
+      html += `<h4>${plat.os}/${plat.architecture}</h4>`;
+      html += '<table class="table url-table w-100"><colgroup>'+
+               '<col/><col class="w-6em"/><col/><col class="w-6em"/>'+
+               '</colgroup><thead><tr>'+
+               '<th class="sortable" data-field="digest">Digest</th>'+
+               '<th class="sortable" data-field="size">Size</th>'+
+               '<th>Files</th><th>Download</th>'+
+               '</tr></thead><tbody>';
+      for(const layer of plat.layers){
+        const files = layer.files.map(f=>`<li>${f}</li>`).join('');
+        const filesHtml = `<details><summary>${layer.files.length} files</summary><ul>${files}</ul></details>`;
+        const dlink = `/download_layer?image=${encodeURIComponent(img)}&digest=${encodeURIComponent(layer.digest)}`;
+        html += `<tr><td class="w-25em"><div class="cell-content">${layer.digest}</div></td>`+
+                `<td>${layer.size}</td><td>${filesHtml}</td>`+
+                `<td><a href="${dlink}">Get</a></td></tr>`;
+      }
+      html += '</tbody></table>';
+    }
+    return html;
+  }
+
+  function render(data){
+    const ownerUrl = `https://hub.docker.com/u/${data.owner}`;
+    const repoUrl = `https://hub.docker.com/r/${data.owner}/${data.repo}/tags`;
+    const manifestUrl = `https://hub.docker.com/layers/${data.owner}/${data.repo}/${data.tag}/images/${data.manifest}`;
+    infoDiv.innerHTML = `Owner: <a href="${ownerUrl}" target="_blank">${data.owner}</a> | `+
+                        `Image: <a href="${repoUrl}" target="_blank">${data.repo}</a> | `+
+                        `Tag: <a href="${repoUrl}" target="_blank">${data.tag}</a> | `+
+                        `Manifest: <a href="${manifestUrl}" target="_blank">${data.manifest}</a>`;
+    let html = '';
+    const imgRef = `${data.owner}/${data.repo}:${data.tag}`;
+    if(data.results){
+      for(const m of data.methods){
+        html += `<h3>${m}</h3>`;
+        html += buildTables(data.results[m], imgRef);
+      }
+    } else {
+      html = buildTables(data.platforms, imgRef);
+    }
+    tableDiv.innerHTML = html;
+    tableDiv.querySelectorAll('table').forEach(t=>{ attachSort(t); makeResizable(t,'registry-col-widths'); });
+  }
+
+  fetchBtn.addEventListener('click', async () => {
+    const img = imageInput.value.trim();
+    if(!img) return;
+    const methods = Array.from(methodChecks).filter(c=>c.checked).map(c=>c.value);
+    let url = '/registry_explorer?image=' + encodeURIComponent(img);
+    if(methods.length === 1){
+      url += '&method=' + encodeURIComponent(methods[0]);
+    }else if(methods.length > 1){
+      url += '&methods=' + methods.map(encodeURIComponent).join(',');
+    }
+    fetchBtn.disabled = true;
+    const oldText = fetchBtn.textContent;
+    fetchBtn.textContent = 'Fetching...';
+    try{
+      const resp = await fetch(url);
+      if(resp.ok){
+        const data = await resp.json();
+        render(data);
+      } else {
+        alert(await resp.text());
+      }
+    }catch(err){ alert('Error: '+err); }
+    finally{ fetchBtn.disabled=false; fetchBtn.textContent=oldText; }
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/registry_viewer'){
+      history.pushState({}, '', '/');
+    }
+  });
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initRegistryExplorer);
+}else{
+  initRegistryExplorer();
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,6 +167,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="layerpeek-link">DockerHub LayerPeek</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="layerpeek-b-link">LayerPeek B</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="registry-viewer-link">Registry Explorer</a></div>
       </div>
     </div>
   </div>
@@ -1075,6 +1076,50 @@
 
       if(location.pathname === '/tools/screenshotter' || openTool === 'screenshot'){
         showScreenshot(true);
+      }
+
+      const registryLink = document.getElementById('registry-viewer-link');
+      let registryLoaded = false;
+
+      async function showRegistryViewer(skipPush){
+        if(!registryLoaded){
+          const resp = await fetch('/registry_viewer');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/registry_explorer.js';
+          document.body.appendChild(script);
+          registryLoaded = true;
+        }
+        document.getElementById('registry-explorer-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'registry'}, '', '/tools/registry_viewer');
+        }
+      }
+
+      function hideRegistryViewer(){
+        const ov = document.getElementById('registry-explorer-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
+      if(registryLink){
+        registryLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showRegistryViewer();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/registry_viewer'){
+          showRegistryViewer(true);
+        } else {
+          hideRegistryViewer();
+        }
+      });
+
+      if(location.pathname === '/tools/registry_viewer' || openTool === 'registry'){
+        showRegistryViewer(true);
       }
 
     const themeSelect = document.getElementById('theme-select');

--- a/templates/registry_explorer.html
+++ b/templates/registry_explorer.html
@@ -1,0 +1,12 @@
+<!-- File: templates/registry_explorer.html -->
+<div id="registry-explorer-overlay" class="notes-overlay hidden">
+  <div class="mb-05">
+    <input type="text" id="registry-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
+    <label class="mr-05"><input type="checkbox" name="registry-method" value="extension" checked> extension</label>
+    <label class="mr-05"><input type="checkbox" name="registry-method" value="layerslayer" checked> layerslayer</label>
+    <button type="button" class="btn" id="registry-fetch-btn">Fetch</button>
+    <button type="button" class="btn" id="registry-close-btn">Close</button>
+  </div>
+  <div id="registry-info" class="mb-05"></div>
+  <div id="registry-table" class="mt-05"></div>
+</div>

--- a/tests/test_registry_viewer.py
+++ b/tests/test_registry_viewer.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_registry_viewer_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/registry_viewer')
+        assert resp.status_code == 200
+        assert b'id="registry-explorer-overlay"' in resp.data


### PR DESCRIPTION
## Summary
- create new overlay for Registry Explorer
- add registry viewer routes
- implement frontend JS with sortable/resizable tables
- link the new tool in index page
- add regression test for registry viewer route

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68512c71d92c83329de439d4ecb6f97d