### PR TITLE
Add Google font preload

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -17,5 +17,10 @@
       "styled": 5
     }
   },
-  "unscoped_selectors": {}
+  "unscoped_selectors": {
+    "static/base.css": [
+      "from",
+      "to"
+    ]
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <title>retrorecon - {{ db_name }} - {{ total_count }} results</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
   {% if current_theme %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -3,6 +3,9 @@
 <head>
   <title>{{ title or 'Registry Explorer' }}</title>
   <link rel="icon" href="{{ url_for('favicon_svg') }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}">
   {% set current_theme = session.get('theme') %}
   {% if current_theme %}


### PR DESCRIPTION
## Summary
- load Share Tech Mono from Google Fonts in index and OCI templates
- update CSS audit report

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6857889b0de483329b548a77caacc66c