### PR TITLE
Improve layer listing details

### DIFF
--- a/tests/test_docker_layers.py
+++ b/tests/test_docker_layers.py
@@ -144,6 +144,6 @@ def test_list_layer_files_fallback(monkeypatch):
         return await dl.list_layer_files('user/repo:tag', 'sha256:x', client=client)
 
     files = asyncio.run(run())
-    assert files == ['hello.txt']
+    assert files and files[0].endswith('hello.txt')
 
 

--- a/tests/test_dockerhub_layer_validation.py
+++ b/tests/test_dockerhub_layer_validation.py
@@ -43,5 +43,6 @@ def test_dockerhub_layer_files_match(tmp_path, monkeypatch):
         with tarfile.open(fileobj=io.BytesIO(resp.data), mode="r:gz") as tar:
             tar_files = [m.name for m in tar.getmembers()]
 
-    assert sorted(api_files) == sorted(tar_files)
+    api_names = [f.split()[-1] for f in api_files]
+    assert sorted(api_names) == sorted(tar_files)
 


### PR DESCRIPTION
## Summary
- include size, mode and timestamps when listing layer contents
- adjust tests for new detailed output

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a8fc51188332be72d1869b2fc959