### PR TITLE
Fix results frame height

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -591,7 +591,8 @@ body {
   box-shadow: 0 1px 6px var(--fg-color);
   padding: 0.5em;
   flex: 1 1 auto;
-  min-height: 0;
+  /* Maintain visible frame even when no URLs are listed */
+  min-height: 810px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- keep the results table area at least 810px high

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a44b0cf48332beff689d822259de