### PR TITLE
Fix OCI explorer wrapping

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -1,16 +1,16 @@
 {
   "coverage": {
     "button": {
-      "total": 63,
-      "styled": 63
+      "total": 64,
+      "styled": 64
     },
     "input": {
       "total": 38,
       "styled": 16
     },
     "select": {
-      "total": 7,
-      "styled": 7
+      "total": 8,
+      "styled": 8
     },
     "checkbox": {
       "total": 7,

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -20,11 +20,9 @@
   }
   .retrorecon-root {
     font-family: monospace;
-    width: fit-content;
-    overflow-wrap: anywhere;
     padding: 12px;
   }
-  .retrorecon-root pre { white-space: pre-wrap; }
+  .retrorecon-root pre { white-space: pre; }
   .retrorecon-root .manifest-json { white-space: pre; }
   .retrorecon-root .indent { margin-left: 2em; display: block; }
   .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
@@ -35,8 +33,6 @@
   .retrorecon-root .noselect {
     user-select: none;
     -webkit-user-select: none;
-    width: fit-content;
-    overflow-wrap: none;
     padding-right: 1em;
     text-align: right;
     white-space: nowrap;


### PR DESCRIPTION
## Summary
- remove wrap styles from OCI explorer base template
- update CSS audit report

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6856467dd2448332b67a52159c6d1f26