### PR TITLE
Fix invalid layer tar handling

### DIFF
--- a/retrorecon/routes/dag.py
+++ b/retrorecon/routes/dag.py
@@ -90,15 +90,18 @@ def dag_fs(digest: str, path: str):
     except Exception as exc:
         return jsonify({"error": "server_error", "details": str(exc)}), 500
 
-    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:*") as tar:
-        try:
-            member = tar.getmember(path)
-        except KeyError:
-            return jsonify({"error": "not_found"}), 404
-        file_obj = tar.extractfile(member)
-        if not file_obj:
-            return jsonify({"error": "not_found"}), 404
-        data = file_obj.read()
+    try:
+        with tarfile.open(fileobj=io.BytesIO(blob), mode="r:*") as tar:
+            try:
+                member = tar.getmember(path)
+            except KeyError:
+                return jsonify({"error": "not_found"}), 404
+            file_obj = tar.extractfile(member)
+            if not file_obj:
+                return jsonify({"error": "not_found"}), 404
+            data = file_obj.read()
+    except tarfile.TarError:
+        return jsonify({"error": "invalid_blob"}), 415
     filename = Path(path).name
     return send_file(io.BytesIO(data), download_name=filename, as_attachment=False)
 

--- a/tests/test_dag_explorer.py
+++ b/tests/test_dag_explorer.py
@@ -78,6 +78,20 @@ def test_dag_fs_route(tmp_path, monkeypatch):
         assert resp.data == b'hello'
 
 
+def test_dag_fs_invalid_tar(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.dag as dag
+
+    async def fake_fetch_bytes(self, url, user, repo):
+        return b"invalid"
+
+    monkeypatch.setattr(dag.DockerRegistryClient, 'fetch_bytes', fake_fetch_bytes)
+    with app.app.test_client() as client:
+        resp = client.get('/dag/fs/sha256:x/a.txt?image=user/repo:tag')
+        assert resp.status_code == 415
+        assert resp.get_json()['error'] == 'invalid_blob'
+
+
 def test_dag_layer_route(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     import retrorecon.routes.dag as dag


### PR DESCRIPTION
## Summary
- return HTTP 415 for invalid layer blobs in OCI and DAG routes
- add unit tests for invalid tar blobs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68526ce1c28c8332b368325dfafecf8a