### PR TITLE
Add neon swirl background effect

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -174,8 +174,7 @@ body {
 /* --- Updated CSS to emulate Fandom Map Room style --- */
 
 .retrorecon-root {
-  background: var(--bg-color) url("/static/img/background.jpg") no-repeat center center fixed;
-  background-size: cover;
+  background: var(--bg-color);
   display: flex;
   flex-direction: column;
   font-family: var(--font-main);
@@ -186,6 +185,38 @@ body {
   overflow: hidden;
   color: #ffffff;
   line-height: 1.5;
+}
+
+.retrorecon-root.neon-bg::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+      45deg,
+      #ff00aa,
+      #ff00aa 10%,
+      #00ffff 10%,
+      #00ffff 20%
+    );
+  background-size: 200% 200%;
+  opacity: 0.4;
+  animation: neon-swirl 20s linear infinite;
+  z-index: -1;
+}
+
+@keyframes neon-swirl {
+  from {
+    transform: rotate(0deg);
+    background-position: 0 0;
+  }
+  to {
+    transform: rotate(360deg);
+    background-position: 200% 0;
+  }
+}
+
+body.bg-hidden .retrorecon-root.neon-bg::before {
+  display: none;
 }
 
 /* Force all text to white 14px */

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
   <link rel="shortcut icon" href="{{ url_for('core.favicon_ico') }}">
 </head>
 <body class="app">
-  <div class="retrorecon-root">
+  <div class="retrorecon-root neon-bg">
     <div id="dropdown-shade" class="dropdown-shade hidden"></div>
 {% macro render_pagination(page, total_pages, q, total_count, items_per_page, select_all_matching) %}
   <div class="pagination mt-05">


### PR DESCRIPTION
## Summary
- use `neon-bg` class on index page container
- add CSS for swirling neon stripe background

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6857863730b48332bf4f8c0c2a4be107