### PR TITLE
Fix Stylelint errors

### DIFF
--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -165,6 +165,16 @@ body.bg-hidden {
   cursor: pointer;
   transition: opacity 0.2s;
 }
+.retrorecon-root .search-bar button {
+  font-size: 1.05em;
+  padding: 5px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--color-contrast);
+  background: var(--bg-color);
+  color: var(--fg-color);
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
 .retrorecon-root .tag-pill button:hover {
   box-shadow: none;
   opacity: 0.8;
@@ -191,6 +201,7 @@ body.bg-hidden {
   box-shadow: 0 0 6px var(--fg-color);
 }
 
+
 .retrorecon-root .search-history .tag-pill button {
   background: none;
   border: none;
@@ -203,43 +214,6 @@ body.bg-hidden {
 .retrorecon-root .search-history .tag-pill button:hover {
   box-shadow: none;
   opacity: 0.8;
-}
-
-.retrorecon-root .search-history .tag-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 10px;
-  background: var(--bg-color);
-  opacity: 1;
-  border-radius: 999px;
-  border: 1px solid var(--color-contrast);
-  margin-right: 4px;
-  font-size: 0.65em;
-  font-weight: 600;
-  margin-bottom: 4px;
-  color: var(--fg-color);
-  cursor: pointer;
-}
-
-.retrorecon-root .search-history .tag-pill button {
-  background: none;
-  border: none;
-  color: inherit;
-  font-size: 0.8em;
-  margin-left: 0.35em;
-  cursor: pointer;
-  transition: opacity 0.2s;
-}
-
-.retrorecon-root .search-bar button {
-  font-size: 1.05em;
-  padding: 5px 10px;
-  border-radius: 5px;
-  border: 1px solid var(--color-contrast);
-  background: var(--bg-color);
-  color: var(--fg-color);
-  cursor: pointer;
-  transition: opacity 0.2s;
 }
 
 .retrorecon-root .pagination {


### PR DESCRIPTION
## Summary
- clean up duplicate selectors in `theme-neon.css`
- reorder rules so more general selectors come first

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e08ae9008332bc6411dae75e2e80