### PR TITLE
Fix /image size hyperlink

### DIFF
--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -17,5 +17,5 @@
 </div>
 
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
-<pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest) }}</pre>
+<pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest, link_size=False) }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add link_size option to manifest rendering helpers
- disable size hyperlinking in image route template
- verify image page has no /size links

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e56d3a808332adac3b12b519107e