### PR TITLE
Fix secrets file encoding

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,11 @@ def load_secrets_file(path: str = "secrets.json") -> None:
     try:
         with open(secrets_path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
+    except UnicodeDecodeError:
+        # Some editors on Windows may save JSON as UTF-16 with a BOM.
+        # Fallback to UTF-16 if UTF-8 decoding fails.
+        with open(secrets_path, "r", encoding="utf-16") as fh:
+            data = json.load(fh)
     except Exception as exc:  # pragma: no cover - log only
         raise RuntimeError(f"Failed to load secrets file: {exc}") from exc
 

--- a/tests/test_secrets_file.py
+++ b/tests/test_secrets_file.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 
 def test_secret_key_from_secrets_file(monkeypatch, tmp_path):
+    monkeypatch.delenv('RETRORECON_SECRET', raising=False)
     secrets = tmp_path / 'secrets.json'
     secrets.write_text(json.dumps({'RETRORECON_SECRET': 'filekey'}))
     monkeypatch.setenv('RETRORECON_SECRETS_FILE', str(secrets))
@@ -21,4 +22,26 @@ def test_secret_key_from_secrets_file(monkeypatch, tmp_path):
         assert app.app.secret_key == 'filekey'
 
     monkeypatch.delenv('RETRORECON_SECRETS_FILE', raising=False)
+    monkeypatch.delenv('RETRORECON_SECRET', raising=False)
+
+
+def test_secret_key_utf16_file(monkeypatch, tmp_path):
+    monkeypatch.delenv('RETRORECON_SECRET', raising=False)
+    secrets = tmp_path / 'secrets.json'
+    secrets.write_text(json.dumps({'RETRORECON_SECRET': 'utf16key'}), encoding='utf-16')
+    monkeypatch.setenv('RETRORECON_SECRETS_FILE', str(secrets))
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import importlib
+    import config
+    importlib.reload(config)
+    import app
+    importlib.reload(app)
+
+    monkeypatch.setattr(app.app, 'root_path', str(tmp_path))
+    with app.app.app_context():
+        assert app.app.secret_key == 'utf16key'
+
+    monkeypatch.delenv('RETRORECON_SECRETS_FILE', raising=False)
+    monkeypatch.delenv('RETRORECON_SECRET', raising=False)
 


### PR DESCRIPTION
## Summary
- handle secrets.json saved as UTF-16
- test UTF-16 secrets file loading

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574e247c1c8332a09340c15f7714ed