### PR TITLE
Fix layer peek on truncated archives

### DIFF
--- a/layerslayer/client.py
+++ b/layerslayer/client.py
@@ -179,14 +179,14 @@ async def list_layer_files(
             data.extend(chunk)
         try:
             return _parse(data)
-        except tarfile.ReadError:
+        except (tarfile.TarError, OSError, EOFError):
             if len(chunk) < range_size:
                 break
             start += range_size
             continue
     try:
         return _parse(data)
-    except tarfile.ReadError:
+    except (tarfile.TarError, OSError, EOFError):
         try:
             data = await c.fetch_bytes(url, user, repo)
             return _parse(data)


### PR DESCRIPTION
## Summary
- handle `BadGzipFile` errors when reading layer blobs

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a4314f108332be0878e7b10dcbac