### PR TITLE
Implement ociTaglister

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,8 @@ from flask import (
     jsonify,
     Response,
 )
+
+import retrorecon.routes.oci as oci  # for direct repo/image views
 from markupsafe import escape
 from config import Config
 from database import (
@@ -264,13 +266,13 @@ def delete_subdomain(root_domain: str, subdomain: str) -> None:
 
 @app.route('/', methods=['GET'])
 def index() -> str:
-    """Render the main search page or redirect to registry explorer views."""
+    """Render the main search page or serve registry explorer views."""
     repo_param = request.args.get("repo")
     image_param = request.args.get("image")
     if repo_param:
-        return redirect(url_for("oci.repo_view", repo=repo_param))
+        return oci.repo_view(repo_param)
     if image_param:
-        return redirect(url_for("oci.image_view", image=image_param))
+        return oci.image_view(image_param)
 
     q = request.args.get('q', '').strip()
     select_all_matching = request.args.get('select_all_matching', 'false').lower() == 'true'

--- a/tests/test_oci_index.py
+++ b/tests/test_oci_index.py
@@ -12,17 +12,41 @@ def setup_tmp(monkeypatch, tmp_path):
     (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
 
 
-def test_index_repo_redirect(tmp_path, monkeypatch):
+def test_index_repo_view(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.oci as oci
+
+    async def fake_fetch_json(self, url, user, repo):
+        return {"tags": ["v1"]}
+
+    async def fake_fetch_digest(self, url, user, repo):
+        return "sha256:d"
+
+    monkeypatch.setattr(oci.DockerRegistryClient, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(oci.DockerRegistryClient, "fetch_digest", fake_fetch_digest)
+
     with app.app.test_client() as client:
-        resp = client.get('/?repo=myrepo')
-        assert resp.status_code == 302
-        assert resp.headers['Location'].endswith('/repo/myrepo')
+        resp = client.get('/?repo=user/repo')
+        assert resp.status_code == 200
+        assert b"v1" in resp.data
+        assert b"sha256:d" in resp.data
 
 
-def test_index_image_redirect(tmp_path, monkeypatch):
+def test_index_image_view(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
+    import retrorecon.routes.oci as oci
+
+    async def fake_manifest(image, client=None):
+        return {"layers": [{"digest": "sha256:x"}]}
+
+    monkeypatch.setattr(oci, "get_manifest", fake_manifest)
+
+    async def fake_digest(image, client=None):
+        return "sha256:x"
+
+    monkeypatch.setattr(oci, "get_manifest_digest", fake_digest)
+
     with app.app.test_client() as client:
-        resp = client.get('/?image=myimg:latest')
-        assert resp.status_code == 302
-        assert resp.headers['Location'].endswith('/image/myimg:latest')
+        resp = client.get('/?image=user/repo:tag')
+        assert resp.status_code == 200
+        assert b"sha256:x" in resp.data


### PR DESCRIPTION
## Summary
- return repo/image views directly when `repo` or `image` query is provided
- update tests for new behavior

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ef249f6c833298615381445b4019