### PR TITLE
Fix registry explorer links

### DIFF
--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -27,11 +27,9 @@ def _render_layer(layer: Dict[str, Any], repo: str) -> str:
     media_type = str(layer.get("mediaType", ""))
     digest = str(layer.get("digest", ""))
     size = int(layer.get("size", 0) or 0)
-    digest_link = (
-        f'<a href="/fs/{repo}@{digest}?mt={escape(media_type)}&size={size}">{escape(digest)}</a>'
-    )
+    digest_link = f'<a href="/fs/{repo}@{digest}">{escape(digest)}</a>'
     size_link = (
-        f'<a href="/size/{repo}@{digest}?mt={escape(media_type)}&size={size}">' \
+        f'<a href="/size/{digest}?image={escape(repo)}">'
         f'<span title="{human_readable_size(size)}">{size}</span></a>'
     )
     parts = [

--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -96,6 +96,7 @@ def _hexdump(data: bytes) -> str:
     return "\n".join(hex_lines)
 
 
+@bp.route("/fs/<path:repo>@<digest>", defaults={"subpath": ""}, methods=["GET"])
 @bp.route("/fs/<path:repo>@<digest>/<path:subpath>", methods=["GET"])
 def fs_view(repo: str, digest: str, subpath: str):
     render_mode = request.args.get("render")
@@ -108,6 +109,9 @@ def fs_view(repo: str, digest: str, subpath: str):
     except Exception:
         return ("server error", 500)
     with tarfile.open(fileobj=io.BytesIO(blob), mode="r:*") as tar:
+        if not subpath:
+            names = [m.name for m in tar.getmembers()]
+            return render_template("oci_fs.html", repo=repo, digest=digest, path="", items=names)
         try:
             member = tar.getmember(subpath)
         except KeyError:

--- a/static/dag_explorer.js
+++ b/static/dag_explorer.js
@@ -42,8 +42,8 @@ function initDagExplorer(){
     const mt = String(layer.mediaType || '');
     const digest = String(layer.digest || '');
     const size = Number(layer.size || layer.size_bytes || 0);
-    const digestLink = `<a href="/fs/${repo}@${digest}?mt=${encodeURIComponent(mt)}&size=${size}" class="mt layer-link" data-digest="${digest}">${escapeHtml(digest)}</a>`;
-    const sizeLink = `<a href="/size/${repo}@${digest}?mt=${encodeURIComponent(mt)}&size=${size}"><span title="${humanReadableSize(size)}">${size}</span></a>`;
+    const digestLink = `<a href="/fs/${repo}@${digest}" class="mt layer-link" data-digest="${digest}">${escapeHtml(digest)}</a>`;
+    const sizeLink = `<a href="/size/${digest}?image=${encodeURIComponent(repo)}"><span title="${humanReadableSize(size)}">${size}</span></a>`;
     return '{<br>'+
       `<div class="indent">"mediaType": "${linkMediaType(mt)}",</div>`+
       `<div class="indent">"digest": "${digestLink}",</div>`+


### PR DESCRIPTION
## Summary
- return file listing when `/fs/<repo>@<digest>` root path requested
- correct registry explorer links for layers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685244a4088c8332a0e707733c325060