### PR TITLE
Fix heavy layer fetching in registry explorer

### DIFF
--- a/retrorecon/routes/registry.py
+++ b/retrorecon/routes/registry.py
@@ -22,6 +22,7 @@ def registry_viewer_full_page():
 @bp.route('/registry_explorer', methods=['GET'])
 def registry_explorer_route():
     image = request.args.get('image')
+    files_flag = request.args.get('files', 'false').lower() in {'1', 'true', 'yes'}
     methods_param = request.args.get('methods')
     if methods_param:
         methods = [m.strip() for m in methods_param.split(',') if m.strip()]
@@ -32,8 +33,12 @@ def registry_explorer_route():
 
     async def _gather():
         if len(methods) == 1:
-            return await rex.gather_image_info_with_backend(image, methods[0])
-        return await rex.gather_image_info_multi(image, methods)
+            return await rex.gather_image_info_with_backend(
+                image, methods[0], fetch_files=files_flag
+            )
+        return await rex.gather_image_info_multi(
+            image, methods, fetch_files=files_flag
+        )
 
     async def _digest() -> str | None:
         return await rex.get_manifest_digest(image)

--- a/tests/test_registry_explorer.py
+++ b/tests/test_registry_explorer.py
@@ -26,7 +26,7 @@ def test_registry_explorer_route(tmp_path, monkeypatch):
     ]
     import retrorecon.routes.registry as reg
 
-    async def fake_gather(img, method="extension"):
+    async def fake_gather(img, method="extension", **kwargs):
         assert method == "extension"
         return sample
 
@@ -37,7 +37,7 @@ def test_registry_explorer_route(tmp_path, monkeypatch):
     monkeypatch.setattr(reg.rex, "get_manifest_digest", fake_digest)
 
     with app.app.test_client() as client:
-        resp = client.get("/registry_explorer?image=test/test:tag&method=extension")
+        resp = client.get("/registry_explorer?image=test/test:tag&method=extension&files=1")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["manifest"] == "sha256:d1"
@@ -48,7 +48,7 @@ def test_registry_explorer_timeout(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     import retrorecon.routes.registry as reg
 
-    async def fail_gather(img, method="extension"):
+    async def fail_gather(img, method="extension", **kwargs):
         raise asyncio.TimeoutError()
 
     monkeypatch.setattr(reg.rex, "gather_image_info_with_backend", fail_gather)
@@ -63,7 +63,7 @@ def test_registry_explorer_multi_methods(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     import retrorecon.routes.registry as reg
 
-    async def fake_multi(img, methods):
+    async def fake_multi(img, methods, **kwargs):
         assert set(methods) == {"extension", "layerslayer"}
         return {
             "extension": [
@@ -113,7 +113,7 @@ def test_registry_explorer_file_listing(tmp_path, monkeypatch):
     ]
     import retrorecon.routes.registry as reg
 
-    async def fake_gather(img, method="extension"):
+    async def fake_gather(img, method="extension", **kwargs):
         return sample
 
     async def fake_digest(img):
@@ -153,7 +153,7 @@ def test_registry_explorer_file_listing(tmp_path, monkeypatch):
         return html
 
     with app.app.test_client() as client:
-        resp = client.get("/registry_explorer?image=test/test:tag&method=extension")
+        resp = client.get("/registry_explorer?image=test/test:tag&method=extension&files=1")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["manifest"] == "sha256:d3"


### PR DESCRIPTION
## Summary
- avoid fetching layer file lists unless requested
- add `files` query option to `/registry_explorer`
- update registry explorer tests for new parameter

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522c6c37808332b924919fcf72d238