### PR TITLE
Fix /fs page styling

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -3,7 +3,18 @@
 <head>
   <title>{{ title or 'Registry Explorer' }}</title>
   <link rel="icon" href="{{ url_for('favicon_svg') }}">
-<style>
+  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}">
+  {% set current_theme = session.get('theme') %}
+  {% if current_theme %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}">
+  {% endif %}
+  {% set current_background = session.get('background') %}
+  {% if current_background %}
+  <style>
+    body { background-image: url('{{ url_for('static', filename='img/' + current_background) }}'); }
+  </style>
+  {% endif %}
+  <style>
   :root {
     color-scheme: light dark;
   }


### PR DESCRIPTION
## Summary
- add global stylesheet to OCI template
- support theme/background in `/fs` views

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856272e06a08332b741788c66bad813