### PR TITLE
Implement dagdotdev route aliases

### DIFF
--- a/app.py
+++ b/app.py
@@ -722,6 +722,7 @@ from retrorecon.routes import (
     registry_bp,
     dag_bp,
     oci_bp,
+    dagdotdev_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -732,6 +733,7 @@ app.register_blueprint(docker_bp)
 app.register_blueprint(registry_bp)
 app.register_blueprint(dag_bp)
 app.register_blueprint(oci_bp)
+app.register_blueprint(dagdotdev_bp)
 
 
 @app.after_request

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -7,5 +7,6 @@ from .docker import bp as docker_bp
 from .registry import bp as registry_bp
 from .dag import bp as dag_bp
 from .oci import bp as oci_bp
+from .dagdotdev import bp as dagdotdev_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp']

--- a/retrorecon/routes/dagdotdev.py
+++ b/retrorecon/routes/dagdotdev.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+from aiohttp import ClientError
+from flask import Blueprint, jsonify, request
+
+from . import oci, dag
+from layerslayer.client import DockerRegistryClient
+from layerslayer.utils import parse_image_ref, registry_base_url
+
+bp = Blueprint("dagdotdev", __name__)
+
+
+@bp.route("/r/<path:ref>", methods=["GET"])
+def r_route(ref: str):
+    """Alias for repository or image views."""
+    if ":" in ref or "@" in ref:
+        return oci.image_view(ref)
+    return oci.repo_view(ref)
+
+
+@bp.route("/fs/<digest>/<path:path>", methods=["GET"])
+def fs_route(digest: str, path: str):
+    """Alias for ``/dag/fs`` route."""
+    return dag.dag_fs(digest, path)
+
+
+@bp.route("/layer/<digest>", methods=["GET"])
+def layer_route(digest: str):
+    """Alias for ``/dag/layer`` route."""
+    return dag.dag_layer(digest)
+
+
+@bp.route("/size/<digest>", methods=["GET"])
+def size_route(digest: str):
+    """Return the byte size of ``digest`` for ``image`` query."""
+    image = request.args.get("image")
+    if not image:
+        return jsonify({"error": "missing_image"}), 400
+
+    async def _fetch() -> int:
+        user, repo, _ = parse_image_ref(image)
+        url = f"{registry_base_url(user, repo)}/blobs/{digest}"
+        async with DockerRegistryClient() as client:
+            data = await client.fetch_bytes(url, user, repo)
+            return len(data)
+
+    try:
+        size = asyncio.run(_fetch())
+    except asyncio.TimeoutError:
+        return jsonify({"error": "timeout"}), 504
+    except ClientError as exc:
+        return jsonify({"error": "client_error", "details": str(exc)}), 502
+    except Exception as exc:  # pragma: no cover - unexpected
+        return jsonify({"error": "server_error", "details": str(exc)}), 500
+    return jsonify({"size": size})

--- a/tests/test_dagdotdev_routes.py
+++ b/tests/test_dagdotdev_routes.py
@@ -1,0 +1,111 @@
+import io
+import tarfile
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_r_repo_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dagdotdev as dd
+    import retrorecon.routes.oci as oci
+
+    async def fake_fetch_json(self, url, user, repo):
+        return {"tags": ["v1"]}
+
+    async def fake_fetch_digest(self, url, user, repo):
+        return "sha256:d"
+
+    monkeypatch.setattr(oci.DockerRegistryClient, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(oci.DockerRegistryClient, "fetch_digest", fake_fetch_digest)
+
+    with app.app.test_client() as client:
+        resp = client.get("/r/user/repo")
+        assert resp.status_code == 200
+        assert b"v1" in resp.data
+        assert b"sha256:d" in resp.data
+
+
+def test_r_image_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dagdotdev as dd
+    import retrorecon.routes.oci as oci
+
+    async def fake_manifest(image, client=None):
+        return {"layers": [{"digest": "sha256:x"}]}
+
+    monkeypatch.setattr(oci, "get_manifest", fake_manifest)
+
+    with app.app.test_client() as client:
+        resp = client.get("/r/user/repo:tag")
+        assert resp.status_code == 200
+        assert b"sha256:x" in resp.data
+
+
+def test_fs_alias_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dagdotdev as dd
+    import retrorecon.routes.dag as dag
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo("a.txt")
+        data = b"hello"
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    tar_bytes = buf.getvalue()
+
+    async def fake_fetch_bytes(self, url, user, repo):
+        return tar_bytes
+
+    monkeypatch.setattr(dag.DockerRegistryClient, "fetch_bytes", fake_fetch_bytes)
+
+    with app.app.test_client() as client:
+        resp = client.get("/fs/sha256:x/a.txt?image=user/repo:tag")
+        assert resp.status_code == 200
+        assert resp.data == b"hello"
+
+
+def test_layer_alias_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dagdotdev as dd
+    import retrorecon.routes.dag as dag
+
+    async def fake_list(image_ref, digest, client=None):
+        assert image_ref == "user/repo:tag"
+        assert digest == "sha256:x"
+        return ["a.txt", "b.txt"]
+
+    monkeypatch.setattr(dag, "list_layer_files", fake_list)
+
+    with app.app.test_client() as client:
+        resp = client.get("/layer/sha256:x?image=user/repo:tag")
+        assert resp.status_code == 200
+        assert resp.get_json()["files"] == ["a.txt", "b.txt"]
+
+
+def test_size_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dagdotdev as dd
+
+    async def fake_fetch_bytes(self, url, user, repo):
+        return b"abc"
+
+    monkeypatch.setattr(dd.DockerRegistryClient, "fetch_bytes", fake_fetch_bytes)
+
+    with app.app.test_client() as client:
+        resp = client.get("/size/sha256:x?image=user/repo:tag")
+        assert resp.status_code == 200
+        assert resp.get_json()["size"] == 3


### PR DESCRIPTION
## Summary
- add `dagdotdev` blueprint with aliases for `/r`, `/fs`, `/layer`, `/size`
- register blueprint in app
- test new routes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68522af8716c833297ea0b9d58baff51