### PR TITLE
Fix Subdomonster close button and show fetch progress

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -264,6 +264,7 @@ function initSubdomonster(){
     } else if(source !== 'local' && !domain){
       return;
     }
+    showStatus('Fetching...');
     const resp = await fetch('/subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
     if(resp.ok){
       const data = await resp.json();
@@ -312,9 +313,7 @@ function initSubdomonster(){
   });
 
   closeBtn.addEventListener('click', () => {
-    overlay.classList.add('hidden');
-    stopStatusPolling();
-    history.pushState({}, '', '/');
+    history.back();
   });
 
   if(tableData.length){


### PR DESCRIPTION
## Summary
- improve Subdomonster user experience
- show a quick "Fetching..." status while loading
- close the overlay with `history.back()` so the page URL and view stay in sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857064497f48332a42461898154da64