### PR TITLE
Fix layers link for OCI image view

### DIFF
--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -267,3 +267,12 @@ def layer_dir(image: str, subpath: str):
     digest = layers[0]["digest"]
     repo = image.split(":")[0]
     return fs_view(repo, digest, subpath)
+
+
+@bp.route("/layers/<path:image>@<digest>/", defaults={"subpath": ""}, methods=["GET"])
+@bp.route("/layers/<path:image>@<digest>/<path:subpath>", methods=["GET"])
+def layer_digest_dir(image: str, digest: str, subpath: str):
+    """Browse ``digest`` from ``image`` starting at ``subpath``."""
+    user, repo, _ = parse_image_ref(image)
+    repo_full = f"{user}/{repo}"
+    return fs_view(repo_full, digest, subpath)

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -17,5 +17,5 @@
 </div>
 
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
-<pre class="manifest-json">{{ data.manifest|manifest_links(image) }}</pre>
+<pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest) }}</pre>
 {% endblock %}

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -52,6 +52,7 @@ def test_image_route(tmp_path, monkeypatch):
         resp = client.get("/image/user/repo:tag")
         assert resp.status_code == 200
         assert b"sha256:x" in resp.data
+        assert b'/layers/user/repo:tag@sha256:x/' in resp.data
 
 
 def test_image_route_manifest_index(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- hyperlink manifest `layers` key to `/layers/<image>@<digest>/`
- support `/layers/<image>@<digest>/` route in OCI blueprint
- adjust template to pass manifest digest to filter
- test for layers hyperlink

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852660bd4748332ae4ac2a8e409ccbe