### PR TITLE
Fix FS listing paths

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -1,12 +1,12 @@
 {
   "coverage": {
     "button": {
-      "total": 59,
-      "styled": 59
+      "total": 63,
+      "styled": 63
     },
     "input": {
-      "total": 31,
-      "styled": 15
+      "total": 36,
+      "styled": 16
     },
     "select": {
       "total": 7,

--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -302,7 +302,12 @@ def _list_children(tar: tarfile.TarFile, subpath: str) -> list[dict[str, Any]]:
         child_path = prefix + name
         if mapping[name] and not child_path.endswith("/"):
             child_path += "/"
-        items.append({"name": name, "path": child_path, "is_dir": mapping[name]})
+        display_path = "/" + child_path
+        items.append({
+            "name": name,
+            "path": display_path,
+            "is_dir": mapping[name],
+        })
     return items
 
 
@@ -443,10 +448,11 @@ def _overlay_view(image: str, digest: str, subpath: str):
         child_path = prefix + name
         if mapping[name] and not child_path.endswith("/"):
             child_path += "/"
+        display_path = "/" + child_path
         digest_val, _, perms, owner, size, ts = overlay.get(child_path, ("", False, "", "", "0", ""))
         items.append({
             "name": name,
-            "path": child_path,
+            "path": display_path,
             "is_dir": mapping[name],
             "digest": digest_val,
             "perms": perms,

--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -10,7 +10,7 @@
 <ul>
 {% for item in items %}
   <li>
-    <a class="mt" href="/fs/{{ repo }}@{{ digest }}/{{ item.path }}{% if q %}?q={{ q|urlencode }}{% endif %}">
+    <a class="mt" href="/fs/{{ repo }}@{{ digest }}{{ item.path }}{% if q %}?q={{ q|urlencode }}{% endif %}">
       {{ item.name }}{% if item.is_dir %}/{% endif %}
     </a>
   </li>

--- a/templates/oci_overlay.html
+++ b/templates/oci_overlay.html
@@ -17,7 +17,7 @@ Docker-Content-Digest: <a class="mt" href="/?image={{ repo }}@{{ digest }}&mt={{
 <h4><span style="padding:0;" class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md">export</a> {{ image }} | tar -tv{% if path %} {{ path }}{% endif %}</h4>
 <pre>
 {% for it in items %}
-<a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a> {{ it.perms }} {{ it.owner }} <span title="{{ it.size_hr }}">{{ '%12s'|format(it.size) }}</span> {{ it.ts }} <a href="{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a>
+<a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a> {{ it.perms }} {{ it.owner }} <span title="{{ it.size_hr }}">{{ '%12s'|format(it.size) }}</span> {{ it.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a>
 {% endfor %}
 </pre>
 {% endblock %}

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -300,7 +300,7 @@ def test_layers_overlay_listing(tmp_path, monkeypatch):
         assert "foo.txt" in html
         assert "bar.txt" in html
         assert '/fs/user/repo@sha256:a' in html
-        assert 'href="foo.txt"' in html
+        assert 'href="/fs/user/repo@sha256:m/foo.txt"' in html
 
         resp = client.get("/layers/user/repo:tag@sha256:m/foo.txt")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- ensure filesystem listings use absolute paths
- fix overlay view links to /fs route
- update tests for new paths

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6855fb3600bc833285b33dad82ecbdb3