### PR TITLE
Add HTTP metadata to registry explorer

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -5,7 +5,7 @@
       "styled": 59
     },
     "input": {
-      "total": 29,
+      "total": 31,
       "styled": 15
     },
     "select": {

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -24,6 +24,22 @@
     text-align: right;
     white-space: nowrap;
   }
+  /* simple tab styling used by registry explorer pages */
+  input + label { display: inline-block; }
+  input { display: none; }
+  input ~ .tab { display: none; }
+  #tab1:checked ~ .tab.content1,
+  #tab2:checked ~ .tab.content2 { display: block; }
+  input + label {
+    border: 1px solid #999;
+    padding: 4px 12px;
+    border-radius: 4px 4px 0 0;
+    position: relative;
+    top: 1px;
+    opacity: 50%;
+  }
+  input:checked + label { opacity: 100%; }
+  input ~ .tab { border-top: 1px solid #999; padding-top: 0.5em; }
   </style>
 </head>
 <body>

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -2,6 +2,17 @@
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ image }}</h2>
+<input type="radio" name="tabs" id="tab1" checked>
+<label for="tab1">HTTP</label>
+<input type="radio" name="tabs" id="tab2">
+<label for="tab2">OCI</label>
+<div class="tab content1">
+{% for k, v in data.headers.items() %}
+{{ k }}: {{ v }}<br>
+{% endfor %}
+</div>
+<div class="tab content2">
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
 <pre class="manifest-json">{{ data.manifest|manifest_links(image) }}</pre>
+</div>
 {% endblock %}

--- a/tests/test_dagdotdev_routes.py
+++ b/tests/test_dagdotdev_routes.py
@@ -48,6 +48,11 @@ def test_r_image_route(tmp_path, monkeypatch):
 
     monkeypatch.setattr(oci, "get_manifest", fake_manifest)
 
+    async def fake_digest(image, client=None):
+        return "sha256:x"
+
+    monkeypatch.setattr(oci, "get_manifest_digest", fake_digest)
+
     with app.app.test_client() as client:
         resp = client.get("/r/user/repo:tag")
         assert resp.status_code == 200

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -43,6 +43,11 @@ def test_image_route(tmp_path, monkeypatch):
 
     monkeypatch.setattr(oci, "get_manifest", fake_manifest)
 
+    async def fake_digest(image, client=None):
+        return "sha256:x"
+
+    monkeypatch.setattr(oci, "get_manifest_digest", fake_digest)
+
     with app.app.test_client() as client:
         resp = client.get("/image/user/repo:tag")
         assert resp.status_code == 200
@@ -60,6 +65,11 @@ def test_image_route_manifest_index(tmp_path, monkeypatch):
         return {"layers": [{"digest": "sha256:x"}]}
 
     monkeypatch.setattr(oci, "get_manifest", fake_manifest)
+
+    async def fake_digest(image, client=None):
+        return "sha256:d"
+
+    monkeypatch.setattr(oci, "get_manifest_digest", fake_digest)
 
     with app.app.test_client() as client:
         resp = client.get("/image/user/repo:tag")


### PR DESCRIPTION
## Summary
- enrich image view with HTTP header info
- add tab styling in base template
- adjust tests for new headers

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_685257c7bfac8332b648aad1953477ea