### PR TITLE
Add Swagger UI support

### DIFF
--- a/app.py
+++ b/app.py
@@ -784,6 +784,7 @@ from retrorecon.routes import (
     oci_bp,
     dagdotdev_bp,
     urls_bp,
+    swagger_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -796,6 +797,7 @@ app.register_blueprint(dag_bp)
 app.register_blueprint(oci_bp)
 app.register_blueprint(dagdotdev_bp)
 app.register_blueprint(urls_bp)
+app.register_blueprint(swagger_bp)
 
 
 @app.after_request

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Pillow
 playwright
 pyelftools
 tldextract
+flask-swagger-ui

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -9,5 +9,6 @@ from .dag import bp as dag_bp
 from .oci import bp as oci_bp
 from .dagdotdev import bp as dagdotdev_bp
 from .urls import bp as urls_bp
+from .swagger import bp as swagger_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp']

--- a/retrorecon/routes/swagger.py
+++ b/retrorecon/routes/swagger.py
@@ -1,0 +1,14 @@
+from flask_swagger_ui import get_swaggerui_blueprint
+
+SWAGGER_URL = '/swagger'
+API_URL = '/static/openapi.yaml'
+
+bp = get_swaggerui_blueprint(
+    SWAGGER_URL,
+    API_URL,
+    config={
+        'app_name': 'Retrorecon Swagger',
+        'displayRequestDuration': True,
+        'tryItOutEnabled': True,
+    },
+)

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.0
+info:
+  title: Retrorecon API
+  version: "1.0"
+paths:
+  /import_progress:
+    get:
+      summary: Get import progress status
+      responses:
+        '200':
+          description: JSON progress data
+          content:
+            application/json:
+              schema:
+                type: object
+  /fetch_cdx:
+    post:
+      summary: Fetch CDX records
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+      responses:
+        '302':
+          description: Redirect to index with flash message
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    bearerAuth:
+      type: http
+      scheme: bearer
+    jwtAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    customHeaderAuth:
+      type: apiKey
+      in: header
+      name: X-Custom-Auth

--- a/templates/index.html
+++ b/templates/index.html
@@ -189,6 +189,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">ScreenShotter</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="dag-explorer-link">OCI Explorer</a></div>
+          <div class="menu-row"><a href="/swagger" class="menu-btn" id="swagger-ui-link" target="_blank">Swagger UI</a></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add Swagger blueprint for interactive API docs
- link Swagger UI in the Tools dropdown
- include simple OpenAPI spec
- install `flask-swagger-ui`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576e43b6488332a099e4bdab649b88