### PR TITLE
Add close button to OCI image view

### DIFF
--- a/static/oci_image.js
+++ b/static/oci_image.js
@@ -1,0 +1,16 @@
+function initImagePage(){
+  const btn = document.getElementById('image-close-btn');
+  if(!btn) return;
+  btn.addEventListener('click', () => {
+    if(window.history.length > 1){
+      window.history.back();
+    } else {
+      window.location.href = '/';
+    }
+  });
+}
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initImagePage);
+}else{
+  initImagePage();
+}

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -1,6 +1,7 @@
 {% extends 'oci_base.html' %}
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
+<button type="button" class="btn" id="image-close-btn">Close</button>
 <h2>{{ display_image or image }}</h2>
 <input type="radio" name="tabs" id="tab1" checked>
 <label for="tab1">HTTP</label>
@@ -18,4 +19,5 @@
 
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
 <pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest) }}</pre>
+<script src="{{ url_for('static', filename='oci_image.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a Close button to OCI image template
- provide JS to navigate back or home when closing

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855e8f120bc8332bb9abecf188b71a4