### PR TITLE
Improve navbar alignment

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -337,9 +337,10 @@
 /* Navbar layout */
 .retrorecon-root .navbar {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   margin: 0 10px;
+  width: 100%;
 }
 .retrorecon-root .navbar__menus {
   display: flex;
@@ -350,10 +351,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  justify-self: center;
   gap: 0.5em;
 }
 .retrorecon-root .navbar__info {
   margin-left: 0;
+  display: flex;
+  align-items: center;
+  justify-self: start;
 }
 .retrorecon-root .navbar__title h1 {
   margin: 0;
@@ -1028,6 +1033,7 @@
   display: flex;
   align-items: center;
   gap: 0.4em;
+  white-space: nowrap;
   font-size: 1em;
   letter-spacing: 0.04em;
   font-weight: bold;

--- a/templates/index.html
+++ b/templates/index.html
@@ -181,9 +181,10 @@
     </div>
   </div>
   <div class="navbar__title">
-      <h1></h1>
+      <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
+    </div>
+    <div class="navbar__info">
       <div id="import-status-block" class="db-info">
-        <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
         <span class="ml-01"><strong>Status:</strong></span>
         <span id="import-status-text">idle</span>
         <div id="import-progress-bar-container" class="d-none">


### PR DESCRIPTION
## Summary
- ensure navbar title is centered in its grid column
- align import status block to the left within the right column

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853a44cac508332bbcc1a07eda82024