### PR TITLE
Fix manifest HTML in registry pages

### DIFF
--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -34,12 +34,12 @@ def _render_layer(layer: Dict[str, Any], repo: str) -> str:
     )
     parts = [
         '{',
-        f'<div class="indent">"mediaType": "{_link_media_type(media_type)}",</div>',
-        f'<div class="indent">"digest": "{digest_link}",</div>',
-        f'<div class="indent">"size": {size_link}</div>',
+        f'<span class="indent">"mediaType": "{_link_media_type(media_type)}",</span>',
+        f'<span class="indent">"digest": "{digest_link}",</span>',
+        f'<span class="indent">"size": {size_link}</span>',
         '}',
     ]
-    return "<br>".join(parts)
+    return "\n".join(parts)
 
 
 def _render_obj(obj: Any, repo: str) -> str:
@@ -52,23 +52,24 @@ def _render_obj(obj: Any, repo: str) -> str:
                 layer_lines = ['[']
                 for i, layer in enumerate(v):
                     layer_html = _render_layer(layer, repo)
-                    layer_lines.append(f'<div class="indent">{layer_html}</div>' + (' ,' if i < len(v)-1 else ''))
+                    suffix = ',' if i < len(v)-1 else ''
+                    layer_lines.append(f'<span class="indent">{layer_html}{suffix}</span>')
                 layer_lines.append(']')
-                value_html = "<br>".join(layer_lines)
+                value_html = "\n".join(layer_lines)
             elif k == 'mediaType' and isinstance(v, str):
                 value_html = f'"{_link_media_type(v)}"'
             else:
                 value_html = _render_obj(v, repo)
-            lines.append(f'<div class="indent">"{escape(k)}": {value_html}{comma}</div>')
+            lines.append(f'<span class="indent">"{escape(k)}": {value_html}{comma}</span>')
         lines.append('}')
-        return "<br>".join(lines)
+        return "\n".join(lines)
     if isinstance(obj, list):
         lines = ['[']
         for i, item in enumerate(obj):
             comma = ',' if i < len(obj) - 1 else ''
-            lines.append(f'<div class="indent">{_render_obj(item, repo)}{comma}</div>')
+            lines.append(f'<span class="indent">{_render_obj(item, repo)}{comma}</span>')
         lines.append(']')
-        return "<br>".join(lines)
+        return "\n".join(lines)
     if isinstance(obj, str):
         return f'"{escape(obj)}"'
     return escape(json.dumps(obj))

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -11,8 +11,8 @@
     padding: 12px;
   }
   .retrorecon-root pre { white-space: pre-wrap; }
-  .retrorecon-root .manifest-json { white-space: pre-wrap; }
-  .retrorecon-root .indent { margin-left: 2em; }
+  .retrorecon-root .manifest-json { white-space: pre; }
+  .retrorecon-root .indent { margin-left: 2em; display: block; }
   .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
   .retrorecon-root .mt:hover { text-decoration: underline; }
   .retrorecon-root .noselect {

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -3,5 +3,5 @@
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ image }}</h2>
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
-<div class="manifest-json">{{ data.manifest|manifest_links(image) }}</div>
+<pre class="manifest-json">{{ data.manifest|manifest_links(image) }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- switch manifest container back to `<pre>` and render spans
- tweak CSS for indented manifest sections
- update manifest HTML filter to use span-based markup

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68524a88775083329c84580edaf62d9f