### PR TITLE
Fix digest path in layers view

### DIFF
--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -465,8 +465,9 @@ def layer_dir(image: str, subpath: str):
             404,
         )
     digest = layers[0]["digest"]
-    repo = image.split(":")[0]
-    return fs_view(repo, digest, subpath)
+    user, repo, _ = parse_image_ref(image)
+    repo_full = f"{user}/{repo}"
+    return fs_view(repo_full, digest, subpath)
 
 
 @bp.route("/layers/<path:image>@<digest>/", defaults={"subpath": ""}, methods=["GET"])


### PR DESCRIPTION
## Summary
- handle images with digests in `/layers/<image>/` route correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855ca37f8b4833280895414ad02cefe