### PR TITLE
Fix OCI file view styling

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -1,8 +1,9 @@
 
 <html>
 <head>
-<title>{{ title or 'Registry Explorer' }}</title>
-<link rel="icon" href="{{ url_for('favicon_svg') }}">
+  <title>{{ title or 'Registry Explorer' }}</title>
+  <link rel="icon" href="{{ url_for('favicon_svg') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
 <style>
   :root {
     color-scheme: light dark;


### PR DESCRIPTION
## Summary
- load base.css in `oci_base.html` so /fs pages match site theme

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68539782cccc8332a305d2d22cbedbdf