### PR TITLE
Fix registry overlay links to avoid invalid tar

### DIFF
--- a/static/registry_explorer.js
+++ b/static/registry_explorer.js
@@ -75,7 +75,7 @@ function initRegistryExplorer(){
     });
   }
 
-  function buildTables(plats, img){
+  function buildTables(plats, img, manifestDigest){
     let html = '';
     for(const plat of plats){
       const label = (plat.os || plat.architecture)
@@ -96,7 +96,9 @@ function initRegistryExplorer(){
         const files = layer.files.map(f=>{
           const p = f.split('/').map(encodeURIComponent).join('/');
           const imgEnc = img.split('/').map(encodeURIComponent).join('/');
-          const href = `/layers/${imgEnc}/${p}`;
+          const href = manifestDigest
+            ? `/layers/${imgEnc}@${manifestDigest}/${p}`
+            : `/layers/${imgEnc}/${p}`;
           return `<li><a class="mt" href="${href}" target="_blank">${f}</a></li>`;
         }).join('');
         const filesHtml = `<details><summary>${layer.files.length} files</summary><ul>${files}</ul></details>`;
@@ -124,10 +126,10 @@ function initRegistryExplorer(){
     if(data.results){
       for(const m of data.methods){
         html += `<h3>${m}</h3>`;
-        html += buildTables(data.results[m], imgRef);
+        html += buildTables(data.results[m], imgRef, data.manifest);
       }
     } else {
-      html = buildTables(data.platforms, imgRef);
+      html = buildTables(data.platforms, imgRef, data.manifest);
     }
     tableDiv.innerHTML = html;
     tableDiv.querySelectorAll('table').forEach(t=>{ attachSort(t); makeResizable(t,'registry-col-widths'); });

--- a/tests/test_registry_explorer.py
+++ b/tests/test_registry_explorer.py
@@ -122,7 +122,7 @@ def test_registry_explorer_file_listing(tmp_path, monkeypatch):
     monkeypatch.setattr(reg.rex, "gather_image_info_with_backend", fake_gather)
     monkeypatch.setattr(reg.rex, "get_manifest_digest", fake_digest)
 
-    def build_tables(plats, img):
+    def build_tables(plats, img, manifest):
         html = ""
         for plat in plats:
             html += f"<h4>{plat['os']}/{plat['architecture']}</h4>"
@@ -137,7 +137,7 @@ def test_registry_explorer_file_listing(tmp_path, monkeypatch):
             )
             for layer in plat["layers"]:
                 files = "".join(
-                    f'<li><a class="mt" href="/layers/{img}/{f}">{f}</a></li>'
+                    f'<li><a class="mt" href="/layers/{img}@{manifest}/{f}">{f}</a></li>'
                     for f in layer["files"]
                 )
                 files_html = (
@@ -157,6 +157,6 @@ def test_registry_explorer_file_listing(tmp_path, monkeypatch):
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["manifest"] == "sha256:d3"
-        html = build_tables(data["platforms"], "test/test:tag")
+        html = build_tables(data["platforms"], "test/test:tag", data["manifest"])
         assert "dir/file1" in html
         assert "dir/file2" in html


### PR DESCRIPTION
## Summary
- ensure registry explorer links use manifest digest for layer browsing
- update registry explorer tests for new link format

## Testing
- `pytest -q`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853734538608332940edc4ad97ead57