### PR TITLE
Add link back to dashboard from DAG explorer

### DIFF
--- a/templates/dag_explorer_page.html
+++ b/templates/dag_explorer_page.html
@@ -20,6 +20,7 @@
 <body class="app">
 <div class="retrorecon-root">
 <h1><a class="top" href="/"><img class="crane" src="/favicon.svg"/> <span class="link">Registry Explorer</span></a></h1>
+<p><a class="mt" href="/">Back to Dashboard</a></p>
 <p>
 This beautiful tool allows you to <em>explore</em> the contents of a registry interactively.
 </p>

--- a/tests/test_dag_explorer.py
+++ b/tests/test_dag_explorer.py
@@ -25,6 +25,14 @@ def test_dag_explorer_page(tmp_path, monkeypatch):
         assert b'id="dag-explorer-overlay"' in resp.data
 
 
+def test_dag_explorer_full_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/tools/dag_explorer')
+        assert resp.status_code == 200
+        assert b'Back to Dashboard' in resp.data
+
+
 def test_dag_repo_route(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     import retrorecon.routes.dag as dag


### PR DESCRIPTION
## Summary
- add a `Back to Dashboard` link on the standalone DAG explorer page
- test that the full-page DAG explorer includes the link

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e97349a883329d5ed192e9ebcb68