### PR TITLE
Improve local scrape efficiency

### DIFF
--- a/database.py
+++ b/database.py
@@ -28,7 +28,9 @@ def init_db() -> None:
     conn = sqlite3.connect(app.config['DATABASE'])
     for statement in sql.split(';'):
         stmt = statement.strip()
-        if stmt.upper().startswith('CREATE TABLE IF NOT EXISTS'):
+        if not stmt:
+            continue
+        if stmt.upper().startswith('CREATE TABLE IF NOT EXISTS') or stmt.upper().startswith('CREATE INDEX IF NOT EXISTS'):
             conn.execute(stmt)
     conn.commit()
     conn.close()
@@ -124,4 +126,14 @@ def execute_db(query: str, args: Union[Tuple, List] = ()) -> int:
     cur = db.execute(query, args)
     db.commit()
     return cur.lastrowid
+
+
+def executemany_db(query: str, args_list: List[Tuple]) -> int:
+    """Execute ``query`` for each tuple in ``args_list`` and return rows inserted."""
+    if not args_list:
+        return 0
+    db = get_db()
+    cur = db.executemany(query, args_list)
+    db.commit()
+    return cur.rowcount
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -72,3 +72,7 @@ CREATE TABLE IF NOT EXISTS domains (
     fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(subdomain, source)
 );
+
+CREATE INDEX IF NOT EXISTS idx_urls_domain ON urls(domain);
+CREATE INDEX IF NOT EXISTS idx_domains_root ON domains(root_domain);
+CREATE INDEX IF NOT EXISTS idx_domains_subdomain ON domains(subdomain);


### PR DESCRIPTION
## Summary
- add `executemany_db` helper to batch DB writes
- apply index statements in `init_db`
- create indexes for URL and domain lookups
- optimize `insert_records` using `executemany_db`
- batch-fetch URLs in `scrape_from_urls` and cache root lookups

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f6495b288332a45d19a87a5139aa