### PR TITLE
Fix favicon template usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,7 +63,7 @@ app.add_template_filter(manifest_links, name="manifest_links")
 app.add_template_filter(oci_obj, name="oci_obj")
 
 
-@app.route('/favicon.ico')
+@app.route('/favicon.ico', endpoint='core.favicon_ico')
 def favicon_ico() -> Response:
     """Serve the favicon.ico from the application root."""
     return send_from_directory(app.root_path, 'favicon.ico', mimetype='image/vnd.microsoft.icon')

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
     {% endfor %}
     /* stylelint-enable */
   </style>
-  <link rel="shortcut icon" href="{{ url_for('favicon_ico') }}">
+  <link rel="shortcut icon" href="{{ url_for('core.favicon_ico') }}">
 </head>
 <body class="app">
   <div class="retrorecon-root">


### PR DESCRIPTION
## Summary
- reference `core.favicon_ico` in index template
- expose favicon route using endpoint `core.favicon_ico`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576edbac04833297b7567c28e040ae