### PR TITLE
Fix OCI image view slowness

### DIFF
--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -52,15 +52,13 @@ def repo_view(repo: str):
 
 
 async def _image_data(image: str) -> Dict[str, Any]:
+    """Return manifest information for ``image`` without downloading layers."""
     async with DockerRegistryClient() as client:
         manifest = await get_manifest(image, client=client)
         if manifest.get("manifests"):
             digest = manifest["manifests"][0]["digest"]
             manifest = await get_manifest(image, specific_digest=digest, client=client)
-        layers: List[str] = []
-        if manifest.get("layers"):
-            layers = await list_layer_files(image, manifest["layers"][0]["digest"], client=client)
-    return {"manifest": manifest, "layers": layers}
+    return {"manifest": manifest}
 
 
 @bp.route("/image/<path:image>", methods=["GET"])

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -3,15 +3,6 @@
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ image }}</h2>
-<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md">gcrane</a> pull {{ image }}</h4>
+<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
 <pre>{{ data.manifest|tojson(indent=2) }}</pre>
-{% if data.layers %}
-<h3>First layer files</h3>
-<ul>
-{% for f in data.layers %}
-  {% set fname = f.split(' ', 5)[5] %}
-  <li><a class="mt" href="/fs/{{ image.split(':')[0] }}@{{ data.manifest.layers[0].digest }}/{{ fname|replace(' ', '%20') }}">{{ f }}</a></li>
-{% endfor %}
-</ul>
-{% endif %}
 {% endblock %}

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -41,17 +41,12 @@ def test_image_route(tmp_path, monkeypatch):
     async def fake_manifest(image, client=None):
         return {"layers": [{"digest": "sha256:x"}]}
 
-    async def fake_list(image, digest, client=None):
-        return ["a.txt"]
-
     monkeypatch.setattr(oci, "get_manifest", fake_manifest)
-    monkeypatch.setattr(oci, "list_layer_files", fake_list)
 
     with app.app.test_client() as client:
         resp = client.get("/image/user/repo:tag")
         assert resp.status_code == 200
         assert b"sha256:x" in resp.data
-        assert b"a.txt" in resp.data
 
 
 def test_image_route_manifest_index(tmp_path, monkeypatch):
@@ -64,17 +59,12 @@ def test_image_route_manifest_index(tmp_path, monkeypatch):
         assert specific_digest == "sha256:d"
         return {"layers": [{"digest": "sha256:x"}]}
 
-    async def fake_list(image, digest, client=None):
-        return ["file.txt"]
-
     monkeypatch.setattr(oci, "get_manifest", fake_manifest)
-    monkeypatch.setattr(oci, "list_layer_files", fake_list)
 
     with app.app.test_client() as client:
         resp = client.get("/image/user/repo:tag")
         assert resp.status_code == 200
         assert b"sha256:x" in resp.data
-        assert b"file.txt" in resp.data
 
 
 def test_fs_route(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- speed up OCI image endpoint by skipping layer download
- show `crane manifest` command in the OCI image page
- adjust tests for new image view behavior

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685213b88ef883329f13447928962eeb