### PR TITLE
Improve /layers overlay listing

### DIFF
--- a/templates/oci_overlay.html
+++ b/templates/oci_overlay.html
@@ -1,0 +1,23 @@
+{% extends 'oci_base.html' %}
+{% block body %}
+<h1><a class="top" href="/"><img class="crane" src="{{ url_for('favicon_svg') }}"/> <span class="link">Registry Explorer</span></a></h1>
+<h2><a class="mt" href="/?repo={{ repo }}">{{ repo }}</a>@<a class="mt" href="/?image={{ image }}&mt={{ headers['Content-Type']|urlencode }}">{{ digest }}</a></h2>
+<input type="radio" name="tabs" id="tab1" checked>
+<label for="tab1">HTTP</label>
+<input type="radio" name="tabs" id="tab2">
+<label for="tab2">OCI</label>
+<div class="tab content1">
+Content-Type: <a class="mt" href="https://github.com/opencontainers/image-spec/blob/main/manifest.md">{{ headers['Content-Type'] }}</a><br>
+Docker-Content-Digest: <a class="mt" href="/?image={{ repo }}@{{ digest }}&mt={{ headers['Content-Type']|urlencode }}&size={{ descriptor.size }}">{{ digest }}</a><br>
+<span title="{{ descriptor_size_hr }}">Content-Length: {{ descriptor.size }}</span><br>
+</div>
+<div class="tab content2">
+<pre class="manifest-json">{{ descriptor|tojson(indent=2) }}</pre>
+</div>
+<h4><span style="padding:0;" class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md">export</a> {{ image }} | tar -tv{% if path %} {{ path }}{% endif %}</h4>
+<pre>
+{% for it in items %}
+<a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a> {{ it.perms }} {{ it.owner }} <span title="{{ it.size_hr }}">{{ '%12s'|format(it.size) }}</span> {{ it.ts }} <a href="{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a>
+{% endfor %}
+</pre>
+{% endblock %}

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -263,8 +263,8 @@ def test_layers_overlay_listing(tmp_path, monkeypatch):
 
     async def fake_list(image_ref, digest, client=None):
         if digest == "sha256:a":
-            return ["-rw-r--r-- 0/0 0 2024-01-01 foo.txt"]
-        return ["-rw-r--r-- 0/0 0 2024-01-01 bar.txt"]
+            return ["-rw-r--r-- 0/0 0 2024-01-01 00:00 foo.txt"]
+        return ["-rw-r--r-- 0/0 0 2024-01-01 00:00 bar.txt"]
 
     monkeypatch.setattr(oci, "list_layer_files", fake_list)
 
@@ -296,8 +296,11 @@ def test_layers_overlay_listing(tmp_path, monkeypatch):
     with app.app.test_client() as client:
         resp = client.get("/layers/user/repo:tag@sha256:m/")
         assert resp.status_code == 200
-        assert b"foo.txt" in resp.data
-        assert b"bar.txt" in resp.data
+        html = resp.data.decode()
+        assert "foo.txt" in html
+        assert "bar.txt" in html
+        assert '/fs/user/repo@sha256:a' in html
+        assert 'href="foo.txt"' in html
 
         resp = client.get("/layers/user/repo:tag@sha256:m/foo.txt")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- enhance overlay view to show manifest details and tar-style listing
- add new `oci_overlay.html` template
- test updated overlay page behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f555be288332ba048520a10edc98