### PR TITLE
Add list_dbs and load_saved_db Postman endpoints

### DIFF
--- a/retrorecon.postman.json
+++ b/retrorecon.postman.json
@@ -721,6 +721,54 @@
       }
     },
     {
+      "name": "GET /list_dbs",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/list_dbs?pattern=demo",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "list_dbs"
+          ],
+          "query": [
+            {
+              "key": "pattern",
+              "value": "demo"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /load_saved_db",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {
+              "key": "db_file",
+              "value": "example.db",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{base_url}}/load_saved_db",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "load_saved_db"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /set_theme",
       "request": {
         "method": "POST",

--- a/tests/postman/retrorecon.postman.json
+++ b/tests/postman/retrorecon.postman.json
@@ -721,6 +721,54 @@
       }
     },
     {
+      "name": "GET /list_dbs",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/list_dbs?pattern=demo",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "list_dbs"
+          ],
+          "query": [
+            {
+              "key": "pattern",
+              "value": "demo"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /load_saved_db",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {
+              "key": "db_file",
+              "value": "example.db",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{base_url}}/load_saved_db",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "load_saved_db"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /set_theme",
       "request": {
         "method": "POST",


### PR DESCRIPTION
## Summary
- update Postman collection with GET `/list_dbs` and POST `/load_saved_db`
- include example parameters for both requests
- regenerate test collection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ecd1c1b08332b603662ae5452d4c