### PR TITLE
Fix broken FS links

### DIFF
--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -9,7 +9,8 @@
 <h3>First layer files</h3>
 <ul>
 {% for f in data.layers %}
-  <li><a class="mt" href="/fs/{{ image.split(':')[0] }}@{{ data.manifest.layers[0].digest }}/{{ f }}">{{ f }}</a></li>
+  {% set fname = f.split(' ', 5)[5] %}
+  <li><a class="mt" href="/fs/{{ image.split(':')[0] }}@{{ data.manifest.layers[0].digest }}/{{ fname|replace(' ', '%20') }}">{{ f }}</a></li>
 {% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
## Summary
- fix file path links in OCI image view so they work with directories and spaces

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68520de9ff5083328eec0a6ec58cf9c0