### PR TITLE
Fix Subdomonster column width init

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -171,13 +171,17 @@ function initSubdomonster(){
     try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
     ths.forEach((th, idx) => {
       const id = idx;
-      if(widths[id]){
-        th.style.width = widths[id];
-        if(cols[id]) cols[id].style.width = widths[id];
+      let w = widths[id];
+      if(!w){
+        const ow = th.offsetWidth;
+        if(ow > 0){
+          w = ow + 'px';
+        }
       }
-      const initial = th.style.width || th.offsetWidth + 'px';
-      th.style.width = initial;
-      if(cols[id]) cols[id].style.width = initial;
+      if(w){
+        th.style.width = w;
+        if(cols[id]) cols[id].style.width = w;
+      }
       if(th.classList.contains('no-resize')) return;
       const res = document.createElement('div');
       res.className = 'col-resizer';


### PR DESCRIPTION
## Summary
- avoid zero width columns when Subdomonster overlay is hidden

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577a04a07c8332939ff8e357940e79