### PR TITLE
Fix favicon references

### DIFF
--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -2,7 +2,7 @@
 <div id="dag-explorer-overlay" class="notes-overlay hidden">
   <h1>
     <a class="top" href="/">
-      <img class="crane" src="/favicon.svg"/>
+      <img class="crane" src="{{ url_for('favicon_svg') }}"/>
       <span class="link">Registry Explorer</span>
     </a>
   </h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
     {% endfor %}
     /* stylelint-enable */
   </style>
-  <link rel="shortcut icon" href="/favicon.ico">
+  <link rel="shortcut icon" href="{{ url_for('favicon_ico') }}">
 </head>
 <body class="app">
   <div class="retrorecon-root">

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>{{ title or 'Registry Explorer' }}</title>
-<link rel="icon" href="/favicon.svg">
+<link rel="icon" href="{{ url_for('favicon_svg') }}">
 <style>
   :root {
     color-scheme: light dark;

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -1,7 +1,7 @@
 <!-- File: templates/oci_repo.html -->
 {% extends 'oci_base.html' %}
 {% block body %}
-<h1><a class="top" href="/"><img class="crane" src="/favicon.svg"/> <span class="link">Registry Explorer</span></a></h1>
+<h1><a class="top" href="/"><img class="crane" src="{{ url_for('favicon_svg') }}"/> <span class="link">Registry Explorer</span></a></h1>
 <h2>{{ repo }}</h2>
 <h4><span style="padding:0;" class="noselect">$ </span>curl -sL "{{ data_url }}" | jq .</h4>
 


### PR DESCRIPTION
## Summary
- update templates to use `url_for` to resolve `/favicon.svg` and `/favicon.ico`

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853804b9da08332825003a2ab1d3ea9