### PR TITLE
Enable URL export to multiple formats

### DIFF
--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -8,5 +8,6 @@ from .registry import bp as registry_bp
 from .dag import bp as dag_bp
 from .oci import bp as oci_bp
 from .dagdotdev import bp as dagdotdev_bp
+from .urls import bp as urls_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp']

--- a/retrorecon/routes/urls.py
+++ b/retrorecon/routes/urls.py
@@ -1,0 +1,39 @@
+import io
+import csv
+from typing import List, Optional
+
+import app
+from flask import Blueprint, request, Response, jsonify
+
+bp = Blueprint('urls', __name__)
+
+@bp.route('/export_urls', methods=['GET'])
+def export_urls():
+    """Export URL records in various formats."""
+    if not app._db_loaded():
+        return jsonify([])
+
+    fmt = request.args.get('format', 'json').lower()
+    q = request.args.get('q', '').strip()
+    select_all = request.args.get('select_all_matching', 'false').lower() == 'true'
+    ids: Optional[List[int]] = None
+    if not select_all:
+        ids = [int(i) for i in request.args.getlist('id') if i.isdigit()]
+    rows = app.export_url_data(ids=ids, query=q)
+
+    if fmt == 'txt':
+        text = '\n'.join(r['url'] for r in rows)
+        return Response(text, mimetype='text/plain')
+    if fmt == 'csv':
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(['url', 'timestamp', 'status_code', 'mime_type', 'tags'])
+        for r in rows:
+            writer.writerow([r['url'], r['timestamp'], r['status_code'], r['mime_type'], r['tags']])
+        return Response(output.getvalue(), mimetype='text/csv')
+    if fmt == 'md':
+        lines = ['| url | timestamp | status_code | mime_type | tags |', '|---|---|---|---|---|']
+        for r in rows:
+            lines.append(f"| {r['url']} | {r['timestamp'] or ''} | {r['status_code'] or ''} | {r['mime_type'] or ''} | {r['tags'] or ''} |")
+        return Response('\n'.join(lines), mimetype='text/markdown')
+    return jsonify(rows)

--- a/static/index_page.js
+++ b/static/index_page.js
@@ -27,4 +27,36 @@ document.addEventListener('DOMContentLoaded', function(){
       }
     });
   });
+
+  const exportSel = document.getElementById('url-export-formats');
+  const exportForm = document.getElementById('url-export-form');
+  const exportFmt = document.getElementById('url-export-format');
+  const exportQ = document.getElementById('url-export-q');
+  const exportSam = document.getElementById('url-export-sam');
+  if(exportSel && exportForm){
+    exportSel.addEventListener('change', () => {
+      const fmt = exportSel.value;
+      if(!fmt) return;
+      exportFmt.value = fmt;
+      if(exportQ){
+        const box = document.getElementById('searchbox');
+        exportQ.value = box ? box.value.trim() : '';
+      }
+      if(exportSam){
+        exportSam.value = document.getElementById('select-all-matching-input').value;
+      }
+      exportForm.querySelectorAll('input[name="id"]').forEach(n => n.remove());
+      if(exportSam.value !== 'true'){
+        document.querySelectorAll('.row-checkbox:checked').forEach(cb => {
+          const inp = document.createElement('input');
+          inp.type = 'hidden';
+          inp.name = 'id';
+          inp.value = cb.value;
+          exportForm.appendChild(inp);
+        });
+      }
+      exportForm.submit();
+      exportSel.value = '';
+    });
+  }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -101,11 +101,21 @@
             <input id="domain-input" type="hidden" name="domain" />
             <button type="button" class="menu-btn" id="fetch-cdx-btn">Import from Wayback API</button>
           </form>
-          <div class="menu-row"><a href="#" class="menu-btn">Export JSON</a></div>
+          <select id="url-export-formats" class="form-select menu-btn">
+            <option value="" selected>Export...</option>
+            <option value="txt">Plain Text</option>
+            <option value="md">Markdown</option>
+            <option value="csv">CSV</option>
+            <option value="json">JSON</option>
+          </select>
+          <form id="url-export-form" class="hidden" action="/export_urls" method="GET" target="_blank">
+            <input type="hidden" name="format" id="url-export-format" />
+            <input type="hidden" name="q" id="url-export-q" value="{{ q }}" />
+            <input type="hidden" name="select_all_matching" id="url-export-sam" value="{{ 'true' if select_all_matching else 'false' }}" />
+          </form>
           <form method="GET" action="/save_db" id="save-db-form" class="menu-row">
             <button type="submit" class="menu-btn">Export SQLite (.db)</button>
           </form>
-          <div class="menu-row"><a href="#" class="menu-btn">Export CSV</a></div>
       </div>
     </div>
     <div class="dropdown">

--- a/tests/test_export_urls.py
+++ b/tests/test_export_urls.py
@@ -1,0 +1,57 @@
+import io
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def init_sample(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db('urls')
+        id1 = app.execute_db(
+            "INSERT INTO urls (url, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?)",
+            ['http://a.com', '20200101', 200, 'text/html', 'tag1']
+        )
+        id2 = app.execute_db(
+            "INSERT INTO urls (url, timestamp, status_code, mime_type, tags) VALUES (?, ?, ?, ?, ?)",
+            ['http://b.com', '20200102', 404, 'text/html', 'tag2']
+        )
+    return id1, id2
+
+
+def test_export_formats(tmp_path, monkeypatch):
+    id1, _ = init_sample(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get(f'/export_urls?format=txt&id={id1}')
+        assert resp.status_code == 200
+        assert b'http://a.com' in resp.data
+        resp = client.get('/export_urls?format=csv&select_all_matching=true&q=.com')
+        text = resp.data.decode()
+        assert 'http://a.com' in text and 'http://b.com' in text
+        resp = client.get('/export_urls?format=md&id={}'.format(id1))
+        assert resp.status_code == 200
+        assert b'| http://a.com |' in resp.data
+        resp = client.get('/export_urls?id={}&format=json'.format(id1))
+        assert resp.is_json
+        data = resp.get_json()
+        assert data and data[0]['url'] == 'http://a.com'
+
+
+def test_export_query_filter(tmp_path, monkeypatch):
+    init_sample(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/export_urls?format=txt&q=b.com&select_all_matching=true')
+        text = resp.data.decode()
+        assert 'http://b.com' in text
+        assert 'http://a.com' not in text


### PR DESCRIPTION
## Summary
- add utility to export URL data from the database
- expose `/export_urls` route returning txt/markdown/csv/json
- wire new blueprint and JS for export
- add export dropdown to the UI
- test URL export behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685745daaefc83328c5a9922c282dc59