### PR TITLE
Fix Subdomonster overlay loading

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1041,9 +1041,13 @@
           const html = await resp.text();
           const root = document.querySelector('.retrorecon-root') || document.body;
           root.insertAdjacentHTML('beforeend', html);
-          const script = document.createElement('script');
-          script.src = '/static/subdomonster.js';
-          document.body.appendChild(script);
+          await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = '/static/subdomonster.js';
+            script.onload = resolve;
+            script.onerror = reject;
+            document.body.appendChild(script);
+          });
           subLoaded = true;
         }
         document.getElementById('subdomonster-overlay').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- ensure subdomonster script loads before displaying overlay

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564b98c3b4833296d9f0c2227c0b24