### PR TITLE
Fix root lint commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "glob": "^10.3.10"
   },
   "scripts": {
-    "lint:css": "stylelint \"static/**/*.css\"",
-    "lint:inline": "node scripts/check_inline_styles.js",
-    "lint": "npm run lint:css && npm run lint:inline"
+    "lint": "npm --prefix frontend run lint",
+    "lint:css": "npm --prefix frontend run lint:css",
+    "lint:inline": "npm --prefix frontend run lint:inline"
   }
 }


### PR DESCRIPTION
## Summary
- call frontend linter scripts from the root package.json

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851da613a9c8332b2fc8a9b7d8b9400