### PR TITLE
Add OCI mirror golden rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,3 +177,14 @@ python scripts/generate_midnight_themes.py
 
 When creating new CSS, follow `STYLE_GUIDE.md` which mandates that selectors be scoped under `.retrorecon-root` using BEM-style naming. Running `npm run lint` checks for inline styles and standard Stylelint rules.
 
+## Golden Rule: OCI Mirror Parity
+
+Routes under `/image/` must mirror the behavior of the hosted service at [oci.dag.dev](https://oci.dag.dev). Example:
+
+```
+https://oci.dag.dev/?image=ubuntu%3Alatest    # canonical reference
+http://127.0.0.1:5000/image/ubuntu:latest     # must produce the same content
+```
+
+The local output should match the remote HTML and manifest data exactly. Do not fake results—always fetch real registry data.
+

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - **LayerPeek** inspect Docker image layers from Docker Hub
 - **Registry Explorer** query image manifests from multiple backends
 - **Dag Explorer** list repository tags and view manifests via a simple browser; works with public registries like [ghcr.io](https://ghcr.io). Example: [oci.dag.dev/?image=ghcr.io/stargz-containers/node:13.13.0-esgz](https://oci.dag.dev/?image=ghcr.io/stargz-containers/node:13.13.0-esgz)
+- **Golden Rule** the local route `http://127.0.0.1:5000/image/ubuntu:latest` must show the same output as `https://oci.dag.dev/?image=ubuntu%3Alatest`.
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -48,3 +48,7 @@ Key element defaults derived from `static/base.css`:
 Inputs, dropdowns, and other controls follow the same naming pattern (`.input`, `.dropdown`, `.dropdown--open`). Ensure every rule is scoped under `.retrorecon-root`.
 
 Adhering to these conventions keeps Retrorecon styles clear, maintainable, and easy to extend with additional themes.
+
+## Golden Rule: OCI Mirror Parity
+
+The example URL `https://oci.dag.dev/?image=ubuntu%3Alatest` defines the canonical output for image views. The local route `http://127.0.0.1:5000/image/ubuntu:latest` must render the same information with no fabricated data.


### PR DESCRIPTION
## Summary
- document golden rule that `/image/<ref>` must match `oci.dag.dev`
- highlight the rule in the style guide
- note the rule in README feature list

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68525979bb6c8332b5deab3f4ab4deb7