### PR TITLE
Reduce tag pill size

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -862,13 +862,13 @@ body {
 /* Tag pills styling */
 .retrorecon-root .tag-pill {
   display: inline-block;
-  padding: 2px 8px;
+  padding: 1px 4px;
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
   border: 1px solid var(--color-contrast);
   margin-right: 4px;
-  font-size: 0.95em;
+  font-size: 0.475em;
   margin-bottom: 4px;
   color: var(--fg-color);
 }
@@ -879,8 +879,8 @@ body {
   background: none;
   border: none;
   color: inherit;
-  font-size: 1em;
-  margin-left: 2px;
+  font-size: 0.5em;
+  margin-left: 1px;
   cursor: pointer;
   transition: opacity 0.2s;
 }
@@ -888,8 +888,8 @@ body {
 .retrorecon-root .search-history .tag-pill {
   display: inline-flex;
   align-items: center;
-  padding: 2px 6px;
-  font-size: 0.55em;
+  padding: 1px 3px;
+  font-size: 0.275em;
   font-weight: 600;
   margin-right: 4px;
   margin-bottom: 4px;
@@ -1024,8 +1024,8 @@ body {
   background: none;
   border: none;
   color: inherit;
-  font-size: 0.8em;
-  margin-left: 0.35em;
+  font-size: 0.4em;
+  margin-left: 0.175em;
   cursor: pointer;
   transition: opacity 0.2s;
 }

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -141,13 +141,13 @@ body.bg-hidden {
 
 .retrorecon-root .tag-pill {
   display: inline-block;
-  padding: 2px 8px;
+  padding: 1px 4px;
   background: var(--bg-color);
   opacity: 1;
   border-radius: 10px;
   border: 1px solid var(--color-contrast);
   margin-right: 4px;
-  font-size: 0.95em;
+  font-size: 0.475em;
   margin-bottom: 4px;
   color: var(--fg-color);
 }
@@ -160,8 +160,8 @@ body.bg-hidden {
   background: none;
   border: none;
   color: inherit;
-  font-size: 1em;
-  margin-left: 2px;
+  font-size: 0.5em;
+  margin-left: 1px;
   cursor: pointer;
   transition: opacity 0.2s;
 }
@@ -183,8 +183,8 @@ body.bg-hidden {
 .retrorecon-root .search-history .tag-pill {
   display: inline-flex;
   align-items: center;
-  padding: 2px 6px;
-  font-size: 0.55em;
+  padding: 1px 3px;
+  font-size: 0.275em;
   font-weight: 600;
   margin-right: 4px;
   margin-bottom: 4px;
@@ -206,8 +206,8 @@ body.bg-hidden {
   background: none;
   border: none;
   color: inherit;
-  font-size: 0.8em;
-  margin-left: 0.35em;
+  font-size: 0.4em;
+  margin-left: 0.175em;
   cursor: pointer;
   transition: opacity 0.2s;
 }


### PR DESCRIPTION
## Summary
- shrink tag pill font and padding in base styles
- apply same sizing adjustments to neon theme

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576bf240bc8332b5f8535daee4e757