### PR TITLE
Fix registry explorer close button

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -46,10 +46,12 @@
   }
   input:checked + label { opacity: 100%; }
   input ~ .tab { border-top: 1px solid #999; padding-top: 0.5em; }
+  .retrorecon-root .close-btn { float: right; margin-left: 1em; }
   </style>
 </head>
 <body>
 <div class="retrorecon-root">
+  <button type="button" class="btn btn--small close-btn" onclick="history.back();">Close</button>
 {% block body %}{% endblock %}
 </div>
 </body>


### PR DESCRIPTION
## Summary
- add small close button to all OCI explorer pages

## Testing
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68561d9de3008332a8e01bcd78438134