### PR TITLE
Fix saved tag search quoting

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -668,6 +668,9 @@
       .catch(() => { updateImportStatus({status:'idle'}); });
 
     function quickSearch(term){
+      if(term.startsWith('#')){
+        term = '"' + term.slice(1) + '"';
+      }
       const box = document.getElementById('searchbox');
       let current = box.value.trim();
       if(current){


### PR DESCRIPTION
## Summary
- fix saved tags button logic in `index.html` to replace leading `#` with quotes
- run linters and unit tests

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563fb5688883329c6b6b4f4daab7dc