### PR TITLE
Fix SubDomonster scrape results

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -466,6 +466,16 @@ Full-page subdomain overlay.
 curl http://localhost:5000/tools/subdomonster
 ```
 
+### `GET /subdomains`
+List subdomains from the database.
+
+Parameters (optional):
+- `domain` – limit results to a root domain.
+
+```
+curl "http://localhost:5000/subdomains?domain=example.com"
+```
+
 ### `POST /subdomains`
 Fetch subdomains from crt.sh or VirusTotal.
 

--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -21,10 +21,17 @@ def subdomonster_full_page():
     return app.index()
 
 
-@bp.route('/subdomains', methods=['POST'])
+@bp.route('/subdomains', methods=['GET', 'POST'])
 def subdomains_route():
     if not app._db_loaded():
         return jsonify({'error': 'no_db'}), 400
+
+    if request.method == 'GET':
+        domain = request.args.get('domain', '').strip().lower()
+        if domain:
+            return jsonify(subdomain_utils.list_subdomains(domain))
+        return jsonify(subdomain_utils.list_all_subdomains())
+
     domain = request.form.get('domain', '').strip().lower()
     if not domain:
         return ('Missing domain', 400)

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -172,7 +172,15 @@ function initSubdomonster(){
     if(domain) body.append('domain', domain);
     const resp = await fetch('/scrape_subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body});
     if(resp.ok){
-      fetchBtn.click();
+      const q = domain ? ('?domain=' + encodeURIComponent(domain)) : '';
+      const r = await fetch('/subdomains' + q);
+      if(r.ok){
+        const data = await r.json();
+        tableData = Array.isArray(data) ? data : [];
+        render();
+      } else {
+        fetchBtn.click();
+      }
     } else {
       alert('Scrape failed');
     }

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -141,6 +141,20 @@ def test_scrape_subdomains(tmp_path, monkeypatch):
         subs = [r['subdomain'] for r in rows]
         assert 'a.example.com' in subs
 
+def test_list_all_subdomains_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db('listall')
+        from retrorecon import subdomain_utils
+        subdomain_utils.insert_records('example.com', ['a.example.com'], 'scrape')
+        subdomain_utils.insert_records('test.org', ['b.test.org'], 'scrape')
+    with app.app.test_client() as client:
+        resp = client.get('/subdomains')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        subs = {r['subdomain'] for r in data}
+        assert subs == {'a.example.com', 'b.test.org'}
+
 def test_delete_subdomain(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     with app.app.app_context():


### PR DESCRIPTION
## Summary
- expose a `GET /subdomains` route for retrieving subdomains from the DB
- show all scraped subdomains when no domain is specified
- document the new endpoint
- test listing all subdomains

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685639d7ea708332b96d139e7be97c6c