### PR TITLE
Fix Subdomonster table column widths

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -5,12 +5,12 @@
       "styled": 66
     },
     "input": {
-      "total": 42,
+      "total": 39,
       "styled": 19
     },
     "select": {
-      "total": 11,
-      "styled": 11
+      "total": 12,
+      "styled": 12
     },
     "checkbox": {
       "total": 7,

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -289,7 +289,7 @@ function initSubdomonster(){
     if(currentPage > totalPages) currentPage = totalPages;
     const pageData = sorted.slice((currentPage-1)*itemsPerPage, (currentPage-1)*itemsPerPage + itemsPerPage);
     let html = '<table class="table url-table w-100"><colgroup>'+
-      '<col/><col/><col/><col/><col/><col class="send-col"/><col class="tag-col"/>'+
+      '<col class="w-2em"/><col/><col/><col/><col/><col class="send-col"/><col class="tag-col"/>'+
       '</colgroup><thead><tr>'+
       '<th class="w-2em"><input type="checkbox" onclick="document.querySelectorAll(\'#subdomonster-table .row-checkbox\').forEach(c=>c.checked=this.checked);selectAll=false;" /></th>'+
       '<th class="sortable" data-field="subdomain">Subdomain</th>'+


### PR DESCRIPTION
## Summary
- ensure Subdomonster table uses a `w-2em` column like the URL results table
- update CSS audit report

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_68577dbe71ac8332ab8761d3707ab851