### PR TITLE
Add OCI layer listing page

### DIFF
--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -29,7 +29,7 @@ def _render_layer(layer: Dict[str, Any], repo: str) -> str:
     size = int(layer.get("size", 0) or 0)
     digest_link = f'<a href="/fs/{repo}@{digest}">{escape(digest)}</a>'
     size_link = (
-        f'<a href="/size/{digest}?image={escape(repo)}">'
+        f'<a href="/size/{repo}@{digest}?mt={escape(media_type)}&size={size}">' 
         f'<span title="{human_readable_size(size)}">{size}</span></a>'
     )
     parts = [
@@ -48,7 +48,7 @@ def _render_manifest_entry(entry: Dict[str, Any], repo: str) -> str:
     size = int(entry.get("size", 0) or 0)
     digest_link = f'<a href="/?image={repo}@{digest}">{escape(digest)}</a>'
     size_link = (
-        f'<a href="/size/{digest}?image={escape(repo)}">'
+        f'<a href="/size/{repo}@{digest}?mt={escape(media_type)}&size={size}">' 
         f'<span title="{human_readable_size(size)}">{size}</span></a>'
     )
     parts = ["{"]

--- a/templates/oci_layer.html
+++ b/templates/oci_layer.html
@@ -1,0 +1,24 @@
+<!-- File: templates/oci_layer.html -->
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1><a class="mt" href="/">Registry Explorer</a></h1>
+<h2><a class="mt" href="/?repo={{ repo }}">{{ repo }}</a>@<a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type }}&size={{ size }}">{{ digest }}</a></h2>
+<input type="radio" name="tabs" id="tab1" checked>
+<label for="tab1">HTTP</label>
+<input type="radio" name="tabs" id="tab2">
+<label for="tab2">OCI</label>
+<div class="tab content1">
+Content-Type: <a class="mt" href="https://github.com/opencontainers/image-spec/blob/main/layer.md">{{ media_type }}</a><br>
+Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type }}&size={{ size }}">{{ digest }}</a><br>
+<span title="{{ size_hr }}">Content-Length: {{ size }}</span><br>
+</div>
+<div class="tab content2">
+<pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
+</div>
+<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz | sort -n -r -k3</h4>
+<pre>
+{% for line in lines %}
+{{ line }}
+{% endfor %}
+</pre>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `/size/<repo>@<digest>` route for HTML layer listing
- adjust manifest link filters to use the new path
- provide oci_layer template to display tar contents

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852624bd28c8332a6994683fd023914