### PR TITLE
Fix Dag Explorer white box rendering

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1121,3 +1121,12 @@ body.bg-hidden {
   margin-right: 0.5em;
   cursor: pointer;
 }
+
+/* Ensure preformatted output boxes match the theme */
+.retrorecon-root pre {
+  background: var(--bg-color);
+  color: var(--fg-color);
+  padding: 0.5em;
+  overflow-x: auto;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- avoid white background on Dag Explorer output

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e93c9b7c8332859e9cae73deee0f