### PR TITLE
Fix text file rendering on /fs route

### DIFF
--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -474,12 +474,18 @@ def fs_view(repo: str, digest: str, subpath: str):
         return render_template(
             "oci_elf.html", info=json.dumps(info, indent=2), path=subpath
         )
+    mimetype = None
     if render_mode is None:
         mt, _ = mimetypes.guess_type(subpath)
-        if not (mt and mt.startswith("text/")) and not _is_text(data):
+        is_text = (mt and mt.startswith("text/")) or _is_text(data)
+        if not is_text:
             return render_template("oci_hex.html", data=_hexdump(data), path=subpath)
+        mimetype = mt or "text/plain"
     return send_file(
-        io.BytesIO(data), download_name=Path(subpath).name, as_attachment=False
+        io.BytesIO(data),
+        download_name=Path(subpath).name,
+        as_attachment=False,
+        mimetype=mimetype,
     )
 
 

--- a/tests/test_oci_fs.py
+++ b/tests/test_oci_fs.py
@@ -60,3 +60,21 @@ def test_fs_binary_hex(tmp_path, monkeypatch):
         assert resp.status_code == 200
         assert b'00000000:' in resp.data
 
+
+def test_fs_text_file_no_ext(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    from retrorecon.routes import oci
+
+    tar_bytes = make_tar_with_file('.wh..wh..opq', b'')
+
+    async def fake_read(repo, digest):
+        return tar_bytes
+
+    monkeypatch.setattr(oci, '_read_layer', fake_read)
+
+    with app.app.test_client() as client:
+        resp = client.get('/fs/repo@sha256:x/.wh..wh..opq')
+        assert resp.status_code == 200
+        assert resp.data == b''
+        assert resp.headers['Content-Type'].startswith('text/plain')
+


### PR DESCRIPTION
## Summary
- render text/plain for files with unknown extensions
- test for text file with no extension served from `/fs`

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561b4228a48332a6034cfb91d01606