### PR TITLE
Add standalone DAG Explorer page

### DIFF
--- a/retrorecon/routes/dag.py
+++ b/retrorecon/routes/dag.py
@@ -29,7 +29,7 @@ def dag_explorer_page():
 
 @bp.route("/tools/dag_explorer", methods=["GET"])
 def dag_explorer_full_page():
-    return app.index()
+    return render_template("dag_explorer_page.html")
 
 
 @bp.route("/dag/repo/<path:repo>", methods=["GET"])

--- a/templates/dag_explorer_page.html
+++ b/templates/dag_explorer_page.html
@@ -1,0 +1,83 @@
+<!-- File: templates/dag_explorer_page.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Registry Explorer</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
+  {% if current_theme %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
+  {% endif %}
+  <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" />
+  <style>
+  .retrorecon-root .mt:hover { text-decoration: underline; }
+  .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
+  .retrorecon-root .link { position: relative; bottom: .125em; }
+  .retrorecon-root .crane { height: 1em; width: 1em; }
+  .retrorecon-root .top { color: inherit; text-decoration: inherit; }
+  </style>
+</head>
+<body class="app">
+<div class="retrorecon-root">
+<h1><a class="top" href="/"><img class="crane" src="/favicon.svg"/> <span class="link">Registry Explorer</span></a></h1>
+<p>
+This beautiful tool allows you to <em>explore</em> the contents of a registry interactively.
+</p>
+<p>
+You can even drill down into layers to explore an image's filesystem.
+</p>
+<p>
+Enter a <strong>public</strong> image, e.g. <tt>"ubuntu:latest"</tt>:
+</p>
+<form action="/" method="GET" autocomplete="off" spellcheck="false">
+<input size="100" type="text" name="image" value="ubuntu:latest" />
+<input type="submit" />
+</form>
+<p></p>
+<p>
+Enter a <strong>public</strong> repository, e.g. <tt>"ubuntu"</tt>:
+</p>
+<form action="/" method="GET" autocomplete="off" spellcheck="false">
+<input size="100" type="text" name="repo" value="ubuntu" />
+<input type="submit" />
+</form>
+<p></p>
+<h4>Interesting examples</h4>
+<ul>
+  <li><a href="/?image=cgr.dev/chainguard/static:latest-glibc">cgr.dev/chainguard/static:latest-glibc</a></li>
+  <li><a href="/?image=gcr.io/distroless/static">gcr.io/distroless/static:latest</a></li>
+  <li><a href="/?repo=ghcr.io/homebrew/core/crane">ghcr.io/homebrew/core/crane</a></li>
+  <li><a href="/?repo=registry.k8s.io">registry.k8s.io</a></li>
+  <li><a href="/?image=registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig">registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig</a></li>
+  <li><a href="/?image=docker/dockerfile:1.5.1">docker/dockerfile:1.5.1</a></li>
+  <li><a href="/?image=pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760">pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760</a></li>
+  <li><a href="/?image=tianon/true:oci">tianon/true:oci</a></li>
+  <li><a href="/?image=ghcr.io/stargz-containers/node:13.13.0-esgz">ghcr.io/stargz-containers/node:13.13.0-esgz</a></li>
+</ul>
+<h3>FAQ</h3>
+<h4>How does this work?</h4>
+<p>
+This service lives on <a href="https://cloud.run">Cloud Run</a> and uses <a href="https://github.com/google/go-containerregistry">google/go-containerregistry</a> for registry interactions.
+</p>
+<h4>Isn't this expensive to run?</h4>
+<p>Not really! Ingress is cheap, Cloud Run is cheap, and GCS is cheap.</p>
+<p>To avoid paying for egress, I limit the amount of data that I'll serve directly and instead give you a command you can run on your own machine.</p>
+<p>The most expensive part of this is actually the domain name.</p>
+<h4>Isn't this expensive for the registry?</h4>
+<p>Not really! The first time a layer is accessed, I download and index it. Browsing the filesystem just uses that index, and opening a file uses Range requests to load small chunks of the layer as needed.</p>
+<p>Since I only have to download the whole layer once, this actually reduces traffic to the registry in a lot of cases, e.g. if you share a link with someone rather than having them pull the whole image on their machine.</p>
+<p>In fact, Docker has graciously sponsored this service by providing me an account with unlimited public Docker Hub access. Thanks, Docker!</p>
+<h4>That can't be true, gzip doesn't support random access!</h4>
+<p>
+That's not a question.
+</p>
+<h4>Okay then, how does random access work if the layers are gzipped tarballs?</h4>
+<p>Great question! See <a href="https://github.com/madler/zlib/blob/master/examples/zran.c">here</a>.</p>
+<p>Tl;dr, you can seek to an arbitrary position in a gzip stream if you know the 32KiB of uncompressed data that comes just before it, so by storing ~1% of the uncompressed layer size, I can jump ahead to predetermined locations and start reading from there rather than reading the entire layer.</p>
+<p>Thanks <a href="https://github.com/aidansteele">@aidansteele</a>!</p>
+<h4>Is this open source?</h4>
+<p>Yes! See <a href="https://github.com/jonjohnsonjr/dagdotdev">here</a>.</p>
+</div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- implement full-page DAG Explorer HTML page
- hook up `/tools/dag_explorer` route to render it

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851bedbf3e083329b3f0120acd106cc