### PR TITLE
Fix Subdomonster select-all test

### DIFF
--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -30,7 +30,7 @@ def test_subdomonster_route(tmp_path, monkeypatch):
         resp = client.get('/subdomonster')
         assert resp.status_code == 200
         assert b'id="subdomonster-overlay"' in resp.data
-        assert b'id="subdomonster-select-all"' in resp.data
+        assert b'id="subdom-select-all-page"' in resp.data or b'id="subdom-select-all-matching"' in resp.data
 
 
 def test_subdomain_insert(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- update subdomonster template ID check in unit test

## Testing
- `pytest tests/test_subdomonster.py::test_subdomonster_route -q`
- `pytest -q` *(fails: network operations cause KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68571ddb89388332b4b497d91e4e03eb