### PR TITLE
Add DB loader select to navbar

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -364,7 +364,7 @@ body {
   align-items: center;
   justify-content: center;
   justify-self: center;
-  gap: 0.5em;
+  gap: 5px;
 }
 .retrorecon-root .navbar__info {
   margin-left: 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -179,6 +179,14 @@
     </div>
   </div>
   <div class="navbar__title">
+      <form method="POST" action="/load_saved_db" id="load-saved-db-bar-form">
+        <select name="db_file" id="load-saved-db-bar-select" class="form-select menu-btn">
+          <option value="">Load Saved DB...</option>
+          {% for db in saved_dbs %}
+          <option value="{{ db }}">{{ db }}</option>
+          {% endfor %}
+        </select>
+      </form>
       <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
     </div>
     <div class="navbar__info">
@@ -793,6 +801,15 @@
       savedSelect.addEventListener('change', () => {
         if (savedSelect.value) {
           savedForm.submit();
+        }
+      });
+    }
+    const savedBarSelect = document.getElementById('load-saved-db-bar-select');
+    const savedBarForm = document.getElementById('load-saved-db-bar-form');
+    if (savedBarSelect && savedBarForm) {
+      savedBarSelect.addEventListener('change', () => {
+        if (savedBarSelect.value) {
+          savedBarForm.submit();
         }
       });
     }


### PR DESCRIPTION
## Summary
- show saved DB select directly in the navbar next to the database name
- handle change events for new navbar select
- tweak navbar spacing

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856319ebb30833283ea6df0b44f716f