### PR TITLE
Fix Swagger scheme-container style and close button

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1225,3 +1225,16 @@ body.bg-hidden {
   max-height: 80vh;
   overflow-y: auto;
 }
+
+/* Swagger UI overrides */
+.retrorecon-root #swagger-ui .scheme-container {
+  background: var(--bg-color);
+  color: var(--fg-color);
+  border: 1px solid var(--color-contrast);
+}
+
+/* Generic close button for standalone pages */
+.retrorecon-root .close-btn {
+  float: right;
+  margin-left: 1em;
+}

--- a/templates/swaggerui.html
+++ b/templates/swaggerui.html
@@ -24,6 +24,7 @@
 </head>
 <body class="app">
 <div class="retrorecon-root">
+  <button type="button" class="btn btn--small close-btn" onclick="history.back();">Close</button>
   <div id="swagger-ui"></div>
 </div>
 <script src="{{ base_url }}/swagger-ui-bundle.js"></script>


### PR DESCRIPTION
## Summary
- style the Swagger UI scheme container for dark theme
- add a close button to the Swagger page

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68579840699483328c1acd4ebeca23a2