### PR TITLE
Simplify CI Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,11 @@ on: [push, pull_request]
 jobs:
   python-tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Cache pip
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- drop matrix build from CI workflow
- set CI to run on Python 3.11 only

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685746c299488332a9d6004ed321e3a9