### PR TITLE
Fix repo browsing for public registries

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -4,6 +4,9 @@
 <title>{{ title or 'Registry Explorer' }}</title>
 <link rel="icon" href="/favicon.svg">
 <style>
+  :root {
+    color-scheme: light dark;
+  }
   .retrorecon-root {
     font-family: monospace;
     width: fit-content;
@@ -15,6 +18,9 @@
   .retrorecon-root .indent { margin-left: 2em; display: block; }
   .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
   .retrorecon-root .mt:hover { text-decoration: underline; }
+  .retrorecon-root .link { position: relative; bottom: .125em; }
+  .retrorecon-root .crane { height: 1em; width: 1em; }
+  .retrorecon-root .top { color: inherit; text-decoration: inherit; }
   .retrorecon-root .noselect {
     user-select: none;
     -webkit-user-select: none;

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -1,8 +1,22 @@
 <!-- File: templates/oci_repo.html -->
 {% extends 'oci_base.html' %}
 {% block body %}
-<h1><a class="mt" href="/">Registry Explorer</a></h1>
+<h1><a class="top" href="/"><img class="crane" src="/favicon.svg"/> <span class="link">Registry Explorer</span></a></h1>
 <h2>{{ repo }}</h2>
-<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md">gcrane</a> ls --json {{ repo }} | jq .</h4>
-<pre>{{ data|tojson(indent=2) }}</pre>
+<h4><span style="padding:0;" class="noselect">$ </span>curl -sL "{{ data_url }}" | jq .</h4>
+
+<div>{
+<div class="indent">
+  <div>"name": &#34;{{ data.name }}&#34;,</div>
+  <div>"child": [</div>
+  <div class="indent">
+  {% for child in data.child %}
+    <div>"<a href="/?repo={{ repo|urlencode }}%2F{{ child|urlencode }}">{{ child }}</a>",</div>
+  {% endfor %}
+  </div>
+  <div>],</div>
+  <div>"tags": {{ data.tags|tojson }},</div>
+  <div>"manifest": {{ data.manifest|tojson }}</div>
+</div>
+}</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- handle domain-only repos without Docker auth
- expose repository listing URL in repo view
- enhance registry explorer base styles
- show repository children as hyperlinks
- update tests for new workflow

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685358445a248332970b408954879560