### PR TITLE
Add test comparing local image output to remote

### DIFF
--- a/tests/test_image_route_equivalence.py
+++ b/tests/test_image_route_equivalence.py
@@ -1,0 +1,27 @@
+import requests
+from pathlib import Path
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_local_matches_remote(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        local_resp = client.get("/image/ubuntu:latest")
+        assert local_resp.status_code == 200
+        local_html = local_resp.get_data(as_text=True)
+
+    remote_resp = requests.get("https://oci.dag.dev/?image=ubuntu:latest", timeout=10)
+    remote_resp.raise_for_status()
+    remote_html = remote_resp.text
+
+    assert local_html == remote_html


### PR DESCRIPTION
## Summary
- add a failing test `test_image_route_equivalence` that compares the HTML from `/image/ubuntu:latest` with the HTML served by `https://oci.dag.dev/?image=ubuntu:latest`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_image_route_equivalence)*

------
https://chatgpt.com/codex/tasks/task_e_6852363895548332b6a71a7bde9d04b6