### PR TITLE
Centralize DB storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.db
+db/*.db
 *.zip
 *.sqlite
 *.json
@@ -11,6 +11,8 @@ package-lock.json
 __pycache__/
 !reports/report.json
 last_db.txt
-static/screenshots/*
-static/sitezips/*
-venv/*
+static/screenshots/
+static/sitezips/
+logs/
+*.log
+venv/

--- a/database.py
+++ b/database.py
@@ -77,7 +77,9 @@ def create_new_db(name: Optional[str] = None) -> str:
     nm = _sanitize_db_name(name) if name else 'waybax.db'
     if nm is None:
         raise ValueError('Invalid database name.')
-    db_path = os.path.join(current_app.root_path, nm)
+    db_dir = os.path.join(current_app.root_path, 'db')
+    os.makedirs(db_dir, exist_ok=True)
+    db_path = os.path.join(db_dir, nm)
     if os.path.exists(db_path):
         os.remove(db_path)
     current_app.config['DATABASE'] = db_path

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -6,12 +6,12 @@ This document describes the tests required for the new database creation and ren
 
 1. **Create New DB with Name**
    - POST `/new_db` with `db_name=client1`.
-   - Verify a file `client1.db` is created and `session['db_display_name']` equals `client1.db`.
+   - Verify a file `db/client1.db` is created and `session['db_display_name']` equals `client1.db`.
    - Ensure tables exist by querying `urls`.
 
 2. **Create New DB with Default Name**
    - POST `/new_db` with no name.
-   - Expect file `waybax.db` and matching session value.
+   - Expect file `db/waybax.db` and matching session value.
 
 3. **Rename Database**
    - Start with a temporary database.

--- a/retrorecon/routes/db.py
+++ b/retrorecon/routes/db.py
@@ -12,7 +12,7 @@ def new_db():
         flash('Invalid database name.', 'error')
         return redirect(url_for('index'))
     app.close_connection(None)
-    temp_path = os.path.join(app.app.root_path, app.TEMP_DB_NAME)
+    temp_path = os.path.join(app.get_db_folder(), app.TEMP_DB_NAME)
     if app.app.config.get('DATABASE') == temp_path and os.path.exists(temp_path):
         os.remove(temp_path)
     try:
@@ -34,9 +34,9 @@ def load_db_route():
     if not filename:
         flash('Invalid database file.', 'error')
         return redirect(url_for('index'))
-    db_path = os.path.join(app.app.root_path, filename)
+    db_path = os.path.join(app.get_db_folder(), filename)
     app.close_connection(None)
-    temp_path = os.path.join(app.app.root_path, app.TEMP_DB_NAME)
+    temp_path = os.path.join(app.get_db_folder(), app.TEMP_DB_NAME)
     if app.app.config.get('DATABASE') == temp_path and os.path.exists(temp_path):
         os.remove(temp_path)
     try:
@@ -78,7 +78,7 @@ def rename_db():
         flash('No database loaded.', 'error')
         return redirect(url_for('index'))
     app.close_connection(None)
-    new_path = os.path.join(app.app.root_path, safe)
+    new_path = os.path.join(app.get_db_folder(), safe)
     try:
         os.rename(app.app.config['DATABASE'], new_path)
     except OSError as e:


### PR DESCRIPTION
## Summary
- keep database files under `db/`
- ensure DB folder is created and used throughout the app
- disable browser caching for every response
- ignore logs and local DBs
- update workflow tests and docs for new DB location

## Testing
- `npm install`
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851cf9786c48332981003c27ccf4a45