### PR TITLE
Fix fetching status location

### DIFF
--- a/static/layerpeek.js
+++ b/static/layerpeek.js
@@ -12,6 +12,7 @@ function initLayerpeek(){
   const infoDiv = document.getElementById('layerslayer-info');
   const consoleDiv = document.getElementById('layerslayer-console');
   const closeBtn = document.getElementById('layerslayer-close-btn');
+  const statusSpan = document.getElementById('layerslayer-status');
 
   function logStatus(msg){
     if(!consoleDiv) return;
@@ -122,7 +123,7 @@ function initLayerpeek(){
     startPolling();
     fetchBtn.disabled = true;
     const oldText = fetchBtn.textContent;
-    fetchBtn.textContent = 'Fetching...';
+    if(statusSpan) statusSpan.textContent = 'Fetching...';
     try {
       const resp = await fetch('/docker_layers?image=' + encodeURIComponent(img));
       if(resp.ok){
@@ -146,6 +147,7 @@ function initLayerpeek(){
     } finally {
       fetchBtn.disabled = false;
       fetchBtn.textContent = oldText;
+      if(statusSpan) statusSpan.textContent = '';
     }
   });
 

--- a/templates/layerslayer.html
+++ b/templates/layerslayer.html
@@ -4,6 +4,7 @@
     <input type="text" id="layerslayer-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
     <button type="button" class="btn" id="layerslayer-fetch-btn">Fetch</button>
     <button type="button" class="btn" id="layerslayer-close-btn">Close</button>
+    <span id="layerslayer-status" class="ml-05"></span>
   </div>
   <div id="layerslayer-info" class="mb-05"></div>
   <pre id="layerslayer-console" class="mb-05"></pre>


### PR DESCRIPTION
## Summary
- show a status text element on LayerPeek overlay
- update script to write status messages outside the Fetch button

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_local_matches_remote)*
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_68523a6d78a08332b2e0aae045d09a2b