### PR TITLE
Add full screen dropdown shade

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -402,7 +402,7 @@ body {
   background-color: var(--select-bg-color);
   min-width: 260px;
   box-shadow: 0 8px 20px rgba(var(--bg-rgb) / 0.2);
-  z-index: 1;
+  z-index: 100;
   padding: 8px 12px;
   border-radius: 0;
   border: 1px solid var(--select-border-color);
@@ -1152,6 +1152,17 @@ body.bg-hidden {
   flex-direction: column;
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+.retrorecon-root .dropdown-shade {
+  position: fixed;
+  inset: 0;
+  background: rgba(var(--bg-rgb) / 0.8);
+  z-index: 99;
+  display: none;
+}
+.retrorecon-root .dropdown-shade.show {
+  display: block;
 }
 .retrorecon-root .notes-overlay.hidden {
   display: none;

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
 </head>
 <body class="app">
   <div class="retrorecon-root">
+    <div id="dropdown-shade" class="dropdown-shade hidden"></div>
 {% macro render_pagination(page, total_pages, q, total_count, items_per_page, select_all_matching) %}
   <div class="pagination mt-1">
     <form id="set-items-form" method="POST" action="/set_items_per_page" class="d-none">
@@ -403,17 +404,30 @@
       }
     });
 
+    const dropdownShade = document.getElementById('dropdown-shade');
     document.querySelectorAll('.dropbtn').forEach(btn => {
       btn.addEventListener('click', function(e){
         e.preventDefault();
         const item = this.parentElement;
-        item.classList.toggle('show');
+        const show = !item.classList.contains('show');
+        document.querySelectorAll('.dropdown').forEach(it => it.classList.remove('show'));
+        if(show){
+          item.classList.add('show');
+          dropdownShade.classList.add('show');
+        } else {
+          dropdownShade.classList.remove('show');
+        }
       });
     });
     document.addEventListener('click', function(e){
-      document.querySelectorAll('.dropdown').forEach(it => {
-        if(!it.contains(e.target)) it.classList.remove('show');
-      });
+      if(!e.target.closest('.dropdown')){
+        document.querySelectorAll('.dropdown').forEach(it => it.classList.remove('show'));
+        dropdownShade.classList.remove('show');
+      }
+    });
+    dropdownShade.addEventListener('click', () => {
+      document.querySelectorAll('.dropdown').forEach(it => it.classList.remove('show'));
+      dropdownShade.classList.remove('show');
     });
 
     function toggleSelectAllPage(cb) {


### PR DESCRIPTION
## Summary
- add overlay element for dropdown shading
- style dropdown shade overlay
- toggle shade visibility via JS when menus open
- raise dropdown menu z-index above overlay to keep menus clickable

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685629f0a68883329404337059e17d97