### PR TITLE
Handle manifest list digests

### DIFF
--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -64,7 +64,7 @@ def test_image_route_manifest_index(tmp_path, monkeypatch):
     with app.app.test_client() as client:
         resp = client.get("/image/user/repo:tag")
         assert resp.status_code == 200
-        assert b"sha256:d" in resp.data
+        assert b'<a href="/?image=user/repo@sha256:d">sha256:d</a>' in resp.data
 
 
 def test_fs_route(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- extend `manifest_links` to link digests for manifest lists
- test the new filter behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685254abf780833287928c7dcc5eda19