### PR TITLE
Style overhaul for Swagger UI

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -17,10 +17,5 @@
       "styled": 5
     }
   },
-  "unscoped_selectors": {
-    "static/base.css": [
-      "from",
-      "to"
-    ]
-  }
+  "unscoped_selectors": {}
 }

--- a/retrorecon/routes/swagger.py
+++ b/retrorecon/routes/swagger.py
@@ -1,14 +1,39 @@
-from flask_swagger_ui import get_swaggerui_blueprint
+"""Custom Swagger UI blueprint using Retrorecon styling."""
+
+import json
+import os
+from flask import Blueprint, render_template, request, send_from_directory
+import flask_swagger_ui
 
 SWAGGER_URL = '/swagger'
 API_URL = '/static/openapi.yaml'
 
-bp = get_swaggerui_blueprint(
-    SWAGGER_URL,
-    API_URL,
-    config={
-        'app_name': 'Retrorecon Swagger',
-        'displayRequestDuration': True,
-        'tryItOutEnabled': True,
-    },
-)
+DIST_DIR = os.path.join(os.path.dirname(flask_swagger_ui.__file__), "dist")
+
+bp = Blueprint("swagger_ui", __name__, url_prefix=SWAGGER_URL)
+
+_config = {
+    "app_name": "Retrorecon Swagger",
+    "dom_id": "#swagger-ui",
+    "url": API_URL,
+    "layout": "StandaloneLayout",
+    "deepLinking": True,
+    "displayRequestDuration": True,
+    "tryItOutEnabled": True,
+}
+
+
+@bp.route("/")
+@bp.route("/<path:path>")
+def show(path: str | None = None):
+    """Serve the Swagger UI with Retrorecon styling."""
+    if not path or path == "index.html":
+        if not _config.get("oauth2RedirectUrl"):
+            _config["oauth2RedirectUrl"] = os.path.join(request.base_url, "oauth2-redirect.html")
+        fields = {
+            "base_url": SWAGGER_URL,
+            "app_name": _config.get("app_name", "Swagger UI"),
+            "config_json": json.dumps({k: v for k, v in _config.items() if k != "app_name"}),
+        }
+        return render_template("swaggerui.html", **fields)
+    return send_from_directory(DIST_DIR, path)

--- a/templates/swaggerui.html
+++ b/templates/swaggerui.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ app_name }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
+  {% set current_theme = session.get('theme') %}
+  {% if current_theme %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
+  {% endif %}
+  {% set current_background = session.get('background') %}
+  {% if current_background %}
+  <style>
+    body { background-image: url('{{ url_for('static', filename='img/' + current_background) }}'); }
+  </style>
+  {% endif %}
+  <link rel="stylesheet" type="text/css" href="{{ base_url }}/index.css" />
+  <link rel="stylesheet" type="text/css" href="{{ base_url }}/swagger-ui.css" />
+  <link rel="icon" type="image/png" href="{{ base_url }}/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="{{ base_url }}/favicon-16x16.png" sizes="16x16" />
+</head>
+<body class="app">
+<div class="retrorecon-root">
+  <div id="swagger-ui"></div>
+</div>
+<script src="{{ base_url }}/swagger-ui-bundle.js"></script>
+<script src="{{ base_url }}/swagger-ui-standalone-preset.js"></script>
+<script>
+  var config = {
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+    ]
+  };
+  var user_config = {{ config_json | safe }};
+  for (var attrname in user_config) { config[attrname] = user_config[attrname]; }
+  window.onload = function () {
+    const ui = SwaggerUIBundle(config);
+    window.ui = ui;
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create custom swaggerui.html template that loads site fonts, theme and background
- reimplement Swagger blueprint to render custom template
- update CSS audit report

## Testing
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6857936d49308332b9b777f1af9b7e37