### PR TITLE
Add docs example of local vs hosted Dag Explorer links

### DIFF
--- a/docs/dag_explorer_spec.md
+++ b/docs/dag_explorer_spec.md
@@ -11,3 +11,31 @@ https://oci.dag.dev/?image=ghcr.io/stargz-containers/node:13.13.0-esgz
 ```
 
 Opening this link displays the image manifest and lets you browse its layers just like Docker Hub images.
+
+## Local vs Hosted Links
+
+You can explore the same image using the local Dag Explorer or the hosted version on oci.dag.dev.
+
+Local server example:
+
+```
+http://127.0.0.1:5000/image/migueldisney/dev:TAE-254
+```
+
+This page links each layer to:
+
+```
+http://127.0.0.1:5000/layers/migueldisney/dev:TAE-254@sha256:2eb5ae5626329845e85d70a53694a99165471ae7970435ed4d4bad24933d963c/
+```
+
+Hosted equivalent:
+
+```
+https://oci.dag.dev/?image=migueldisney/dev:TAE-254
+```
+
+Layers open to:
+
+```
+https://oci.dag.dev/layers/migueldisney/dev:TAE-254@sha256:2eb5ae5626329845e85d70a53694a99165471ae7970435ed4d4bad24933d963c/
+```


### PR DESCRIPTION
## Summary
- document how the local Dag Explorer mirrors the hosted site
- fix example local layer link to include digest

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68526772a7988332a75fc9f7809756fc