### PR TITLE
Add subdomain search

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -91,6 +91,9 @@ def export_subdomains():
     if not domain:
         return jsonify([])
     rows = subdomain_utils.list_subdomains(domain)
+    q = request.args.get('q', '').strip().lower()
+    if q:
+        rows = [r for r in rows if q in r['subdomain'].lower()]
     fmt = request.args.get('format', 'json')
     if fmt == 'csv':
         output = io.StringIO()

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -10,6 +10,7 @@ function initSubdomonster(){
   const statusSpan = document.getElementById('subdomonster-status');
   const exportCsvBtn = document.getElementById('subdomonster-export-csv-btn');
   const exportMdBtn = document.getElementById('subdomonster-export-md-btn');
+  const searchInput = document.getElementById('subdomonster-search');
   const sourceRadios = document.getElementsByName('subdomonster-source');
   const apiInput = document.getElementById('subdomonster-api-key');
   let currentPage = 1;
@@ -23,6 +24,7 @@ function initSubdomonster(){
   let sortField = 'subdomain';
   let sortDir = 'asc';
   let itemsPerPage = 25;
+  let searchText = '';
 
   let statusTimer = null;
   let statusDelay = 1000;
@@ -60,6 +62,14 @@ function initSubdomonster(){
       clearTimeout(statusTimer);
       statusTimer = null;
     }
+  }
+
+  if(searchInput){
+    searchInput.addEventListener('input', () => {
+      searchText = searchInput.value.trim().toLowerCase();
+      currentPage = 1;
+      render();
+    });
   }
 
   function makeResizable(table, key){
@@ -172,7 +182,10 @@ function initSubdomonster(){
   })();
 
   function render(){
-    const sorted = tableData.slice().sort((a,b)=>{
+    const filtered = searchText ?
+      tableData.filter(r => r.subdomain.toLowerCase().includes(searchText)) :
+      tableData;
+    const sorted = filtered.slice().sort((a,b)=>{
       const av = (a[sortField] || '').toString().toLowerCase();
       const bv = (b[sortField] || '').toString().toLowerCase();
       if(av < bv) return sortDir==='asc'? -1:1;
@@ -280,7 +293,10 @@ function initSubdomonster(){
   exportCsvBtn.addEventListener('click', async () => {
     const domain = domainInput.value.trim();
     if(!domain) return;
-    const resp = await fetch('/export_subdomains?format=csv&domain=' + encodeURIComponent(domain));
+    const q = searchInput ? searchInput.value.trim() : '';
+    let requestUrl = '/export_subdomains?format=csv&domain=' + encodeURIComponent(domain);
+    if(q) requestUrl += '&q=' + encodeURIComponent(q);
+    const resp = await fetch(requestUrl);
     if(resp.ok){
       const blob = await resp.blob();
       const url = URL.createObjectURL(blob);
@@ -297,7 +313,10 @@ function initSubdomonster(){
   exportMdBtn.addEventListener('click', async () => {
     const domain = domainInput.value.trim();
     if(!domain) return;
-    const resp = await fetch('/export_subdomains?format=md&domain=' + encodeURIComponent(domain));
+    const q = searchInput ? searchInput.value.trim() : '';
+    let requestUrl = '/export_subdomains?format=md&domain=' + encodeURIComponent(domain);
+    if(q) requestUrl += '&q=' + encodeURIComponent(q);
+    const resp = await fetch(requestUrl);
     if(resp.ok){
       const text = await resp.text();
       const blob = new Blob([text], {type:'text/markdown'});

--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -7,6 +7,7 @@
     <label class="mr-05"><input type="radio" name="subdomonster-source" value="local"> Local</label>
     <input type="text" id="subdomonster-api-key" class="form-input mr-05 hidden" placeholder="API key" />
     <button type="button" class="btn" id="subdomonster-fetch-btn">Fetch</button>
+    <input type="text" id="subdomonster-search" class="form-input mr-05" placeholder="search" />
     <button type="button" class="btn" id="subdomonster-export-csv-btn">Export CSV</button>
     <button type="button" class="btn" id="subdomonster-export-md-btn">Export MD</button>
     <button type="button" class="btn" id="subdomonster-close-btn">Close</button>

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -117,6 +117,20 @@ def test_export_and_mark_cdx(tmp_path, monkeypatch):
         assert rows[0]['cdx_indexed'] is True
 
 
+def test_export_filter(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db('expfilter')
+        from retrorecon import subdomain_utils
+        subdomain_utils.insert_records('example.com', ['a.example.com', 'b.example.com'], 'crtsh')
+    with app.app.test_client() as client:
+        resp = client.get('/export_subdomains?domain=example.com&format=csv&q=a.example')
+        assert resp.status_code == 200
+        text = resp.data.decode()
+        assert 'a.example.com' in text
+        assert 'b.example.com' not in text
+
+
 
 def test_scrape_subdomains(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary
- add search input in `subdomonster` overlay
- filter table rows as user types
- include optional `q` filter in CSV/markdown export
- test export filtering

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570d61157c8332833e7114ad2fa69f