### PR TITLE
Fix font styling overrides

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -188,12 +188,6 @@ body {
   line-height: 1.5;
 }
 
-/* Force all text to white 14px */
-.retrorecon-root * {
-  color: #ffffff !important;
-  font-size: 14px !important;
-}
-
 /* Main header style */
 .retrorecon-root h1{
   margin: 1.4em 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -1292,25 +1292,6 @@
       });
     }
 
-    // Apply theme colors on the URL results table
-    document.querySelectorAll('.url-table tr').forEach(tr => {
-      if(tr.classList.contains('url-row-buttons')){
-        tr.style.backgroundColor = 'rgb(var(--bg-rgb)/var(--panel-opacity))';
-      } else {
-        tr.style.backgroundColor = 'rgb(var(--bg-rgb))';
-      }
-    });
-    document.querySelectorAll('.url-table tbody tr').forEach(tr => {
-      const cells = tr.querySelectorAll('td');
-      if (cells.length >= 5) {
-        cells[0].style.textAlign = 'center';
-        cells[2].style.textAlign = 'center';
-        cells[3].style.textAlign = 'center';
-        cells[4].style.textAlign = 'center';
-        cells[1].style.textAlign = 'left';
-        cells[1].style.fontWeight = 'bold';
-      }
-    });
 
     function toggleBackground(cb){
       if(cb.checked){


### PR DESCRIPTION
## Summary
- remove inline font override block in base.css
- drop JS that set table row styles in index template

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857b3a36b6c83328cb770b86209f7f2