### PR TITLE
Fix text tools full page navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -291,6 +291,8 @@ def index() -> str:
         tool = 'screenshot'
     elif request.path == '/tools/subdomonster':
         tool = 'subdomonster'
+    elif request.path == '/tools/text_tools':
+        tool = 'text'
 
     sort = request.args.get('sort', 'id')
     direction = request.args.get('dir', 'desc').lower()

--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -27,6 +27,12 @@ def text_tools_page():
     return render_template('text_tools.html')
 
 
+@bp.route('/tools/text_tools', methods=['GET'])
+def text_tools_full_page():
+    """Serve the full page with Text Tools overlay loaded."""
+    return app.index()
+
+
 def _get_text_param():
     text = request.form.get('text', '')
     if len(text.encode('utf-8')) > app.TEXT_TOOLS_LIMIT:

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -296,7 +296,7 @@ function initSubdomonster(){
               `<div class="menu-row"><a class="menu-btn" href="/tools/screenshotter?url=${encoded}" target="_blank">Screen Shotter</a></div>`+
               `<div class="menu-row"><a class="menu-btn" href="/tools/site2zip?url=${encoded}" target="_blank">Site2Zip</a></div>`+
               `<div class="menu-row"><a class="menu-btn" href="/tools/webpack-zip?map_url=${encoded}" target="_blank">Webpack Explode...</a></div>`+
-              `<div class="menu-row"><a class="menu-btn" href="/text_tools?text=${encoded}" target="_blank">Text Tools</a></div>`+
+              `<div class="menu-row"><a class="menu-btn" href="/tools/text_tools?text=${encoded}" target="_blank">Text Tools</a></div>`+
               `<div class="menu-row"><a class="menu-btn cdx-import-link" href="#" data-sub="${encoded}">Wayback Import</a></div>`+
             `</div>`+
           `</div>`+

--- a/templates/index.html
+++ b/templates/index.html
@@ -865,21 +865,46 @@
 
       const textToolsLink = document.getElementById('text-tools-link');
       let textToolsLoaded = false;
+
+      async function showTextTools(skipPush){
+        if(!textToolsLoaded){
+          const resp = await fetch('/text_tools');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/text_tools.js';
+          document.body.appendChild(script);
+          textToolsLoaded = true;
+        }
+        document.getElementById('text-tools-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'text'}, '', '/tools/text_tools');
+        }
+      }
+
+      function hideTextTools(){
+        const ov = document.getElementById('text-tools-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
       if (textToolsLink) {
         textToolsLink.addEventListener('click', async (e) => {
           e.preventDefault();
-          if (!textToolsLoaded) {
-            const resp = await fetch('/text_tools');
-            const html = await resp.text();
-            const root = document.querySelector('.retrorecon-root') || document.body;
-            root.insertAdjacentHTML('beforeend', html);
-            const script = document.createElement('script');
-            script.src = '/static/text_tools.js';
-            document.body.appendChild(script);
-            textToolsLoaded = true;
-          }
-          document.getElementById('text-tools-overlay').classList.remove('hidden');
+          showTextTools();
         });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/text_tools'){
+          showTextTools(true);
+        } else {
+          hideTextTools();
+        }
+      });
+
+      if(location.pathname === '/tools/text_tools' || openTool === 'text'){
+        showTextTools(true);
       }
 
       const jwtToolsLink = document.getElementById('jwt-tools-link');

--- a/tests/test_text_tools.py
+++ b/tests/test_text_tools.py
@@ -23,6 +23,14 @@ def test_text_tools_route(tmp_path, monkeypatch):
         assert b'id="text-tools-overlay"' in resp.data
 
 
+def test_text_tools_full_page(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/tools/text_tools')
+        assert resp.status_code == 200
+        assert b'openTool = "text"' in resp.data
+
+
 def test_url_encode_decode_roundtrip(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     with app.app.test_client() as client:


### PR DESCRIPTION
## Summary
- add `/tools/text_tools` route so text tools can be shown as a full page
- open the text tools overlay automatically when visiting `/tools/text_tools`
- update Subdomonster send‑to menu to use the new route
- expose `tool='text'` in main index logic
- test the full page route

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857341ff64883329e8ad325728470a0