### PR TITLE
Add subdomonster status updates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1055,7 +1055,11 @@
           });
           subLoaded = true;
         }
-        document.getElementById('subdomonster-overlay').classList.remove('hidden');
+        const ov = document.getElementById('subdomonster-overlay');
+        ov.classList.remove('hidden');
+        if(window.startSubdomonsterStatus){
+          window.startSubdomonsterStatus();
+        }
         if(!skipPush){
           history.pushState({tool:'subdomonster'}, '', '/tools/subdomonster');
         }
@@ -1063,7 +1067,12 @@
 
       function hideSubdomonster(){
         const ov = document.getElementById('subdomonster-overlay');
-        if(ov) ov.classList.add('hidden');
+        if(ov){
+          ov.classList.add('hidden');
+          if(window.stopSubdomonsterStatus){
+            window.stopSubdomonsterStatus();
+          }
+        }
       }
 
       if(subLink){

--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -11,6 +11,7 @@
     <button type="button" class="btn" id="subdomonster-export-csv-btn">Export CSV</button>
     <button type="button" class="btn" id="subdomonster-export-md-btn">Export MD</button>
     <button type="button" class="btn" id="subdomonster-close-btn">Close</button>
+    <span id="subdomonster-status" class="ml-05"></span>
   </div>
   <div id="subdomonster-table" class="mt-05"></div>
   <div id="subdomonster-pagination" class="mt-05"></div>


### PR DESCRIPTION
## Summary
- show status span in the subdomonster overlay
- poll `/status` and expose start/stop functions for the overlay
- start/stop polling from the index page when opening/closing subdomonster
- push debug status messages from subdomain routes

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ed7a55ec833296f5c27e4622a091