### PR TITLE
Fix subdomonster close button

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -314,9 +314,7 @@ function initSubdomonster(){
   closeBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');
     stopStatusPolling();
-    if(location.pathname === '/tools/subdomonster'){
-      history.pushState({}, '', '/');
-    }
+    history.pushState({}, '', '/');
   });
 
   if(tableData.length){


### PR DESCRIPTION
## Summary
- ensure subdomonster close button always returns to main view

## Testing
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685702a059188332af0edc9ab0fd7947