### PR TITLE
Add Wayback Import to subdomain dropdown

### DIFF
--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -24,6 +24,7 @@
       <option value="site2zip">Site2Zip</option>
       <option value="webpack">Webpack Explode...</option>
       <option value="text">Text Tools</option>
+      <option value="cdx">Wayback Import</option>
     </select>
     <button type="button" class="btn" id="subdom-bulk-send-btn">Go</button>
   </div>


### PR DESCRIPTION
## Summary
- allow sending subdomains to the CDX API importer from Subdomonster
- add `Wayback Import` choice to bulk dropdown
- update Subdomonster JS to post to `/fetch_cdx` and mark subdomains

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571547fb6c83328019aaed97f30cb8