### PR TITLE
Add hierarchical /fs explorer with search

### DIFF
--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -3,9 +3,17 @@
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ repo }}@{{ digest }}: {{ path }}</h2>
+<form method="get" class="mb-05">
+  <input type="text" name="q" value="{{ q }}" placeholder="Filter" class="form-input mr-05" />
+  <button type="submit" class="btn">Apply</button>
+</form>
 <ul>
-{% for name in items %}
-  <li><a class="mt" href="/fs/{{ repo }}@{{ digest }}/{{ name }}">{{ name }}</a></li>
+{% for item in items %}
+  <li>
+    <a class="mt" href="/fs/{{ repo }}@{{ digest }}/{{ item.path }}{% if q %}?q={{ q|urlencode }}{% endif %}">
+      {{ item.name }}{% if item.is_dir %}/{% endif %}
+    </a>
+  </li>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance OCI filesystem explorer with directory-level listings and search
- support filtered overlay view when browsing layers
- update HTML template to display directory links and search form
- add regression tests for new behavior

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538ceb26e48332aafd6f398adb4be8