### PR TITLE
Clarify partial tar handling

### DIFF
--- a/docs/dag_explorer_spec.md
+++ b/docs/dag_explorer_spec.md
@@ -39,3 +39,7 @@ Layers open to:
 ```
 https://oci.dag.dev/layers/migueldisney/dev:TAE-254@sha256:2eb5ae5626329845e85d70a53694a99165471ae7970435ed4d4bad24933d963c/
 ```
+
+## Partial Tar Ranges
+
+Dag Explorer intentionally issues HTTP range requests to peek inside layer blobs. When about 32 KiB of uncompressed data before a target offset is available, the gzip stream can be repositioned to read arbitrary sections. Storing only ~1% of a layer allows directory listings without downloading the entire archive. As a result the data may appear as an "invalid tar" when viewed in full, but this is expected behavior.

--- a/docs/dagdotdev_porting_prd.md
+++ b/docs/dagdotdev_porting_prd.md
@@ -83,6 +83,7 @@ The following sections summarize key features and recommended Python implementat
 
 - **Environment Variables:** `CACHE_DIR`, `CACHE_BUCKET`, `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URL`, `AUTH`.
 - **Performance:** Consider async handlers for network-bound operations.
+- **Partial layer fetches:** Directory listings rely on HTTP range requests. By caching roughly 32 KiB of data before a target offset, the gzip stream can be jumped to arbitrary positions so only about 1% of a layer needs downloading. Tar warnings from truncated blobs are expected.
 - **Testing:** Write integration tests to ensure route parity and feature completeness.
 
 ### Why Is Retrorecon Slower?


### PR DESCRIPTION
## Summary
- document partial layer download behaviour
- note that truncated layers are expected

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853035ae1708332a53b7602a3781f8e