### PR TITLE
Fix DB toolbar placement

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -38,6 +38,7 @@ body {
 .retrorecon-root .ml-1 { margin-left: 1em; }
 .retrorecon-root .ml-05 { margin-left: 0.5em; }
 .retrorecon-root .ml-4px { margin-left: 4px; }
+.retrorecon-root .ml-5px { margin-left: 5px; }
 .retrorecon-root .mr-03 { margin-right: 0.3em; }
 .retrorecon-root .mb-4px { margin-bottom: 4px; }
 .retrorecon-root .m-2em { margin: 2em; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -180,9 +180,7 @@
   </div>
   <div class="navbar__title">
       <span class="glow cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
-    </div>
-    <div class="navbar__info">
-      <form method="POST" action="/load_saved_db" id="load-saved-db-bar-form">
+      <form method="POST" action="/load_saved_db" id="load-saved-db-bar-form" class="ml-5px">
         <select name="db_file" id="load-saved-db-bar-select" class="form-select menu-btn">
           <option value="">Load Saved DB...</option>
           {% for db in saved_dbs %}
@@ -190,6 +188,8 @@
           {% endfor %}
         </select>
       </form>
+    </div>
+    <div class="navbar__info">
       <div id="import-status-block" class="db-info">
         <span class="ml-01"><strong>Status:</strong></span>
         <span id="import-status-text">idle</span>


### PR DESCRIPTION
## Summary
- move DB loader dropdown next to the database name
- add 5px margin helper class for layout

## Testing
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563a234a9c8332993872846cac14e3