### PR TITLE
Add secrets file loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ db/*.db
 *.sqlite
 *.json
 !data/demo_data.json
+!secrets.example.json
 !frontend/package.json
 !frontend/.stylelintrc.json
 !tests/postman/retrorecon.postman.json

--- a/README.md
+++ b/README.md
@@ -91,11 +91,28 @@ launch_app.bat
 Then open <http://127.0.0.1:5000> in your browser.
 ### Playwright on Windows
 If screenshot capture shows a placeholder image, Playwright may not have the Chromium browser installed.
+
 Run `python -m playwright install` to download the browsers. If you previously
 set the `PLAYWRIGHT_BROWSERS_PATH` environment variable, remove it so Playwright
 can use its default location. Alternatively set `PLAYWRIGHT_CHROMIUM_PATH` to an
 existing Chrome executable. You can also assign a path to `app.executablePath`
 before calling screenshot functions to override the Chromium binary.
+
+### Secrets File
+Create a `secrets.json` file alongside `app.py` to store sensitive values like
+API tokens. The application loads this file on startup and sets any variables
+found inside if they are not already defined in the environment. A different
+path can be specified via the `RETRORECON_SECRETS_FILE` environment variable.
+
+Example `secrets.json`:
+
+```json
+{
+  "RETRORECON_SECRET": "change_me",
+  "DOCKERHUB_API": "",
+  "VIRUSTOTAL_API": ""
+}
+```
 
 ### Docker Quick Start
 
@@ -289,7 +306,7 @@ production deployment. Below is the outstanding task list to improve the
 application's security posture.
 
 ```markdown
-- [ ] Load `app.secret_key` from an environment variable and document the requirement.
+- [x] Load `app.secret_key` from an environment variable and document the requirement.
 - [ ] Implement CSRF protection across all POST forms (consider Flask-WTF).
 - [x] Refactor `templates/index.html` to avoid placing `{{ url.url }}` inside JavaScript strings.
   - Use `data-url` attributes and event listeners defined in JS.

--- a/config.py
+++ b/config.py
@@ -1,9 +1,41 @@
 import os
+import json
+
+
+def load_secrets_file(path: str = "secrets.json") -> None:
+    """Load secrets from *path* into ``os.environ`` if the file exists.
+
+    The path can be overridden by the ``RETRORECON_SECRETS_FILE`` environment
+    variable. Existing environment variables are not overwritten. The secrets
+    file should contain a JSON object mapping environment variable names to
+    their values.
+    """
+
+    secrets_path = os.environ.get("RETRORECON_SECRETS_FILE", path)
+    if not os.path.isabs(secrets_path):
+        secrets_path = os.path.join(os.getcwd(), secrets_path)
+
+    if not os.path.exists(secrets_path):
+        return
+    try:
+        with open(secrets_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:  # pragma: no cover - log only
+        raise RuntimeError(f"Failed to load secrets file: {exc}") from exc
+
+    for key, value in data.items():
+        os.environ.setdefault(key, str(value))
+
+
+# Load secrets before configuring the application
+load_secrets_file()
 
 class Config:
-    """Application configuration loaded from environment variables."""
+    """Application configuration loaded from environment variables or a secrets file."""
 
     SECRET_KEY = os.environ.get('RETRORECON_SECRET', 'CHANGE_THIS_TO_A_RANDOM_SECRET_KEY')
     DB_ENV = os.environ.get('RETRORECON_DB')
     DATABASE = None  # Will be set in app.py after app root is known
     LOG_LEVEL = os.environ.get('RETRORECON_LOG_LEVEL', 'WARNING')
+    DOCKERHUB_API = os.environ.get('DOCKERHUB_API')
+    VIRUSTOTAL_API = os.environ.get('VIRUSTOTAL_API')

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -1,0 +1,5 @@
+{
+  "RETRORECON_SECRET": "change_me",
+  "DOCKERHUB_API": "",
+  "VIRUSTOTAL_API": ""
+}

--- a/tests/test_secrets_file.py
+++ b/tests/test_secrets_file.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+
+def test_secret_key_from_secrets_file(monkeypatch, tmp_path):
+    secrets = tmp_path / 'secrets.json'
+    secrets.write_text(json.dumps({'RETRORECON_SECRET': 'filekey'}))
+    monkeypatch.setenv('RETRORECON_SECRETS_FILE', str(secrets))
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import importlib
+    import config
+    importlib.reload(config)
+    import app
+    importlib.reload(app)
+
+    monkeypatch.setattr(app.app, 'root_path', str(tmp_path))
+    with app.app.app_context():
+        assert app.app.secret_key == 'filekey'
+
+    monkeypatch.delenv('RETRORECON_SECRETS_FILE', raising=False)
+


### PR DESCRIPTION
## Summary
- load env values from optional `secrets.json`
- ship `secrets.example.json` with example tokens
- document secrets file in README and mark secret-key task done
- test loading secret key via secrets file

## Testing
- `pytest -q`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68573c7195b083328644916beae0db9b