### PR TITLE
UI support for opening stored DB files

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -257,6 +257,23 @@ Parameter:
 curl -X POST -F "db_file=@existing.db" http://localhost:5000/load_db
 ```
 
+### `GET /list_dbs`
+Return a JSON list of saved database filenames located in the server's db folder.
+
+```
+curl http://localhost:5000/list_dbs
+```
+
+### `POST /load_saved_db`
+Load one of the saved database files on the server.
+
+Parameter:
+- `db_name` – the filename returned from `list_dbs`.
+
+```
+curl -X POST -d "db_name=project.db" http://localhost:5000/load_saved_db
+```
+
 ### `GET /save_db`
 Download the currently loaded database. Use the optional `name` query parameter to specify the download filename.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,6 +80,10 @@
             <input type="file" name="db_file" accept=".db" required class="form-file d-none" id="load-db-file" />
             <button type="button" class="menu-btn" id="load-db-btn">Open SQLite Database</button>
           </form>
+          <form method="POST" action="/load_saved_db" class="menu-row" id="load-saved-db-form">
+            <input type="hidden" name="db_name" id="load-saved-db-name" />
+            <button type="button" class="menu-btn" id="load-saved-db-btn">Open Saved Database</button>
+          </form>
           <form method="POST" action="/rename_db" class="menu-row" id="rename-db-form">
             <input type="hidden" name="new_name" id="rename-db-name" />
             <button type="submit" class="menu-btn">Rename Database</button>
@@ -768,6 +772,30 @@
       loadInput.addEventListener('change', () => {
         if (loadInput.files.length) {
           loadForm.submit();
+        }
+      });
+    }
+
+    const loadSavedBtn = document.getElementById('load-saved-db-btn');
+    const loadSavedInput = document.getElementById('load-saved-db-name');
+    const loadSavedForm = document.getElementById('load-saved-db-form');
+    if (loadSavedBtn && loadSavedInput && loadSavedForm) {
+      loadSavedBtn.addEventListener('click', async () => {
+        try {
+          const resp = await fetch('/list_dbs');
+          const data = await resp.json();
+          const names = Array.isArray(data.dbs) ? data.dbs : [];
+          if (!names.length) {
+            alert('No saved databases found.');
+            return;
+          }
+          const choice = prompt('Select database to load:\n' + names.join('\n'));
+          if (choice && names.includes(choice)) {
+            loadSavedInput.value = choice;
+            loadSavedForm.submit();
+          }
+        } catch (e) {
+          alert('Error retrieving database list.');
         }
       });
     }


### PR DESCRIPTION
## Summary
- expose `/list_dbs` and `/load_saved_db` routes
- add "Open Saved Database" option in the File menu
- fetch database list via JS and submit selected DB for loading
- document the new endpoints
- test loading saved DB files

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e99f7fe88332ba7b3f7bc3e23ff0