### PR TITLE
Fix search filtering in subdomonster

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -96,7 +96,12 @@ def export_subdomains():
     rows = subdomain_utils.list_subdomains(domain)
     q = request.args.get('q', '').strip().lower()
     if q:
-        rows = [r for r in rows if q in r['subdomain'].lower()]
+        rows = [
+            r for r in rows
+            if q in r['subdomain'].lower()
+            or q in r['domain'].lower()
+            or q in (r['tags'] or '').lower()
+        ]
     fmt = request.args.get('format', 'json')
     if fmt == 'csv':
         output = io.StringIO()

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -248,7 +248,11 @@ function initSubdomonster(){
 
   function render(){
     const filtered = searchText ?
-      tableData.filter(r => r.subdomain.toLowerCase().includes(searchText) || (r.tags||'').toLowerCase().includes(searchText)) :
+      tableData.filter(r =>
+        r.subdomain.toLowerCase().includes(searchText) ||
+        r.domain.toLowerCase().includes(searchText) ||
+        (r.tags || '').toLowerCase().includes(searchText)
+      ) :
       tableData;
     const sorted = filtered.slice().sort((a,b)=>{
       const av = (a[sortField] || '').toString().toLowerCase();

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -131,6 +131,11 @@ def test_export_filter(tmp_path, monkeypatch):
         assert 'a.example.com' in text
         assert 'b.example.com' not in text
 
+        resp = client.get('/export_subdomains?domain=example.com&format=csv&q=example.com')
+        text = resp.data.decode()
+        assert 'a.example.com' in text
+        assert 'b.example.com' in text
+
 
 
 def test_scrape_subdomains(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- improve search filtering to include domain and tags
- support domain filter in export_subdomains route
- test export filtering by root domain

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572d700bc483329db9cfe3fb1eec51