### PR TITLE
Fix OCI image view for manifest indexes

### DIFF
--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -54,7 +54,12 @@ def repo_view(repo: str):
 async def _image_data(image: str) -> Dict[str, Any]:
     async with DockerRegistryClient() as client:
         manifest = await get_manifest(image, client=client)
-        layers = await list_layer_files(image, manifest["layers"][0]["digest"], client=client)
+        if manifest.get("manifests"):
+            digest = manifest["manifests"][0]["digest"]
+            manifest = await get_manifest(image, specific_digest=digest, client=client)
+        layers: List[str] = []
+        if manifest.get("layers"):
+            layers = await list_layer_files(image, manifest["layers"][0]["digest"], client=client)
     return {"manifest": manifest, "layers": layers}
 
 


### PR DESCRIPTION
## Summary
- support multi-platform images in `/image/<path>`
- test manifest index handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852008c46dc8332a56f63943379213e