### PR TITLE
Update DAG Explorer UI

### DIFF
--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -10,6 +10,6 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: npm install
+        run: npm --prefix frontend install
       - name: Run linters
-        run: npm run lint
+        run: npm --prefix frontend run lint

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Install dependencies
         run: npm --prefix frontend install
       - name: Run linters
-        run: npm --prefix frontend run lint
+        run: npm  run lint

--- a/app.py
+++ b/app.py
@@ -264,6 +264,16 @@ def index() -> str:
         tool = 'screenshot'
     elif request.path == '/tools/subdomonster':
         tool = 'subdomonster'
+    elif request.path == '/tools/site2zip':
+        tool = 'site2zip'
+    elif request.path == '/tools/layerpeek':
+        tool = 'layerpeek'
+    elif request.path == '/tools/layerpeek-b':
+        tool = 'layerpeek-b'
+    elif request.path == '/tools/registry_viewer':
+        tool = 'registry'
+    elif request.path == '/tools/dag_explorer':
+        tool = 'dag'
 
     sort = request.args.get('sort', 'id')
     direction = request.args.get('dir', 'desc').lower()

--- a/templates/dag_explorer_page.html
+++ b/templates/dag_explorer_page.html
@@ -54,6 +54,7 @@ Enter a <strong>public</strong> repository, e.g. <tt>"ubuntu"</tt>:
   <li><a href="/image/tianon/true:oci">tianon/true:oci</a></li>
   <li><a href="/image/ghcr.io/stargz-containers/node:13.13.0-esgz">ghcr.io/stargz-containers/node:13.13.0-esgz</a></li>
 </ul>
+<p><a class="mt" href="/">Back to Dashboard</a></p>
 <script>
 document.getElementById('image-form').addEventListener('submit', ev => {
   ev.preventDefault();

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -7,9 +7,9 @@
   <style>
   .retrorecon-root {
     font-family: monospace;
-    width: fit-content;
     overflow-wrap: anywhere;
     padding: 12px;
+    width: 100%;
   }
   .retrorecon-root pre { white-space: pre-wrap; }
   .retrorecon-root .indent { margin-left: 2em; }

--- a/tests/test_dag_explorer.py
+++ b/tests/test_dag_explorer.py
@@ -91,3 +91,11 @@ def test_dag_layer_route(tmp_path, monkeypatch):
         resp = client.get('/dag/layer/sha256:x?image=user/repo:tag')
         assert resp.status_code == 200
         assert resp.get_json()['files'] == ['a.txt', 'b.txt']
+
+
+def test_dag_explorer_full_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/tools/dag_explorer')
+        assert resp.status_code == 200
+        assert b'Back to Dashboard' in resp.data

--- a/tests/test_layerpeek.py
+++ b/tests/test_layerpeek.py
@@ -18,3 +18,11 @@ def test_layerpeek_route(tmp_path, monkeypatch):
         resp = client.get('/layerpeek')
         assert resp.status_code == 200
         assert b'id="layerslayer-overlay"' in resp.data
+
+
+def test_layerpeek_full_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/tools/layerpeek')
+        assert resp.status_code == 200
+        assert b'openTool = "layerpeek"' in resp.data

--- a/tests/test_registry_viewer.py
+++ b/tests/test_registry_viewer.py
@@ -18,3 +18,11 @@ def test_registry_viewer_route(tmp_path, monkeypatch):
         resp = client.get('/registry_viewer')
         assert resp.status_code == 200
         assert b'id="registry-explorer-overlay"' in resp.data
+
+
+def test_registry_viewer_full_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/tools/registry_viewer')
+        assert resp.status_code == 200
+        assert b'openTool = "registry"' in resp.data


### PR DESCRIPTION
## Summary
- expand default width for OCI pages to remove white border
- add back link in DAG Explorer page
- set open tool flag for all /tools routes
- cover new routes in tests

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d326dfc08332b0472c6ea6c48499