### PR TITLE
Implement Dag Explorer per porting plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - **Site2Zip** crawl a URL, generate a sitemap and download all assets as a ZIP
 - **LayerPeek** inspect Docker image layers from Docker Hub
 - **Registry Explorer** query image manifests from multiple backends
+- **Dag Explorer** list repository tags and view manifests via a simple browser
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/app.py
+++ b/app.py
@@ -690,7 +690,16 @@ def bulk_action() -> Response:
 
 
 
-from retrorecon.routes import notes_bp, tools_bp, db_bp, settings_bp, domains_bp, docker_bp, registry_bp
+from retrorecon.routes import (
+    notes_bp,
+    tools_bp,
+    db_bp,
+    settings_bp,
+    domains_bp,
+    docker_bp,
+    registry_bp,
+    dag_bp,
+)
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
 app.register_blueprint(db_bp)
@@ -698,6 +707,7 @@ app.register_blueprint(settings_bp)
 app.register_blueprint(domains_bp)
 app.register_blueprint(docker_bp)
 app.register_blueprint(registry_bp)
+app.register_blueprint(dag_bp)
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -356,3 +356,28 @@ Delete one or more captures by ID.
 curl -X POST -d "ids=1,2" http://localhost:5000/delete_sitezips
 ```
 
+### `GET /dag/repo/<name>`
+List tags for a Docker repository.
+
+```
+curl http://localhost:5000/dag/repo/library/ubuntu
+```
+
+### `GET /dag/image/<ref>`
+Return the manifest JSON for an image reference.
+
+```
+curl http://localhost:5000/dag/image/library/ubuntu:latest
+```
+
+### `GET /dag/fs/<digest>/<path>`
+Extract a single file from a layer blob.
+
+Query parameter:
+- `image` – image reference containing the layer.
+
+```
+curl -O \
+  "http://localhost:5000/dag/fs/sha256:1234/etc/os-release?image=library/ubuntu:latest"
+```
+

--- a/reports/report.json
+++ b/reports/report.json
@@ -1,19 +1,19 @@
 {
   "coverage": {
     "button": {
-      "total": 54,
-      "styled": 54
+      "total": 59,
+      "styled": 59
     },
     "input": {
-      "total": 21,
-      "styled": 13
+      "total": 25,
+      "styled": 15
     },
     "select": {
       "total": 6,
       "styled": 6
     },
     "checkbox": {
-      "total": 5,
+      "total": 7,
       "styled": 5
     }
   },

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -5,5 +5,6 @@ from .settings import bp as settings_bp
 from .domains import bp as domains_bp
 from .docker import bp as docker_bp
 from .registry import bp as registry_bp
+from .dag import bp as dag_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp']

--- a/retrorecon/routes/dag.py
+++ b/retrorecon/routes/dag.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import tarfile
+from pathlib import Path
+from typing import Any, Dict
+
+from aiohttp import ClientError
+from flask import Blueprint, jsonify, render_template, request, send_file
+
+import app
+from layerslayer.client import DockerRegistryClient, get_manifest
+from layerslayer.utils import parse_image_ref, registry_base_url
+
+bp = Blueprint("dag", __name__)
+
+
+def _split_repo(name: str) -> tuple[str, str]:
+    if "/" in name:
+        return tuple(name.split("/", 1))  # type: ignore[return-value]
+    return "library", name
+
+
+@bp.route("/dag_explorer", methods=["GET"])
+def dag_explorer_page():
+    return render_template("dag_explorer.html")
+
+
+@bp.route("/tools/dag_explorer", methods=["GET"])
+def dag_explorer_full_page():
+    return app.index()
+
+
+@bp.route("/dag/repo/<path:repo>", methods=["GET"])
+def dag_repo(repo: str):
+    async def _fetch() -> Dict[str, Any]:
+        user, repo_name = _split_repo(repo)
+        url = f"{registry_base_url(user, repo_name)}/tags/list"
+        async with DockerRegistryClient() as client:
+            return await client.fetch_json(url, user, repo_name)
+
+    try:
+        data = asyncio.run(_fetch())
+    except asyncio.TimeoutError:
+        return jsonify({"error": "timeout"}), 504
+    except ClientError as exc:
+        return jsonify({"error": "client_error", "details": str(exc)}), 502
+    except Exception as exc:  # pragma: no cover - unexpected
+        return jsonify({"error": "server_error", "details": str(exc)}), 500
+    return jsonify(data)
+
+
+@bp.route("/dag/image/<path:image>", methods=["GET"])
+def dag_image(image: str):
+    async def _fetch() -> Dict[str, Any]:
+        async with DockerRegistryClient() as client:
+            return await get_manifest(image, client=client)
+
+    try:
+        data = asyncio.run(_fetch())
+    except asyncio.TimeoutError:
+        return jsonify({"error": "timeout"}), 504
+    except ClientError as exc:
+        return jsonify({"error": "client_error", "details": str(exc)}), 502
+    except Exception as exc:
+        return jsonify({"error": "server_error", "details": str(exc)}), 500
+    return jsonify(data)
+
+
+@bp.route("/dag/fs/<digest>/<path:path>", methods=["GET"])
+def dag_fs(digest: str, path: str):
+    image = request.args.get("image")
+    if not image:
+        return jsonify({"error": "missing_image"}), 400
+
+    async def _fetch() -> bytes:
+        user, repo, _ = parse_image_ref(image)
+        url = f"{registry_base_url(user, repo)}/blobs/{digest}"
+        async with DockerRegistryClient() as client:
+            return await client.fetch_bytes(url, user, repo)
+
+    try:
+        blob = asyncio.run(_fetch())
+    except asyncio.TimeoutError:
+        return jsonify({"error": "timeout"}), 504
+    except ClientError as exc:
+        return jsonify({"error": "client_error", "details": str(exc)}), 502
+    except Exception as exc:
+        return jsonify({"error": "server_error", "details": str(exc)}), 500
+
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:*") as tar:
+        try:
+            member = tar.getmember(path)
+        except KeyError:
+            return jsonify({"error": "not_found"}), 404
+        file_obj = tar.extractfile(member)
+        if not file_obj:
+            return jsonify({"error": "not_found"}), 404
+        data = file_obj.read()
+    filename = Path(path).name
+    return send_file(io.BytesIO(data), download_name=filename, as_attachment=False)

--- a/static/dag_explorer.js
+++ b/static/dag_explorer.js
@@ -1,0 +1,38 @@
+/* File: static/dag_explorer.js */
+function initDagExplorer(){
+  const overlay = document.getElementById('dag-explorer-overlay');
+  if(!overlay) return;
+  const imgInput = document.getElementById('dag-image');
+  const fetchBtn = document.getElementById('dag-fetch-btn');
+  const tagsBtn = document.getElementById('dag-tags-btn');
+  const closeBtn = document.getElementById('dag-close-btn');
+  const output = document.getElementById('dag-output');
+
+  async function fetchManifest(){
+    const img = imgInput.value.trim();
+    if(!img) return;
+    const resp = await fetch('/dag/image/' + encodeURIComponent(img));
+    output.textContent = await resp.text();
+  }
+
+  async function fetchTags(){
+    const img = imgInput.value.trim();
+    if(!img) return;
+    const repo = img.split(':')[0];
+    const resp = await fetch('/dag/repo/' + encodeURIComponent(repo));
+    output.textContent = await resp.text();
+  }
+
+  fetchBtn.addEventListener('click', fetchManifest);
+  tagsBtn.addEventListener('click', fetchTags);
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/dag_explorer'){ history.pushState({}, '', '/'); }
+  });
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initDagExplorer);
+}else{
+  initDagExplorer();
+}

--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -1,0 +1,10 @@
+<!-- File: templates/dag_explorer.html -->
+<div id="dag-explorer-overlay" class="notes-overlay hidden">
+  <div class="mb-05">
+    <input type="text" id="dag-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
+    <button type="button" class="btn" id="dag-fetch-btn">Fetch Manifest</button>
+    <button type="button" class="btn" id="dag-tags-btn">List Tags</button>
+    <button type="button" class="btn" id="dag-close-btn">Close</button>
+  </div>
+  <pre id="dag-output" class="mt-05"></pre>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -168,6 +168,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="layerpeek-link">DockerHub LayerPeek</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="layerpeek-b-link">LayerPeek B</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="registry-viewer-link">Registry Explorer</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="dag-explorer-link">Dag Explorer</a></div>
       </div>
     </div>
   </div>
@@ -1120,6 +1121,53 @@
 
       if(location.pathname === '/tools/registry_viewer' || openTool === 'registry'){
         showRegistryViewer(true);
+      }
+
+      const dagLink = document.getElementById('dag-explorer-link');
+      let dagLoaded = false;
+
+      async function showDagExplorer(skipPush){
+        if(!dagLoaded){
+          const resp = await fetch('/dag_explorer');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/dag_explorer.js';
+          document.body.appendChild(script);
+          dagLoaded = true;
+        }
+        document.getElementById('dag-explorer-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'dag'}, '', '/tools/dag_explorer');
+        }
+      }
+
+      function hideDagExplorer(){
+        const ov = document.getElementById('dag-explorer-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
+      if(dagLink){
+        dagLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showDagExplorer();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/registry_viewer'){
+          showRegistryViewer(true);
+        } else if(location.pathname === '/tools/dag_explorer'){
+          showDagExplorer(true);
+        } else {
+          hideRegistryViewer();
+          hideDagExplorer();
+        }
+      });
+
+      if(location.pathname === '/tools/dag_explorer' || openTool === 'dag'){
+        showDagExplorer(true);
       }
 
     const themeSelect = document.getElementById('theme-select');

--- a/tests/test_dag_explorer.py
+++ b/tests/test_dag_explorer.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+import io
+import tarfile
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_dag_explorer_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/dag_explorer')
+        assert resp.status_code == 200
+        assert b'id="dag-explorer-overlay"' in resp.data
+
+
+def test_dag_repo_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dag as dag
+
+    async def fake_fetch_json(self, url, user, repo):
+        return {"name": f"{user}/{repo}", "tags": ["latest"]}
+
+    monkeypatch.setattr(dag.DockerRegistryClient, 'fetch_json', fake_fetch_json)
+    with app.app.test_client() as client:
+        resp = client.get('/dag/repo/user/repo')
+        assert resp.status_code == 200
+        assert resp.get_json()['tags'] == ['latest']
+
+
+def test_dag_image_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dag as dag
+
+    async def fake_manifest(image, client=None):
+        return {"schemaVersion": 2}
+
+    monkeypatch.setattr(dag, 'get_manifest', fake_manifest)
+    with app.app.test_client() as client:
+        resp = client.get('/dag/image/user/repo:tag')
+        assert resp.status_code == 200
+        assert resp.get_json()['schemaVersion'] == 2
+
+
+def test_dag_fs_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dag as dag
+
+    # create small tar
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode='w') as tar:
+        info = tarfile.TarInfo('a.txt')
+        data = b'hello'
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    tar_bytes = buf.getvalue()
+
+    async def fake_fetch_bytes(self, url, user, repo):
+        return tar_bytes
+
+    monkeypatch.setattr(dag.DockerRegistryClient, 'fetch_bytes', fake_fetch_bytes)
+    with app.app.test_client() as client:
+        resp = client.get('/dag/fs/sha256:x/a.txt?image=user/repo:tag')
+        assert resp.status_code == 200
+        assert resp.data == b'hello'


### PR DESCRIPTION
## Summary
- port dagdotdev registry browser with new blueprint and routes
- add Dag Explorer overlay with JS loader
- expose Dag Explorer in Tools drop-down
- document new API endpoints
- add tests for Dag Explorer feature

## Testing
- `npm install`
- `npm run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_68519689a0a483329c3d9a50fd59790a