### PR TITLE
Fix local scrape button and document usage

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -479,15 +479,18 @@ curl "http://localhost:5000/subdomains?domain=example.com&page=1&items=50"
 ```
 
 ### `POST /subdomains`
-Fetch subdomains from crt.sh or VirusTotal.
+Fetch subdomains from crt.sh, VirusTotal, or the local URL list.
 
 Parameters:
-- `domain` – target domain.
-- `source` – `crtsh` or `virustotal`.
+- `domain` – target domain (optional when using the `local` source).
+- `source` – `crtsh`, `virustotal`, or `local`.
 - `api_key` – required for VirusTotal.
 
+Use `source=local` to import subdomains discovered by scraping existing URLs.
+
 ```
-curl -X POST -d "domain=example.com" http://localhost:5000/subdomains
+curl -X POST -d "domain=example.com" -d "source=crtsh" http://localhost:5000/subdomains
+curl -X POST -d "source=local" http://localhost:5000/subdomains
 ```
 
 ### `GET /export_subdomains`

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -258,15 +258,20 @@ function initSubdomonster(){
     if(source === 'local'){
       const body = new URLSearchParams();
       if(domain) body.append('domain', domain);
-      body.append('source', 'local');
-      const resp = await fetch('/subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body});
+      const resp = await fetch('/scrape_subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body});
       if(resp.ok){
-        const data = await resp.json();
-        tableData = Array.isArray(data) ? data : [];
-        currentPage = 1;
-        render();
+        const q = domain ? ('?domain=' + encodeURIComponent(domain)) : '';
+        const r = await fetch('/subdomains' + q);
+        if(r.ok){
+          const data = await r.json();
+          tableData = Array.isArray(data) ? data : [];
+          currentPage = 1;
+          render();
+        } else {
+          alert(await r.text());
+        }
       } else {
-        alert(await resp.text());
+        alert('Scrape failed');
       }
       return;
     }


### PR DESCRIPTION
## Summary
- fix Subdomonster local scrape UI to call `/scrape_subdomains`
- document using `source=local` for `/subdomains`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fd8cbcf0833295aa07a7df15c7e0