### PR TITLE
Fix manifest line breaks and trim template whitespace

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -26,7 +26,7 @@
   }
   .retrorecon-root pre { white-space: pre-wrap; }
   .retrorecon-root .manifest-json { white-space: pre; }
-  .retrorecon-root .indent { margin-left: 2em; display: block; }
+  .retrorecon-root .indent { margin-left: 2em; }
   .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
   .retrorecon-root .mt:hover { text-decoration: underline; }
   .retrorecon-root .link { position: relative; bottom: .125em; }

--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -20,9 +20,7 @@ Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ med
 <pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
 </div>
 <h4><span style="padding:0;" class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz{% if subpath %}  {{ subpath }}{% endif %}</h4>
-<pre>
-{% for item in items %}
-{{ item.perms }} {{ item.owner }} <span title="{{ item.size_hr }}">{{ '%12s'|format(item.size) }}</span> {{ item.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ item.path }}">{{ item.name }}{% if item.is_dir %}/{% endif %}</a>
-{% endfor %}
-</pre>
+<pre>{%- for item in items %}
+{{ item.perms }} {{ item.owner }} <span title="{{ item.size_hr }}">{{ '%12s'|format(item.size) }}</span> {{ item.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ item.path }}">{{ item.name }}{% if item.is_dir %}/{% endif %}</a>{% if not loop.last %}\n{% endif %}
+{%- endfor %}</pre>
 {% endblock %}

--- a/templates/oci_layer.html
+++ b/templates/oci_layer.html
@@ -16,9 +16,5 @@ Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ med
 <pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
 </div>
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz | sort -n -r -k3</h4>
-<pre>
-{% for line in lines %}
-{{ line }}
-{% endfor %}
-</pre>
+<pre>{{ lines|join('\n') }}</pre>
 {% endblock %}

--- a/templates/oci_overlay.html
+++ b/templates/oci_overlay.html
@@ -15,9 +15,7 @@ Docker-Content-Digest: <a class="mt" href="/?image={{ repo }}@{{ digest }}&mt={{
 <pre class="manifest-json">{{ descriptor|tojson(indent=2) }}</pre>
 </div>
 <h4><span style="padding:0;" class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md">export</a> {{ image }} | tar -tv{% if path %} {{ path }}{% endif %}</h4>
-<pre>
-{% for it in items %}
-<a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a> {{ it.perms }} {{ it.owner }} <span title="{{ it.size_hr }}">{{ '%12s'|format(it.size) }}</span> {{ it.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a>
-{% endfor %}
-</pre>
+<pre>{%- for it in items %}
+<a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a> {{ it.perms }} {{ it.owner }} <span title="{{ it.size_hr }}">{{ '%12s'|format(it.size) }}</span> {{ it.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a>{% if not loop.last %}\n{% endif %}
+{%- endfor %}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- stop `.indent` blocks from forcing extra linebreaks
- join file listings in templates so each line prints once

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856475b16248332a289f1918ee1660d