### PR TITLE
Align DAG explorer routes with retrorecon style

### DIFF
--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -46,7 +46,7 @@ def _render_manifest_entry(entry: Dict[str, Any], repo: str, manifest_digest: st
     media_type = str(entry.get("mediaType", ""))
     digest = str(entry.get("digest", ""))
     size = int(entry.get("size", 0) or 0)
-    digest_link = f'<a href="/?image={repo}@{digest}">{escape(digest)}</a>'
+    digest_link = f'<a href="/image/{repo}@{digest}">{escape(digest)}</a>'
     size_link = (
         f'<a href="/size/{repo}@{digest}?mt={escape(media_type)}&size={size}">' 
         f'<span title="{human_readable_size(size)}">{size}</span></a>'

--- a/retrorecon/routes/dag.py
+++ b/retrorecon/routes/dag.py
@@ -69,11 +69,8 @@ def dag_image(image: str):
     return jsonify(data)
 
 
-@bp.route("/dag/fs/<digest>/<path:path>", methods=["GET"])
-def dag_fs(digest: str, path: str):
-    image = request.args.get("image")
-    if not image:
-        return jsonify({"error": "missing_image"}), 400
+@bp.route("/dag/fs/<path:image>@<digest>/<path:path>", methods=["GET"])
+def dag_fs(image: str, digest: str, path: str):
 
     async def _fetch() -> bytes:
         user, repo, _ = parse_image_ref(image)
@@ -107,11 +104,8 @@ def dag_fs(digest: str, path: str):
     return send_file(io.BytesIO(data), download_name=filename, as_attachment=False)
 
 
-@bp.route("/dag/layer/<digest>", methods=["GET"])
-def dag_layer(digest: str):
-    image = request.args.get("image")
-    if not image:
-        return jsonify({"error": "missing_image"}), 400
+@bp.route("/dag/layer/<path:image>@<digest>", methods=["GET"])
+def dag_layer(image: str, digest: str):
 
     async def _fetch() -> list[str]:
         async with DockerRegistryClient() as client:

--- a/retrorecon/routes/dagdotdev.py
+++ b/retrorecon/routes/dagdotdev.py
@@ -21,14 +21,20 @@ def r_route(ref: str):
 
 @bp.route("/fs/<digest>/<path:path>", methods=["GET"])
 def fs_route(digest: str, path: str):
-    """Alias for ``/dag/fs`` route."""
-    return dag.dag_fs(digest, path)
+    """Alias for ``/dag/fs`` route using ``image`` query."""
+    image = request.args.get("image")
+    if not image:
+        return jsonify({"error": "missing_image"}), 400
+    return dag.dag_fs(image, digest, path)
 
 
 @bp.route("/layer/<digest>", methods=["GET"])
 def layer_route(digest: str):
-    """Alias for ``/dag/layer`` route."""
-    return dag.dag_layer(digest)
+    """Alias for ``/dag/layer`` route using ``image`` query."""
+    image = request.args.get("image")
+    if not image:
+        return jsonify({"error": "missing_image"}), 400
+    return dag.dag_layer(image, digest)
 
 
 @bp.route("/size/<digest>", methods=["GET"])

--- a/static/dag_explorer.js
+++ b/static/dag_explorer.js
@@ -43,7 +43,7 @@ function initDagExplorer(){
     const digest = String(layer.digest || '');
     const size = Number(layer.size || layer.size_bytes || 0);
     const digestLink = `<a href="/fs/${repo}@${digest}" class="mt layer-link" data-digest="${digest}">${escapeHtml(digest)}</a>`;
-    const sizeLink = `<a href="/size/${digest}?image=${encodeURIComponent(repo)}"><span title="${humanReadableSize(size)}">${size}</span></a>`;
+    const sizeLink = `<a href="/size/${repo}@${digest}"><span title="${humanReadableSize(size)}">${size}</span></a>`;
     return '{<br>'+
       `<div class="indent">"mediaType": "${linkMediaType(mt)}",</div>`+
       `<div class="indent">"digest": "${digestLink}",</div>`+
@@ -132,7 +132,7 @@ function initDagExplorer(){
     const digest = link.dataset.digest;
     const img = imgInput.value.trim();
     if(!digest || !img) return;
-    const resp = await fetch(`/dag/layer/${encodeURIComponent(digest)}?image=${encodeURIComponent(img)}`);
+    const resp = await fetch(`/dag/layer/${encodeURIComponent(img)}@${encodeURIComponent(digest)}`);
     if(resp.ok){
       const data = await resp.json();
       output.textContent = data.files.join('\n');

--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -22,15 +22,15 @@
   <p></p>
   <h4>Interesting examples</h4>
   <ul>
-    <li><a href="/?image=cgr.dev/chainguard/static:latest-glibc">cgr.dev/chainguard/static:latest-glibc</a></li>
-    <li><a href="/?image=gcr.io/distroless/static">gcr.io/distroless/static:latest</a></li>
-    <li><a href="/?repo=ghcr.io/homebrew/core/crane">ghcr.io/homebrew/core/crane</a></li>
-    <li><a href="/?repo=registry.k8s.io">registry.k8s.io</a></li>
-    <li><a href="/?image=registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig">registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig</a></li>
-    <li><a href="/?image=docker/dockerfile:1.5.1">docker/dockerfile:1.5.1</a></li>
-    <li><a href="/?image=pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760">pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760</a></li>
-    <li><a href="/?image=tianon/true:oci">tianon/true:oci</a></li>
-    <li><a href="/?image=ghcr.io/stargz-containers/node:13.13.0-esgz">ghcr.io/stargz-containers/node:13.13.0-esgz</a></li>
+    <li><a href="/image/cgr.dev/chainguard/static:latest-glibc">cgr.dev/chainguard/static:latest-glibc</a></li>
+    <li><a href="/image/gcr.io/distroless/static">gcr.io/distroless/static:latest</a></li>
+    <li><a href="/repo/ghcr.io/homebrew/core/crane">ghcr.io/homebrew/core/crane</a></li>
+    <li><a href="/repo/registry.k8s.io">registry.k8s.io</a></li>
+    <li><a href="/image/registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig">registry.k8s.io/bom/bom:sha256-499bdf4cc0498bbfb2395f8bbaf3b7e9e407cca605aecc46b2ef1b390a0bc4c4.sig</a></li>
+    <li><a href="/image/docker/dockerfile:1.5.1">docker/dockerfile:1.5.1</a></li>
+    <li><a href="/image/pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760">pengfeizhou/test-oci:sha256-04eaff953b0066d7e4ea2e822eb5c31be0742fca494561336f0912fabc246760</a></li>
+    <li><a href="/image/tianon/true:oci">tianon/true:oci</a></li>
+    <li><a href="/image/ghcr.io/stargz-containers/node:13.13.0-esgz">ghcr.io/stargz-containers/node:13.13.0-esgz</a></li>
   </ul>
 
   <div class="mb-05">

--- a/templates/oci_layer.html
+++ b/templates/oci_layer.html
@@ -2,7 +2,7 @@
 {% extends 'oci_base.html' %}
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
-<h2><a class="mt" href="/?repo={{ repo }}">{{ repo }}</a>@<a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type }}&size={{ size }}">{{ digest }}</a></h2>
+<h2><a class="mt" href="/repo/{{ repo }}">{{ repo }}</a>@<a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type }}&size={{ size }}">{{ digest }}</a></h2>
 <input type="radio" name="tabs" id="tab1" checked>
 <label for="tab1">HTTP</label>
 <input type="radio" name="tabs" id="tab2">

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -11,7 +11,7 @@
   <div>"child": [</div>
   <div class="indent">
   {% for child in data.child %}
-    <div>"<a href="/?repo={{ repo|urlencode }}%2F{{ child|urlencode }}">{{ child }}</a>",</div>
+    <div>"<a href="/repo/{{ (repo ~ '/' ~ child)|urlencode }}">{{ child }}</a>",</div>
   {% endfor %}
   </div>
   <div>],</div>

--- a/tests/test_dag_explorer.py
+++ b/tests/test_dag_explorer.py
@@ -74,7 +74,7 @@ def test_dag_fs_route(tmp_path, monkeypatch):
 
     monkeypatch.setattr(dag.DockerRegistryClient, 'fetch_bytes', fake_fetch_bytes)
     with app.app.test_client() as client:
-        resp = client.get('/dag/fs/sha256:x/a.txt?image=user/repo:tag')
+        resp = client.get('/dag/fs/user/repo:tag@sha256:x/a.txt')
         assert resp.status_code == 200
         assert resp.data == b'hello'
 
@@ -89,7 +89,7 @@ def test_dag_fs_invalid_tar(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(dag.DockerRegistryClient, 'fetch_bytes', fake_fetch_bytes)
     with app.app.test_client() as client:
         caplog.set_level(logging.WARNING)
-        resp = client.get('/dag/fs/sha256:x/a.txt?image=user/repo:tag')
+        resp = client.get('/dag/fs/user/repo:tag@sha256:x/a.txt')
         assert resp.status_code == 415
         assert resp.get_json()['error'] == 'invalid_blob'
         assert any('invalid tar blob' in rec.message for rec in caplog.records)
@@ -107,6 +107,6 @@ def test_dag_layer_route(tmp_path, monkeypatch):
     monkeypatch.setattr(dag, 'list_layer_files', fake_list)
 
     with app.app.test_client() as client:
-        resp = client.get('/dag/layer/sha256:x?image=user/repo:tag')
+        resp = client.get('/dag/layer/user/repo:tag@sha256:x')
         assert resp.status_code == 200
         assert resp.get_json()['files'] == ['a.txt', 'b.txt']

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -113,7 +113,7 @@ def test_image_route_manifest_index(tmp_path, monkeypatch):
     with app.app.test_client() as client:
         resp = client.get("/image/user/repo:tag")
         assert resp.status_code == 200
-        assert b'<a href="/?image=user/repo@sha256:d">sha256:d</a>' in resp.data
+        assert b'<a href="/image/user/repo@sha256:d">sha256:d</a>' in resp.data
 
 
 def test_fs_route(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- update `manifest_links` to generate `/image/<image>@<digest>` URLs
- change overlay links in `dag_explorer.html` to path based routes
- switch `/dag/fs` and `/dag/layer` to accept image references in the path
- adjust `dagdotdev` alias routes for new parameters
- update JS to use new endpoints
- fix tests for updated paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536c73ef2c8332985093bedd24cba2