### PR TITLE
Improve navbar layout

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -337,7 +337,7 @@
 /* Navbar layout */
 .retrorecon-root .navbar {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   margin: 0 10px;
 }
@@ -354,6 +354,8 @@
 }
 .retrorecon-root .navbar__info {
   margin-left: 0;
+  display: flex;
+  align-items: center;
 }
 .retrorecon-root .navbar__title h1 {
   margin: 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -181,9 +181,10 @@
     </div>
   </div>
   <div class="navbar__title">
-      <h1></h1>
+      <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
+    </div>
+    <div class="navbar__info">
       <div id="import-status-block" class="db-info">
-        <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
         <span class="ml-01"><strong>Status:</strong></span>
         <span id="import-status-text">idle</span>
         <div id="import-progress-bar-container" class="d-none">


### PR DESCRIPTION
## Summary
- split navbar into 3 columns
- keep DB name centered
- align import status to the right column

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853a44cac508332bbcc1a07eda82024