### PR TITLE
Fix /image page styling

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -3,7 +3,6 @@
 <head>
   <title>{{ title or 'Registry Explorer' }}</title>
   <link rel="icon" href="{{ url_for('favicon_svg') }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
 <style>
   :root {
     color-scheme: light dark;


### PR DESCRIPTION
## Summary
- revert base.css for `oci_base.html` to restore dark background

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853a63b1cfc8332905a9452483ef81a