### PR TITLE
Fix manifest HTML structure

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -11,6 +11,7 @@
     padding: 12px;
   }
   .retrorecon-root pre { white-space: pre-wrap; }
+  .retrorecon-root .manifest-json { white-space: pre-wrap; }
   .retrorecon-root .indent { margin-left: 2em; }
   .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
   .retrorecon-root .mt:hover { text-decoration: underline; }

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -3,5 +3,5 @@
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ image }}</h2>
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
-<pre>{{ data.manifest|manifest_links(image) }}</pre>
+<div class="manifest-json">{{ data.manifest|manifest_links(image) }}</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- clean up invalid nested tags when rendering OCI manifest

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852478b70648332bdfa720cc6dc4382