### PR TITLE
Document Dag Explorer public registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - **Site2Zip** crawl a URL, generate a sitemap and download all assets as a ZIP
 - **LayerPeek** inspect Docker image layers from Docker Hub
 - **Registry Explorer** query image manifests from multiple backends
-- **Dag Explorer** list repository tags and view manifests via a simple browser
+- **Dag Explorer** list repository tags and view manifests via a simple browser; works with public registries like [ghcr.io](https://ghcr.io). Example: [oci.dag.dev/?image=ghcr.io/stargz-containers/node:13.13.0-esgz](https://oci.dag.dev/?image=ghcr.io/stargz-containers/node:13.13.0-esgz)
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/docs/dag_explorer_spec.md
+++ b/docs/dag_explorer_spec.md
@@ -1,0 +1,13 @@
+# Dag Explorer Use Cases
+
+The **Dag Explorer** overlay provides a lightweight browser for fetching image manifests and listing repository tags from any OCI registry.
+
+## Public Non-GitHub Repositories
+
+Dag Explorer is not limited to GitHub projects. You can inspect images from any publicly accessible registry by supplying the full reference. The following example uses the [stargz‑containers](https://github.com/containerd/stargz-snapshotter) Node image hosted on GitHub Container Registry:
+
+```
+https://oci.dag.dev/?image=ghcr.io/stargz-containers/node:13.13.0-esgz
+```
+
+Opening this link displays the image manifest and lets you browse its layers just like Docker Hub images.


### PR DESCRIPTION
## Summary
- add a short spec covering Dag Explorer use cases
- document that Dag Explorer works with public registries in README

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852329b287483328157f5af1a22d35e