### PR TITLE
Release 1.5 docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - Search and filter by text and tags, including Boolean tag expressions like `#blue AND #tag1`
 - Inline and bulk tag management
 - Bulk actions with "select all visible" or "select all matching"
+- Export URL results as JSON, CSV, Markdown or plain text
 - Quick OSINT links for each URL (Wayback, Shodan, VirusTotal, Google, GitHub, crt.sh)
 - Download, create or switch between databases from the menu, including naming
   new ones

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -307,6 +307,19 @@ Download all notes as structured JSON.
 curl http://localhost:5000/export_notes
 ```
 
+### `GET /export_urls`
+Export URL records in various formats.
+
+Parameters:
+- `format` – one of `txt`, `csv`, `md` or `json`.
+- `q` – optional search query.
+- `id` – repeatable ID filter when not using `select_all_matching`.
+- `select_all_matching` – set to `true` to export all results for the query.
+
+```
+curl -L "http://localhost:5000/export_urls?format=csv&id=1&id=2"
+```
+
 ## Generating a Postman Collection
 Run the helper script to generate a Postman collection from the application's route map:
 

--- a/reports/report.json
+++ b/reports/report.json
@@ -1,16 +1,16 @@
 {
   "coverage": {
     "button": {
-      "total": 64,
-      "styled": 64
+      "total": 66,
+      "styled": 66
     },
     "input": {
-      "total": 38,
-      "styled": 16
+      "total": 42,
+      "styled": 19
     },
     "select": {
-      "total": 8,
-      "styled": 8
+      "total": 11,
+      "styled": 11
     },
     "checkbox": {
       "total": 7,

--- a/templates/index.html
+++ b/templates/index.html
@@ -335,7 +335,7 @@
     {{ render_pagination(page, total_pages, q, total_count, items_per_page, select_all_matching) }}
     <div class="footer">
       <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline text-muted">
-        retrorecon - v1.2.0 by @savant42 &copy; 2025
+        retrorecon - v1.5.0 by @savant42 &copy; 2025
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- document the new `/export_urls` endpoint
- note export feature in README
- bump footer version to v1.5.0
- regenerate CSS audit report

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`
- `python scripts/deploy_docker.py` *(fails: DOCKERHUB_USERNAME and DOCKERHUB_PAT must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6857499075e483328d17d299b1279e37