### PR TITLE
Implement registry explorer parity routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -699,6 +699,7 @@ from retrorecon.routes import (
     docker_bp,
     registry_bp,
     dag_bp,
+    oci_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -708,6 +709,7 @@ app.register_blueprint(domains_bp)
 app.register_blueprint(docker_bp)
 app.register_blueprint(registry_bp)
 app.register_blueprint(dag_bp)
+app.register_blueprint(oci_bp)
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest
 PyJWT
 Pillow
 playwright
+pyelftools

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -6,5 +6,6 @@ from .domains import bp as domains_bp
 from .docker import bp as docker_bp
 from .registry import bp as registry_bp
 from .dag import bp as dag_bp
+from .oci import bp as oci_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp']

--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+from flask import Blueprint, render_template, request, send_file
+from aiohttp import ClientError
+import asyncio
+
+from layerslayer.utils import parse_image_ref, registry_base_url
+from layerslayer.client import DockerRegistryClient, get_manifest, list_layer_files
+from retrorecon.registry_explorer import fetch_token, fetch_blob
+
+bp = Blueprint("oci", __name__)
+
+
+@bp.route("/tools/registry_explorer", methods=["GET"])
+def oci_index():
+    return render_template("oci_index.html")
+
+
+async def _repo_data(repo: str) -> Dict[str, Any]:
+    user, repo_name = parse_image_ref(f"{repo}:latest")[:2]
+    url = f"{registry_base_url(user, repo_name)}/tags/list"
+    async with DockerRegistryClient() as client:
+        data = await client.fetch_json(url, user, repo_name)
+        tags = data.get("tags", [])
+        manifests: Dict[str, Any] = {}
+        for tag in tags:
+            digest = await client.fetch_digest(
+                f"{registry_base_url(user, repo_name)}/manifests/{tag}", user, repo_name
+            )
+            if digest:
+                manifests.setdefault(digest, {"tag": []})["tag"].append(tag)
+        return {"name": f"{repo}", "child": [], "tags": tags, "manifest": manifests}
+
+
+@bp.route("/repo/<path:repo>", methods=["GET"])
+def repo_view(repo: str):
+    try:
+        data = asyncio.run(_repo_data(repo))
+    except asyncio.TimeoutError:
+        return ("timeout", 504)
+    except ClientError as exc:
+        return (str(exc), 502)
+    except Exception:
+        return ("server error", 500)
+    return render_template("oci_repo.html", repo=repo, data=data)
+
+
+async def _image_data(image: str) -> Dict[str, Any]:
+    async with DockerRegistryClient() as client:
+        manifest = await get_manifest(image, client=client)
+        layers = await list_layer_files(image, manifest["layers"][0]["digest"], client=client)
+    return {"manifest": manifest, "layers": layers}
+
+
+@bp.route("/image/<path:image>", methods=["GET"])
+def image_view(image: str):
+    try:
+        data = asyncio.run(_image_data(image))
+    except asyncio.TimeoutError:
+        return ("timeout", 504)
+    except ClientError as exc:
+        return (str(exc), 502)
+    except Exception:
+        return ("server error", 500)
+    return render_template("oci_image.html", image=image, data=data)
+
+
+async def _read_layer(repo: str, digest: str) -> bytes:
+    token = await fetch_token(repo)
+    return await fetch_blob(repo, digest, token)
+
+
+def _hexdump(data: bytes) -> str:
+    hex_lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i : i + 16]
+        hex_bytes = " ".join(f"{b:02x}" for b in chunk)
+        text = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        hex_lines.append(f"{i:08x}: {hex_bytes:<47} {text}")
+    return "\n".join(hex_lines)
+
+
+@bp.route("/fs/<path:repo>@<digest>/<path:subpath>", methods=["GET"])
+def fs_view(repo: str, digest: str, subpath: str):
+    render_mode = request.args.get("render")
+    try:
+        blob = asyncio.run(_read_layer(repo, digest))
+    except asyncio.TimeoutError:
+        return ("timeout", 504)
+    except ClientError as exc:
+        return (str(exc), 502)
+    except Exception:
+        return ("server error", 500)
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:*") as tar:
+        try:
+            member = tar.getmember(subpath)
+        except KeyError:
+            return ("not found", 404)
+        if member.isdir():
+            names = [m.name for m in tar.getmembers() if m.name.startswith(subpath) and m.name != subpath]
+            return render_template("oci_fs.html", repo=repo, digest=digest, path=subpath, items=names)
+        file_obj = tar.extractfile(member)
+        if not file_obj:
+            return ("not found", 404)
+        data = file_obj.read()
+    if render_mode == "hex":
+        return render_template("oci_hex.html", data=_hexdump(data), path=subpath)
+    if render_mode == "elf":
+        try:
+            from elftools.elf.elffile import ELFFile
+        except Exception:
+            return ("elf support missing", 500)
+        f = io.BytesIO(data)
+        try:
+            elf = ELFFile(f)
+            info = {"class": elf.elfclass, "entry": elf.header["e_entry"]}
+        except Exception:
+            info = {"error": "invalid elf"}
+        return render_template("oci_elf.html", info=json.dumps(info, indent=2), path=subpath)
+    return send_file(io.BytesIO(data), download_name=Path(subpath).name, as_attachment=False)
+
+
+@bp.route("/layers/<path:image>/<path:subpath>", methods=["GET"])
+def layer_dir(image: str, subpath: str):
+    try:
+        data = asyncio.run(_image_data(image))
+    except Exception:
+        return ("error", 500)
+    layers = data.get("manifest", {}).get("layers", [])
+    if not layers:
+        return ("no layers", 404)
+    digest = layers[0]["digest"]
+    repo = image.split(":")[0]
+    return fs_view(repo, digest, subpath)

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -1,0 +1,34 @@
+<!-- File: templates/oci_base.html -->
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title or 'Registry Explorer' }}</title>
+  <link rel="icon" href="/favicon.svg"/>
+  <style>
+  .retrorecon-root {
+    font-family: monospace;
+    width: fit-content;
+    overflow-wrap: anywhere;
+    padding: 12px;
+  }
+  .retrorecon-root pre { white-space: pre-wrap; }
+  .retrorecon-root .indent { margin-left: 2em; }
+  .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
+  .retrorecon-root .mt:hover { text-decoration: underline; }
+  .retrorecon-root .noselect {
+    user-select: none;
+    -webkit-user-select: none;
+    width: fit-content;
+    overflow-wrap: none;
+    padding-right: 1em;
+    text-align: right;
+    white-space: nowrap;
+  }
+  </style>
+</head>
+<body>
+<div class="retrorecon-root">
+{% block body %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/oci_elf.html
+++ b/templates/oci_elf.html
@@ -1,0 +1,6 @@
+<!-- File: templates/oci_elf.html -->
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1>{{ path }}</h1>
+<pre>{{ info }}</pre>
+{% endblock %}

--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -1,0 +1,11 @@
+<!-- File: templates/oci_fs.html -->
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1><a class="mt" href="/">Registry Explorer</a></h1>
+<h2>{{ repo }}@{{ digest }}: {{ path }}</h2>
+<ul>
+{% for name in items %}
+  <li><a class="mt" href="/fs/{{ repo }}@{{ digest }}/{{ name }}">{{ name }}</a></li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/oci_hex.html
+++ b/templates/oci_hex.html
@@ -1,0 +1,6 @@
+<!-- File: templates/oci_hex.html -->
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1>{{ path }}</h1>
+<pre>{{ data }}</pre>
+{% endblock %}

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -1,0 +1,16 @@
+<!-- File: templates/oci_image.html -->
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1><a class="mt" href="/">Registry Explorer</a></h1>
+<h2>{{ image }}</h2>
+<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md">gcrane</a> pull {{ image }}</h4>
+<pre>{{ data.manifest|tojson(indent=2) }}</pre>
+{% if data.layers %}
+<h3>First layer files</h3>
+<ul>
+{% for f in data.layers %}
+  <li><a class="mt" href="/fs/{{ image.split(':')[0] }}@{{ data.manifest.layers[0].digest }}/{{ f }}">{{ f }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/templates/oci_index.html
+++ b/templates/oci_index.html
@@ -1,0 +1,6 @@
+<!-- File: templates/oci_index.html -->
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1><a class="mt" href="/">Registry Explorer</a></h1>
+<p>Use /repo/&lt;name&gt; or /image/&lt;ref&gt; in the address bar.</p>
+{% endblock %}

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -1,0 +1,8 @@
+<!-- File: templates/oci_repo.html -->
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1><a class="mt" href="/">Registry Explorer</a></h1>
+<h2>{{ repo }}</h2>
+<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md">gcrane</a> ls --json {{ repo }} | jq .</h4>
+<pre>{{ data|tojson(indent=2) }}</pre>
+{% endblock %}

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -1,0 +1,82 @@
+import io
+import tarfile
+from pathlib import Path
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_repo_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.oci as oci
+
+    async def fake_fetch_json(self, url, user, repo):
+        return {"tags": ["v1"]}
+
+    async def fake_fetch_digest(self, url, user, repo):
+        return "sha256:d"
+
+    monkeypatch.setattr(oci.DockerRegistryClient, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(oci.DockerRegistryClient, "fetch_digest", fake_fetch_digest)
+
+    with app.app.test_client() as client:
+        resp = client.get("/repo/user/repo")
+        assert resp.status_code == 200
+        assert b"v1" in resp.data
+        assert b"sha256:d" in resp.data
+
+
+def test_image_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.oci as oci
+
+    async def fake_manifest(image, client=None):
+        return {"layers": [{"digest": "sha256:x"}]}
+
+    async def fake_list(image, digest, client=None):
+        return ["a.txt"]
+
+    monkeypatch.setattr(oci, "get_manifest", fake_manifest)
+    monkeypatch.setattr(oci, "list_layer_files", fake_list)
+
+    with app.app.test_client() as client:
+        resp = client.get("/image/user/repo:tag")
+        assert resp.status_code == 200
+        assert b"sha256:x" in resp.data
+        assert b"a.txt" in resp.data
+
+
+def test_fs_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.oci as oci
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo("a.txt")
+        data = b"hi"
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    tar_bytes = buf.getvalue()
+
+    async def fake_fetch_token(repo):
+        return "t"
+
+    async def fake_fetch_blob(repo, digest, token, session=None):
+        return tar_bytes
+
+    monkeypatch.setattr(oci, "fetch_token", fake_fetch_token)
+    monkeypatch.setattr(oci, "fetch_blob", fake_fetch_blob)
+
+    with app.app.test_client() as client:
+        resp = client.get("/fs/user/repo@sha256:x/a.txt")
+        assert resp.status_code == 200
+        assert resp.data == b"hi"
+


### PR DESCRIPTION
## Summary
- add `/tools/registry_explorer` with minimal templates
- implement repo/image/fs/layers routes under new `oci` blueprint
- support hex and ELF rendering
- add tests for new routes

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b8b4feac833289083e590813271e