### PR TITLE
Switch subdomonster source selection to dropdown

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -14,7 +14,7 @@ function initSubdomonster(){
   const exportFormatInp = document.getElementById('subdom-export-format');
   const exportQInp = document.getElementById('subdom-export-q');
   const searchInput = document.getElementById('subdomonster-search');
-  const sourceRadios = document.getElementsByName('subdomonster-source');
+  const sourceSel = document.getElementById('subdomonster-source');
   const apiInput = document.getElementById('subdomonster-api-key');
   const selectModeSel = document.getElementById('subdom-select-mode');
   const bulkTag = document.getElementById('subdom-bulk-tag');
@@ -257,21 +257,14 @@ function initSubdomonster(){
     });
   }
 
-  for(const rb of sourceRadios){
-    rb.addEventListener('change', () => {
-      const val = rb.value;
-      if(rb.checked){
-        apiInput.classList.toggle('hidden', val !== 'virustotal');
-      }
+  if(sourceSel){
+    sourceSel.addEventListener('change', () => {
+      const val = sourceSel.value;
+      apiInput.classList.toggle('hidden', val !== 'virustotal');
     });
+    // initialize visibility
+    apiInput.classList.toggle('hidden', sourceSel.value !== 'virustotal');
   }
-  // initialize visibility
-  (function(){
-    let active = Array.from(sourceRadios).find(r=>r.checked);
-    if(active){
-      apiInput.classList.toggle('hidden', active.value !== 'virustotal');
-    }
-  })();
 
   function render(){
     const filtered = searchText ?
@@ -487,8 +480,7 @@ function initSubdomonster(){
 
   fetchBtn.addEventListener('click', async () => {
     const domain = domainInput.value.trim();
-    let source = 'crtsh';
-    for(const rb of sourceRadios){ if(rb.checked){ source = rb.value; break; } }
+    const source = sourceSel ? sourceSel.value : 'crtsh';
     const params = new URLSearchParams();
     if(domain) params.append('domain', domain);
     params.append('source', source);

--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -2,9 +2,11 @@
 <div id="subdomonster-overlay" class="notes-overlay hidden">
   <div class="mb-05">
     <input type="text" id="subdomonster-domain" class="form-input mr-05" placeholder="example.com" />
-    <label class="mr-05"><input type="radio" name="subdomonster-source" value="crtsh" checked> crt.sh</label>
-    <label class="mr-05"><input type="radio" name="subdomonster-source" value="virustotal"> VirusTotal</label>
-    <label class="mr-05"><input type="radio" name="subdomonster-source" value="local"> Local</label>
+    <select id="subdomonster-source" class="form-select mr-05">
+      <option value="crtsh" selected>crt.sh</option>
+      <option value="virustotal">VirusTotal</option>
+      <option value="local">Local</option>
+    </select>
     <input type="text" id="subdomonster-api-key" class="form-input mr-05 hidden" placeholder="API key" />
     <button type="button" class="btn" id="subdomonster-fetch-btn">Fetch</button>
     <input type="text" id="subdomonster-search" class="form-input mr-05" placeholder="search" />

--- a/tests/test_subdomonster.py
+++ b/tests/test_subdomonster.py
@@ -30,6 +30,7 @@ def test_subdomonster_route(tmp_path, monkeypatch):
         resp = client.get('/subdomonster')
         assert resp.status_code == 200
         assert b'id="subdomonster-overlay"' in resp.data
+        assert b'id="subdomonster-source"' in resp.data
         assert b'id="subdom-select-mode"' in resp.data
 
 


### PR DESCRIPTION
## Summary
- swap radio buttons for a dropdown in `subdomonster.html`
- update JS logic to use the select element
- adapt tests for the new input element

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857714c0c2c83328acfbd324e77ed91