### PR TITLE
Fix registry explorer routes and file links

### DIFF
--- a/app.py
+++ b/app.py
@@ -236,7 +236,14 @@ def capture_site(url: str, user_agent: str = '', spoof_referrer: bool = False) -
 
 @app.route('/', methods=['GET'])
 def index() -> str:
-    """Render the main search page."""
+    """Render the main search page or redirect to registry explorer views."""
+    repo_param = request.args.get("repo")
+    image_param = request.args.get("image")
+    if repo_param:
+        return redirect(url_for("oci.repo_view", repo=repo_param))
+    if image_param:
+        return redirect(url_for("oci.image_view", image=image_param))
+
     q = request.args.get('q', '').strip()
     select_all_matching = request.args.get('select_all_matching', 'false').lower() == 'true'
     try:

--- a/static/registry_explorer.js
+++ b/static/registry_explorer.js
@@ -93,7 +93,12 @@ function initRegistryExplorer(){
                '<th class="text-center no-resize">Delete</th>'+
                '</tr></thead><tbody>';
       for(const layer of plat.layers){
-        const files = layer.files.map(f=>`<li>${f}</li>`).join('');
+        const files = layer.files.map(f=>{
+          const p = f.split('/').map(encodeURIComponent).join('/');
+          const imgEnc = img.split('/').map(encodeURIComponent).join('/');
+          const href = `/layers/${imgEnc}/${p}`;
+          return `<li><a class="mt" href="${href}" target="_blank">${f}</a></li>`;
+        }).join('');
         const filesHtml = `<details><summary>${layer.files.length} files</summary><ul>${files}</ul></details>`;
         const dlink = `/download_layer?image=${encodeURIComponent(img)}&digest=${encodeURIComponent(layer.digest)}`;
         html += `<tr><td><div class="cell-content">${layer.digest}</div></td>`+

--- a/tests/test_oci_index.py
+++ b/tests/test_oci_index.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_index_repo_redirect(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/?repo=myrepo')
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/repo/myrepo')
+
+
+def test_index_image_redirect(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/?image=myimg:latest')
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/image/myimg:latest')

--- a/tests/test_registry_explorer.py
+++ b/tests/test_registry_explorer.py
@@ -136,13 +136,14 @@ def test_registry_explorer_file_listing(tmp_path, monkeypatch):
                 '</tr></thead><tbody>'
             )
             for layer in plat["layers"]:
-                files = "".join(f"<li>{f}</li>" for f in layer["files"])
+                files = "".join(
+                    f'<li><a class="mt" href="/layers/{img}/{f}">{f}</a></li>'
+                    for f in layer["files"]
+                )
                 files_html = (
                     f"<details><summary>{len(layer['files'])} files</summary><ul>{files}</ul></details>"
                 )
-                dlink = (
-                    f"/download_layer?image={img}&digest={layer['digest']}"
-                )
+                dlink = f"/download_layer?image={img}&digest={layer['digest']}"
                 html += (
                     f'<tr><td class="w-25em"><div class="cell-content">{layer["digest"]}</div></td>'
                     f'<td>{layer["size"]}</td><td>{files_html}</td>'


### PR DESCRIPTION
## Summary
- support `?repo=` and `?image=` query params in the index route
- make registry explorer file listings clickable
- update related tests and add coverage for new redirects

## Testing
- `npm run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`
- `python scripts/generate_midnight_themes.py`

------
https://chatgpt.com/codex/tasks/task_e_6851bc7f50b48332b2bf1b1f4fa225dc