### PR TITLE
Reduce pagination spacing

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -598,7 +598,7 @@ body {
   display: flex;
   flex-direction: column;
   /* Maintain visible frame even when no URLs are listed */
-  min-height: 810px;
+  min-height: 600px;
   overflow-y: auto;
 }
 
@@ -960,7 +960,7 @@ body {
 
 /* Pagination styling */
 .retrorecon-root .pagination {
-    margin: 0.5em 1em;
+    margin: 0.2em 0.5em;
     border-radius: 4px;
     transition: background 0.2s;
     /* border: 1px solid var(--color-contrast); */
@@ -1093,11 +1093,11 @@ body {
   text-align: center;
   color: var(--fg-color);
   font-size: 0.97em;
-  margin-right: 50px;
+  margin-right: 0;
 }
 .retrorecon-root .bottom-container {
   margin-top: auto;
-  padding-top: 0.5em;
+  padding-top: 0.25em;
 }
 
 /* Misc: checkboxes for row selection */

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
   <div class="retrorecon-root">
     <div id="dropdown-shade" class="dropdown-shade hidden"></div>
 {% macro render_pagination(page, total_pages, q, total_count, items_per_page, select_all_matching) %}
-  <div class="pagination mt-1">
+  <div class="pagination mt-05">
     <form id="set-items-form" method="POST" action="/set_items_per_page" class="d-none">
       <input type="hidden" name="count" id="items-count-input" />
     </form>
@@ -211,7 +211,7 @@
   </div>
 
   <!-- Table C : Pagination and saved tags -->
-  <table id="layout-c" class="w-100 mt-1">
+  <table id="layout-c" class="w-100 mt-05">
     <tr>
       <td class="text-left">
         {{ render_pagination(page, total_pages, q, total_count, items_per_page, select_all_matching) }}
@@ -309,7 +309,7 @@
           {% endif %}
         </div>
 
-  <div class="bottom-container text-center mt-1">
+  <div class="bottom-container text-center mt-05">
     {{ render_pagination(page, total_pages, q, total_count, items_per_page, select_all_matching) }}
     <div class="footer">
       <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline text-muted">


### PR DESCRIPTION
## Summary
- shrink margins around pagination
- lower `results-frame` minimum height
- trim footer spacing
- use `mt-05` class for pagination layout containers

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562cc657988332899e25afe02ebaf4