### PR TITLE
Add manifest descriptor to HTTP tab

### DIFF
--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -68,7 +68,7 @@ def repo_view(repo: str):
 
 
 async def _image_data(image: str) -> Dict[str, Any]:
-    """Return manifest or index information for ``image`` along with basic HTTP headers."""
+    """Return manifest or index information for ``image`` along with HTTP details."""
     async with DockerRegistryClient() as client:
         manifest = await get_manifest(image, client=client)
         digest = await get_manifest_digest(image, client=client)
@@ -77,12 +77,18 @@ async def _image_data(image: str) -> Dict[str, Any]:
         if manifest.get("manifests")
         else "application/vnd.oci.image.manifest.v1+json"
     )
+    size = len(json.dumps(manifest))
     http_headers = {
         "Content-Type": media_type,
         "Docker-Content-Digest": digest or "",
-        "Content-Length": str(len(json.dumps(manifest))),
+        "Content-Length": str(size),
     }
-    return {"manifest": manifest, "headers": http_headers}
+    descriptor = {
+        "mediaType": media_type,
+        "digest": digest or "",
+        "size": size,
+    }
+    return {"manifest": manifest, "headers": http_headers, "descriptor": descriptor}
 
 
 async def _resolve_manifest(image: str) -> Dict[str, Any]:

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -10,9 +10,12 @@
 {% for k, v in data.headers.items() %}
 {{ k }}: {{ v }}<br>
 {% endfor %}
+<pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
 </div>
 <div class="tab content2">
+<pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
+</div>
+
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
 <pre class="manifest-json">{{ data.manifest|manifest_links(image) }}</pre>
-</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include a manifest descriptor JSON in `/image/<ref>` responses
- show descriptor under the HTTP tab and move full manifest outside the tabs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68525e367db083328860575ccda39377