### PR TITLE
Update swagger ui color

### DIFF
--- a/templates/swaggerui.html
+++ b/templates/swaggerui.html
@@ -11,6 +11,13 @@
   {% if current_theme %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
   {% endif %}
+  <style>
+    .retrorecon-root {
+      --color-base: #1b1b1b;
+      --bg-color: #1b1b1b;
+      --bg-rgb: 27 27 27;
+    }
+  </style>
   {% set current_background = session.get('background') %}
   {% if current_background %}
   <style>


### PR DESCRIPTION
## Summary
- tweak `swaggerui.html` to use a darker main color

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857a39fd4888332a44ba38f81eba62f