### PR TITLE
Add DAG explorer forms

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -5,12 +5,12 @@
       "styled": 59
     },
     "input": {
-      "total": 25,
+      "total": 29,
       "styled": 15
     },
     "select": {
-      "total": 6,
-      "styled": 6
+      "total": 7,
+      "styled": 7
     },
     "checkbox": {
       "total": 7,

--- a/static/base.css
+++ b/static/base.css
@@ -1130,3 +1130,10 @@ body.bg-hidden {
   overflow-x: auto;
   border-radius: 4px;
 }
+
+/* Dag Explorer styles */
+.retrorecon-root .mt { color: inherit; text-decoration: inherit; }
+.retrorecon-root .mt:hover { text-decoration: underline; }
+.retrorecon-root .crane { height: 1em; width: 1em; }
+.retrorecon-root .link { position: relative; bottom: .125em; }
+.retrorecon-root .top { color: inherit; text-decoration: inherit; }

--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -1,5 +1,38 @@
 <!-- File: templates/dag_explorer.html -->
 <div id="dag-explorer-overlay" class="notes-overlay hidden">
+  <h1>
+    <a class="top" href="/">
+      <img class="crane" src="/favicon.svg"/>
+      <span class="link">Registry Explorer</span>
+    </a>
+  </h1>
+  <p>This beautiful tool allows you to <em>explore</em> the contents of a registry interactively.</p>
+  <p>You can even drill down into layers to explore an image's filesystem.</p>
+  <p>Enter a <strong>public</strong> image, e.g. <tt>"ubuntu:latest"</tt>:</p>
+  <form action="/" method="GET" autocomplete="off" spellcheck="false">
+    <input size="100" type="text" name="image" value="ubuntu:latest"/>
+    <input type="submit" />
+  </form>
+  <p></p>
+  <p>Enter a <strong>public</strong> repository, e.g. <tt>"ubuntu"</tt>:</p>
+  <form action="/" method="GET" autocomplete="off" spellcheck="false">
+    <input size="100" type="text" name="repo" value="ubuntu"/>
+    <input type="submit" />
+  </form>
+  <p></p>
+  <h4>Interesting examples</h4>
+  <ul>
+    <li><a href="/?image=cgr.dev/chainguard/static:latest-glibc">cgr.dev/chainguard/static:latest-glibc</a></li>
+    <li><a href="/?image=gcr.io/distroless/static">gcr.io/distroless/static:latest</a></li>
+    <li><a href="/?repo=ghcr.io/homebrew/core/crane">ghcr.io/homebrew/core/crane</a></li>
+    <li><a href="/?repo=registry.k8s.io">registry.k8s.io</a></li>
+    <li><a href="/?image=registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig">registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig</a></li>
+    <li><a href="/?image=docker/dockerfile:1.5.1">docker/dockerfile:1.5.1</a></li>
+    <li><a href="/?image=pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760">pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760</a></li>
+    <li><a href="/?image=tianon/true:oci">tianon/true:oci</a></li>
+    <li><a href="/?image=ghcr.io/stargz-containers/node:13.13.0-esgz">ghcr.io/stargz-containers/node:13.13.0-esgz</a></li>
+  </ul>
+
   <div class="mb-05">
     <input type="text" id="dag-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
     <button type="button" class="btn" id="dag-fetch-btn">Fetch Manifest</button>


### PR DESCRIPTION
## Summary
- embed forms for public image and repository into `dag_explorer.html`
- add minimal styles for DAG explorer UI in `base.css`
- update CSS audit report

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_6851f61a41988332b744b7a1b1890c00