### PR TITLE
Fix digest links in Registry Explorer

### DIFF
--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -1,7 +1,7 @@
 {% extends 'oci_base.html' %}
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
-<h2>{{ image }}</h2>
+<h2>{{ display_image or image }}</h2>
 <input type="radio" name="tabs" id="tab1" checked>
 <label for="tab1">HTTP</label>
 <input type="radio" name="tabs" id="tab2">
@@ -16,6 +16,6 @@
 <pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
 </div>
 
-<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ image }} | jq .</h4>
+<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
 <pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest) }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support `/image/<repo>@<digest>` so digest links work
- show the digest in the image page header
- test new digest route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68559e9e8a24833282f2755648dd4e78