### PR TITLE
Reduce logging noise when status queue is empty

### DIFF
--- a/retrorecon/status.py
+++ b/retrorecon/status.py
@@ -21,7 +21,11 @@ def pop_status() -> Optional[Tuple[str, str]]:
     with _STATUS_LOCK:
         if _STATUS_QUEUE:
             evt = _STATUS_QUEUE.popleft()
-            logger.debug("pop_status returning %s: %s (len=%d)", evt[0], evt[1], len(_STATUS_QUEUE))
+            logger.debug(
+                "pop_status returning %s: %s (len=%d)",
+                evt[0],
+                evt[1],
+                len(_STATUS_QUEUE),
+            )
             return evt
-    logger.debug("pop_status called but queue empty")
     return None


### PR DESCRIPTION
## Summary
- stop logging `pop_status` calls when the queue is empty

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853b2170e688332803041f6053b18dd