### PR TITLE
Hyperlink manifest layers in OCI image view

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,10 +49,12 @@ from retrorecon import (
     sitezip_utils,
     status as status_mod,
 )
+from retrorecon.filters import manifest_links
 
 app = Flask(__name__)
 sys.modules.setdefault('app', sys.modules[__name__])
 app.config.from_object(Config)
+app.add_template_filter(manifest_links, name="manifest_links")
 
 def get_db_folder() -> str:
     """Return the folder where database files are stored."""

--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from markupsafe import Markup, escape
+
+from layerslayer.utils import parse_image_ref, human_readable_size
+
+
+_SPEC_LINKS = {
+    "application/vnd.docker.distribution.manifest.v2+json": "https://github.com/opencontainers/image-spec/blob/main/manifest.md",
+    "application/vnd.docker.image.rootfs.diff.tar.gzip": "https://github.com/opencontainers/image-spec/blob/main/layer.md",
+    "application/vnd.docker.container.image.v1+json": "https://github.com/opencontainers/image-spec/blob/main/config.md",
+}
+
+
+def _link_media_type(media_type: str) -> str:
+    url = _SPEC_LINKS.get(media_type)
+    text = escape(media_type)
+    if url:
+        return f'<a class="mt" href="{url}">{text}</a>'
+    return text
+
+
+def _render_layer(layer: Dict[str, Any], repo: str) -> str:
+    media_type = str(layer.get("mediaType", ""))
+    digest = str(layer.get("digest", ""))
+    size = int(layer.get("size", 0) or 0)
+    digest_link = (
+        f'<a href="/fs/{repo}@{digest}?mt={escape(media_type)}&size={size}">{escape(digest)}</a>'
+    )
+    size_link = (
+        f'<a href="/size/{repo}@{digest}?mt={escape(media_type)}&size={size}">' \
+        f'<span title="{human_readable_size(size)}">{size}</span></a>'
+    )
+    parts = [
+        '{',
+        f'<div class="indent">"mediaType": "{_link_media_type(media_type)}",</div>',
+        f'<div class="indent">"digest": "{digest_link}",</div>',
+        f'<div class="indent">"size": {size_link}</div>',
+        '}',
+    ]
+    return "<br>".join(parts)
+
+
+def _render_obj(obj: Any, repo: str) -> str:
+    if isinstance(obj, dict):
+        lines = ['{']
+        items = list(obj.items())
+        for idx, (k, v) in enumerate(items):
+            comma = ',' if idx < len(items) - 1 else ''
+            if k == 'layers' and isinstance(v, list):
+                layer_lines = ['[']
+                for i, layer in enumerate(v):
+                    layer_html = _render_layer(layer, repo)
+                    layer_lines.append(f'<div class="indent">{layer_html}</div>' + (' ,' if i < len(v)-1 else ''))
+                layer_lines.append(']')
+                value_html = "<br>".join(layer_lines)
+            elif k == 'mediaType' and isinstance(v, str):
+                value_html = f'"{_link_media_type(v)}"'
+            else:
+                value_html = _render_obj(v, repo)
+            lines.append(f'<div class="indent">"{escape(k)}": {value_html}{comma}</div>')
+        lines.append('}')
+        return "<br>".join(lines)
+    if isinstance(obj, list):
+        lines = ['[']
+        for i, item in enumerate(obj):
+            comma = ',' if i < len(obj) - 1 else ''
+            lines.append(f'<div class="indent">{_render_obj(item, repo)}{comma}</div>')
+        lines.append(']')
+        return "<br>".join(lines)
+    if isinstance(obj, str):
+        return f'"{escape(obj)}"'
+    return escape(json.dumps(obj))
+
+
+def manifest_links(manifest: Dict[str, Any], image: str) -> Markup:
+    """Return HTML for ``manifest`` with layer digests and sizes hyperlinked."""
+    user, repo, _ = parse_image_ref(image)
+    repo_full = f"{user}/{repo}"
+    html = _render_obj(manifest, repo_full)
+    return Markup(html)
+

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -4,5 +4,5 @@
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ image }}</h2>
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
-<pre>{{ data.manifest|tojson(indent=2) }}</pre>
+<pre>{{ data.manifest|manifest_links(image) }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `manifest_links` filter to render manifest entries with links
- register the filter with Flask
- use the filter in `oci_image.html` to hyperlink layer digests and sizes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68523166a554833289ecad209e3447b5