### PR TITLE
Fix subdomonster local scraping

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -56,7 +56,10 @@ def subdomains_route():
     api_key = request.form.get('api_key', '').strip()
 
     if source == 'local':
-        if domain and not re.match(r'^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
+        # Allow single-label hostnames or IPs when scraping local URLs. A very
+        # loose check avoids rejecting common internal domains like
+        # "localhost" while still filtering obvious bad input.
+        if domain and not re.match(r'^[A-Za-z0-9.-]+$', domain):
             return ('Invalid domain', 400)
         status_mod.push_status('subdomonster_local_start', domain or 'all')
         inserted = subdomain_utils.scrape_from_urls(domain or None)

--- a/tests/test_local_domain_validation.py
+++ b/tests/test_local_domain_validation.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+from retrorecon import subdomain_utils
+from tests.test_subdomonster import setup_tmp
+
+
+def test_local_allows_single_label(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db('single')
+        app.execute_db("INSERT INTO urls (url, domain, tags) VALUES (?, ?, '')", ['http://internal', 'internal'])
+    with app.app.test_client() as client:
+        resp = client.post('/subdomains', data={'source': 'local', 'domain': 'internal'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        subs = {r['subdomain'] for r in data}
+        assert 'internal' in subs


### PR DESCRIPTION
## Summary
- relax hostname validation for local scraping to accept single-label hosts
- add regression test for local domain scraping

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685723cfd9e08332a61469427cd83f19