### PR TITLE
Fix Subdomonster layout

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -289,12 +289,12 @@ function initSubdomonster(){
     if(currentPage > totalPages) currentPage = totalPages;
     const pageData = sorted.slice((currentPage-1)*itemsPerPage, (currentPage-1)*itemsPerPage + itemsPerPage);
     let html = '<table class="table url-table w-100"><colgroup>'+
-      '<col class="checkbox-col"/><col/><col/><col/><col class="cdxed-col"/><col class="send-col actions-col"/><col class="tag-col"/>'+
+      '<col class="checkbox-col"/><col class="subdomain-col"/><col class="domain-col"/><col class="source-col"/><col class="cdxed-col"/><col class="send-col actions-col"/><col class="tag-col"/>'+
       '</colgroup><thead><tr>'+
       '<th class="checkbox-col"><input type="checkbox" onclick="document.querySelectorAll(\'#subdomonster-table .row-checkbox\').forEach(c=>c.checked=this.checked);selectAll=false;" /></th>'+
-      '<th class="sortable" data-field="subdomain">Subdomain</th>'+
-      '<th class="sortable" data-field="domain">Domain</th>'+
-      '<th class="sortable" data-field="source">Source</th>'+
+      '<th class="sortable subdomain-col" data-field="subdomain">Subdomain</th>'+
+      '<th class="sortable domain-col" data-field="domain">Domain</th>'+
+      '<th class="sortable source-col" data-field="source">Source</th>'+
       '<th class="sortable cdxed-col" data-field="cdx_indexed">CDXed</th>'+
       '<th class="no-resize actions-col">Actions:</th>'+
       '<th class="sortable" data-field="tags">Tags</th>'+

--- a/static/tools.css
+++ b/static/tools.css
@@ -108,6 +108,15 @@
 .retrorecon-root #subdomonster-table col.cdxed-col {
   width: 5.5ch;
 }
+.retrorecon-root #subdomonster-table col.subdomain-col {
+  width: 28ch;
+}
+.retrorecon-root #subdomonster-table col.domain-col {
+  width: 22ch;
+}
+.retrorecon-root #subdomonster-table col.source-col {
+  width: 9ch;
+}
 .retrorecon-root #subdomonster-table col.send-col {
   width: 280px;
 }

--- a/templates/subdomonster.html
+++ b/templates/subdomonster.html
@@ -21,10 +21,6 @@
       <input type="hidden" name="format" id="subdom-export-format" />
       <input type="hidden" name="q" id="subdom-export-q" />
     </form>
-    <button type="button" class="btn" id="subdomonster-close-btn">Close</button>
-    <span id="subdomonster-status" class="ml-05"></span>
-  </div>
-  <div class="mb-05">
     <select id="subdom-select-mode" class="form-select mr-05">
       <option value="" selected>Select...</option>
       <option value="page">Select Page</option>
@@ -36,6 +32,8 @@
     <button type="button" class="btn" id="subdom-remove-tag-btn">Remove Tag</button>
     <button type="button" class="btn" id="subdom-clear-tags-btn">Clear Tags</button>
     <button type="button" class="btn" id="subdom-delete-btn">Delete Selected</button>
+    <button type="button" class="btn" id="subdomonster-close-btn">Close</button>
+    <span id="subdomonster-status" class="ml-05"></span>
   </div>
   <div id="subdomonster-table" class="mt-05"></div>
   <div id="subdomonster-pagination" class="mt-05"></div>


### PR DESCRIPTION
## Summary
- fix layout of Subdomonster overlay by moving bulk action controls into the top row
- specify column widths for the Subdomonster table
- add column classes in the table markup

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68579c06d5fc833290cf0958260fff61