### PR TITLE
Add Subdomonster export and CDX status

### DIFF
--- a/database.py
+++ b/database.py
@@ -49,6 +49,10 @@ def ensure_schema() -> None:
             cols = [row[1] for row in cur.fetchall()]
             if 'thumbnail_path' not in cols:
                 conn.execute("ALTER TABLE sitezips ADD COLUMN thumbnail_path TEXT")
+            cur = conn.execute("PRAGMA table_info(domains)")
+            cols = [row[1] for row in cur.fetchall()]
+            if 'cdx_indexed' not in cols:
+                conn.execute("ALTER TABLE domains ADD COLUMN cdx_indexed INTEGER DEFAULT 0")
             conn.commit()
         finally:
             conn.close()

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS domains (
     root_domain TEXT NOT NULL,
     subdomain TEXT NOT NULL,
     source TEXT NOT NULL,
+    cdx_indexed INTEGER DEFAULT 0,
     fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(subdomain, source)
 );

--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -6,6 +6,8 @@
     <label class="mr-05"><input type="radio" name="subdomonster-source" value="virustotal"> VirusTotal</label>
     <input type="text" id="subdomonster-api-key" class="form-input mr-05 hidden" placeholder="API key" />
     <button type="button" class="btn" id="subdomonster-fetch-btn">Fetch</button>
+    <button type="button" class="btn" id="subdomonster-export-csv-btn">Export CSV</button>
+    <button type="button" class="btn" id="subdomonster-export-md-btn">Export MD</button>
     <button type="button" class="btn" id="subdomonster-close-btn">Close</button>
   </div>
   <div id="subdomonster-table" class="mt-05"></div>


### PR DESCRIPTION
## Summary
- track if subdomains have been indexed
- export subdomain results as CSV or Markdown
- prompt to fetch CDX data when clicking a subdomain
- tests for exporting and marking CDX status

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c4aaa9588332a1a384c43d1fdf95