### PR TITLE
Improve results frame style

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -588,7 +588,7 @@ body {
 .retrorecon-root .results-grid {
   display: grid;
   grid-template-columns: 1fr;
-  margin: 5px 10px 10px;
+  margin: 5px 10px;
   gap: 1em;
 }
 .retrorecon-root .results-frame {
@@ -602,6 +602,13 @@ body {
   /* Maintain visible frame even when no URLs are listed */
   min-height: 600px;
   overflow-y: auto;
+}
+
+.retrorecon-root .table-container {
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
+  border-radius: 8px;
+  box-shadow: 0 1px 6px var(--fg-color);
+  padding: 0.5em;
 }
 
 /* Styling for the "no results" message */

--- a/templates/index.html
+++ b/templates/index.html
@@ -247,7 +247,7 @@
 
   <!-- Table D : Results -->
   <div id="layout-d" class="w-100 mt-1">
-    <div class="results-grid results-frame">
+    <div class="results-grid results-frame table-container">
 
           {% if urls %}
           <form method="POST" action="/bulk_action" id="bulk-form">


### PR DESCRIPTION
## Summary
- tweak results frame margin
- add `.table-container` style for rounded panels
- use `.table-container` on results grid

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68578d94c63c8332973c7a0d9b006774