### PR TITLE
Swap DB info section and round nav forms

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -389,7 +389,7 @@ body {
   cursor: pointer;
   transition: opacity 0.2s;
   border: 1px solid var(--color-contrast);
-  border-radius: 0;
+  border-radius: 5px;
 }
 .retrorecon-root .dropbtn:hover,
 .retrorecon-root .dropbtn:focus {
@@ -404,7 +404,7 @@ body {
   box-shadow: 0 8px 20px rgba(var(--bg-rgb) / 0.2);
   z-index: 100;
   padding: 8px 12px;
-  border-radius: 0;
+  border-radius: 5px;
   border: 1px solid var(--select-border-color);
   margin-top: 6px;
   color: var(--select-border-color);
@@ -415,7 +415,7 @@ body {
 .retrorecon-root .navbar button,
 .retrorecon-root .navbar .menu-btn,
 .retrorecon-root .navbar .dropdown-content {
-  border-radius: 0 !important;
+  border-radius: 5px !important;
 }
 
 .retrorecon-root .dropdown.show .dropdown-content {
@@ -741,6 +741,7 @@ body {
   border-bottom: 2px solid var(--fg-color);
   text-align: left;
   position: relative;
+  overflow: hidden;
 }
 
 .retrorecon-root .url-table th.sortable {
@@ -751,8 +752,8 @@ body {
   position: absolute;
   right: 0;
   top: 0;
+  bottom: 0;
   width: 6px;
-  height: 100%;
   cursor: col-resize;
   background: rgba(255, 255, 255, 0.3);
   transition: background-color 0.2s, box-shadow 0.2s;

--- a/templates/index.html
+++ b/templates/index.html
@@ -179,6 +179,9 @@
     </div>
   </div>
   <div class="navbar__title">
+      <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
+    </div>
+    <div class="navbar__info">
       <form method="POST" action="/load_saved_db" id="load-saved-db-bar-form">
         <select name="db_file" id="load-saved-db-bar-select" class="form-select menu-btn">
           <option value="">Load Saved DB...</option>
@@ -187,9 +190,6 @@
           {% endfor %}
         </select>
       </form>
-      <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
-    </div>
-    <div class="navbar__info">
       <div id="import-status-block" class="db-info">
         <span class="ml-01"><strong>Status:</strong></span>
         <span id="import-status-text">idle</span>


### PR DESCRIPTION
## Summary
- move DB loader dropdown next to status info in the navbar
- round navbar form controls and dropdown menus
- clip table headers and tweak column resizer height

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856358ca45483329f3968e6d2ec9207