### PR TITLE
Fix subdomonster selection, export UI

### DIFF
--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -8,14 +8,21 @@
     <input type="text" id="subdomonster-api-key" class="form-input mr-05 hidden" placeholder="API key" />
     <button type="button" class="btn" id="subdomonster-fetch-btn">Fetch</button>
     <input type="text" id="subdomonster-search" class="form-input mr-05" placeholder="search" />
-    <button type="button" class="btn" id="subdomonster-export-csv-btn">Export CSV</button>
-    <button type="button" class="btn" id="subdomonster-export-md-btn">Export MD</button>
+    <select id="subdom-export-formats" class="form-select mr-05" multiple>
+      <option value="csv">CSV</option>
+      <option value="md">Markdown</option>
+    </select>
+    <button type="button" class="btn" id="subdom-export-btn">Export</button>
     <button type="button" class="btn" id="subdomonster-close-btn">Close</button>
     <span id="subdomonster-status" class="ml-05"></span>
   </div>
   <div class="mb-05">
-    <input type="checkbox" id="subdom-select-all-page" class="form-checkbox mr-05" /> Select Page
-    <input type="checkbox" id="subdom-select-all-matching" class="form-checkbox mr-05" /> Select All Matching
+    <select id="subdom-select-mode" class="form-select mr-05">
+      <option value="" selected>Select...</option>
+      <option value="page">Select Page</option>
+      <option value="all">Select All Matching</option>
+      <option value="none">Select None</option>
+    </select>
     <input type="text" id="subdom-bulk-tag" class="form-input mr-05" placeholder="tag" />
     <button type="button" class="btn" id="subdom-add-tag-btn">Add Tag</button>
     <button type="button" class="btn" id="subdom-remove-tag-btn">Remove Tag</button>

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -30,7 +30,7 @@ def test_subdomonster_route(tmp_path, monkeypatch):
         resp = client.get('/subdomonster')
         assert resp.status_code == 200
         assert b'id="subdomonster-overlay"' in resp.data
-        assert b'id="subdom-select-all-page"' in resp.data or b'id="subdom-select-all-matching"' in resp.data
+        assert b'id="subdom-select-mode"' in resp.data
 
 
 def test_subdomain_insert(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- fix syntax error in `subdomonster.js`
- replace page/all checkboxes with a select input
- provide multi-select export dropdown and open downloads in new tab
- update tests for new markup

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685727bdb4a08332a56a2a3487aa0c5e