### PR TITLE
Style download url input

### DIFF
--- a/scripts/check_theme_elements.py
+++ b/scripts/check_theme_elements.py
@@ -35,6 +35,7 @@ ELEMENTS = {
     'json import input': '.retrorecon-root .form-file',
     'db import input': '.retrorecon-root .form-file',
     'map url input': '.retrorecon-root #map-url-input',
+    'download url input': '.retrorecon-root #download-url-input',
 }
 
 def parse_css(files: List[str]) -> Dict[str, Dict[str, str]]:

--- a/static/base.css
+++ b/static/base.css
@@ -552,6 +552,16 @@ body {
   padding: 2px 6px;
 }
 
+.retrorecon-root #download-url-input {
+  width: 250px;
+  max-width: 100%;
+  border: 1px solid var(--color-contrast);
+  border-radius: 5px;
+  background: var(--bg-color);
+  color: var(--fg-color);
+  padding: 2px 6px;
+}
+
 .retrorecon-root #domain-input {
   width: 250px;
 }

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -308,6 +308,16 @@ body.bg-hidden {
   padding: 2px 6px;
 }
 
+.retrorecon-root #download-url-input {
+  width: 250px;
+  max-width: 100%;
+  border: 1px solid var(--fg-color);
+  border-radius: 5px;
+  background: var(--bg-color);
+  color: var(--fg-color);
+  padding: 2px 6px;
+}
+
 /* Standardize dropdown menu styling */
 .retrorecon-root .dropdown-content {
   background-color: var(--color-base);


### PR DESCRIPTION
## Summary
- style `download-url-input` similar to `map-url-input`
- include `download-url-input` in theme checks

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68579e854e948332968759c660991171