### PR TITLE
Improve repo JSON display

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,12 +50,13 @@ from retrorecon import (
     sitezip_utils,
     status as status_mod,
 )
-from retrorecon.filters import manifest_links
+from retrorecon.filters import manifest_links, oci_obj
 
 app = Flask(__name__)
 sys.modules.setdefault('app', sys.modules[__name__])
 app.config.from_object(Config)
 app.add_template_filter(manifest_links, name="manifest_links")
+app.add_template_filter(oci_obj, name="oci_obj")
 
 
 @app.route('/favicon.ico')

--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -121,3 +121,9 @@ def manifest_links(manifest: Dict[str, Any], image: str, digest: str = "") -> Ma
     html = _render_obj(manifest, repo_full, digest, image)
     return Markup(html)
 
+
+def oci_obj(obj: Any, repo: str) -> Markup:
+    """Return HTML representation for arbitrary OCI JSON structures."""
+    html = _render_obj(obj, repo)
+    return Markup(html)
+

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -15,8 +15,14 @@
   {% endfor %}
   </div>
   <div>],</div>
-  <div>"tags": {{ data.tags|tojson }},</div>
-  <div>"manifest": {{ data.manifest|tojson }}</div>
+  <div>"tags": [</div>
+  <div class="indent">
+  {% for tag in data.tags %}
+    <div>"<a href="/?image={{ (repo ~ ':' ~ tag)|urlencode }}">{{ tag }}</a>"{% if not loop.last %},{% endif %}</div>
+  {% endfor %}
+  </div>
+  ],</div>
+  <div>"manifest": {{ data.manifest|oci_obj(repo) }}</div>
 </div>
 }</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- make repository listing tags hyperlinked and multiline
- allow rendering generic OCI objects
- register the new filter in the app

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537b43809c83329c2c909a58d2ab45