### PR TITLE
Fix results frame shadow

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -604,7 +604,7 @@ body {
 .retrorecon-root .results-frame {
   background: var(--bg-color);
   border-radius: 8px;
-  box-shadow: 0 1px 6px var(--fg-color);
+  box-shadow: none;
   padding: 0.5em;
   flex: 1 1 auto;
   display: flex;
@@ -617,7 +617,7 @@ body {
 .retrorecon-root .table-container {
   background: var(--bg-color);
   border-radius: 8px;
-  box-shadow: 0 1px 6px var(--fg-color);
+  box-shadow: none;
   padding: 0.5em;
 }
 


### PR DESCRIPTION
## Summary
- remove box shadows from results frame and table container

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857b0601f548332afc54f9b2f46174a