### PR TITLE
Improve local subdomain scraping

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -33,12 +33,21 @@ def subdomains_route():
         return jsonify(subdomain_utils.list_all_subdomains())
 
     domain = request.form.get('domain', '').strip().lower()
+    source = request.form.get('source', 'crtsh')
+    api_key = request.form.get('api_key', '').strip()
+
+    if source == 'local':
+        if domain and not re.match(r'^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
+            return ('Invalid domain', 400)
+        subdomain_utils.scrape_from_urls(domain or None)
+        if domain:
+            return jsonify(subdomain_utils.list_subdomains(domain))
+        return jsonify(subdomain_utils.list_all_subdomains())
+
     if not domain:
         return ('Missing domain', 400)
     if not re.match(r'^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
         return ('Invalid domain', 400)
-    source = request.form.get('source', 'crtsh')
-    api_key = request.form.get('api_key', '').strip()
     try:
         if source == 'virustotal':
             if not api_key:

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -64,7 +64,10 @@ function initSubdomonster(){
 
   for(const rb of sourceRadios){
     rb.addEventListener('change', () => {
-      apiInput.classList.toggle('hidden', rb.value !== 'virustotal' || !rb.checked);
+      const val = rb.value;
+      if(rb.checked){
+        apiInput.classList.toggle('hidden', val !== 'virustotal');
+      }
     });
   }
   // initialize visibility
@@ -152,9 +155,23 @@ function initSubdomonster(){
 
   fetchBtn.addEventListener('click', async () => {
     const domain = domainInput.value.trim();
-    if(!domain) return;
     let source = 'crtsh';
     for(const rb of sourceRadios){ if(rb.checked){ source = rb.value; break; } }
+    if(source === 'local'){
+      const body = new URLSearchParams();
+      if(domain) body.append('domain', domain);
+      body.append('source', 'local');
+      const resp = await fetch('/subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body});
+      if(resp.ok){
+        const data = await resp.json();
+        tableData = Array.isArray(data) ? data : [];
+        render();
+      } else {
+        alert(await resp.text());
+      }
+      return;
+    }
+    if(!domain) return;
     const api_key = apiInput.value.trim();
     const resp = await fetch('/subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({domain, source, api_key})});
     if(resp.ok){

--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -4,6 +4,7 @@
     <input type="text" id="subdomonster-domain" class="form-input mr-05" placeholder="example.com" />
     <label class="mr-05"><input type="radio" name="subdomonster-source" value="crtsh" checked> crt.sh</label>
     <label class="mr-05"><input type="radio" name="subdomonster-source" value="virustotal"> VirusTotal</label>
+    <label class="mr-05"><input type="radio" name="subdomonster-source" value="local"> Local</label>
     <input type="text" id="subdomonster-api-key" class="form-input mr-05 hidden" placeholder="API key" />
     <button type="button" class="btn" id="subdomonster-fetch-btn">Fetch</button>
     <button type="button" class="btn" id="subdomonster-scrape-btn">Scrape</button>


### PR DESCRIPTION
## Summary
- add `local` option to Subdomonster
- extract subdomains from URL column when domain missing
- support local scraping via `/subdomains` route
- test scraping from URLs and new local source option

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685645b58f508332b36a0d3ed650f621