### PR TITLE
Update docs with openapi and postman

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
 - Save favorite tag searches for quick reuse
 - Adjustable panel opacity and font size
 - Add notes to each URL result via a full-screen editor
+- View the database ER diagram in `docs/database_erd.md`.
+- Follow the OCI Explorer workflow in `docs/oic_explorer_user_journey.md`.
+- Browse the API via Swagger at `/swagger` using the OpenAPI file `static/openapi.yaml`.
 
 ## Installation
 ```bash
@@ -292,6 +295,12 @@ curl -X POST -d "domain=example.com" http://localhost:5000/subdomains
 curl "http://localhost:5000/subdomains?domain=example.com&page=1&items=50"
 curl http://localhost:5000/export_subdomains?domain=example.com
 ```
+
+## API Documentation
+
+An OpenAPI 3.0 document is generated from the running Flask application.
+Browse the interactive Swagger UI at `http://localhost:5000/swagger` or
+download the specification directly from `static/openapi.yaml`.
 
 
 ## License

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -2,6 +2,10 @@
 
 This document describes the HTTP endpoints exposed by the Flask application. All examples assume the server is running locally on `http://localhost:5000` and the `base_url` variable used by the Postman collection refers to that address.
 
+The complete route map can also be browsed via the built-in Swagger UI at
+`/swagger`. The underlying OpenAPI document is served as
+`/static/openapi.yaml`.
+
 ## General Notes
 
 - POST endpoints expect form data unless otherwise indicated.

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -148,3 +148,9 @@ This ensures database workflow tests are executed along with the existing suite 
 
 5. **Delete Capture**
    - POST `/delete_sitezips` with the capture ID and confirm it is removed from `/sitezips`.
+
+## API Spec Tests
+
+1. **OpenAPI Generation**
+   - Run `python scripts/generate_openapi_yaml.py`.
+   - Load `/swagger` and verify the UI shows all application routes.

--- a/scripts/generate_openapi_yaml.py
+++ b/scripts/generate_openapi_yaml.py
@@ -1,0 +1,60 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import yaml
+from app import app
+
+def convert(path: str) -> str:
+    out = ''
+    i = 0
+    while i < len(path):
+        if path[i] == '<':
+            j = path.index('>', i)
+            inner = path[i+1:j]
+            name = inner.split(':')[-1]
+            if '=' in name:
+                name = name.split('=')[0]
+            out += '{' + name + '}'
+            i = j + 1
+        else:
+            out += path[i]
+            i += 1
+    return out
+
+paths = {}
+for rule in app.url_map.iter_rules():
+    if rule.endpoint == 'static':
+        continue
+    op = {}
+    for method in sorted(rule.methods - {'HEAD', 'OPTIONS'}):
+        op[method.lower()] = {
+            'summary': f'{method} {rule.rule}',
+            'responses': {
+                '200': {'description': 'Successful response'}
+            }
+        }
+    paths[convert(rule.rule)] = op
+
+# stub routes for manual packets
+paths['/manual_packet'] = {
+    'post': {
+        'summary': 'Craft a manual packet (stub)',
+        'responses': {'200': {'description': 'OK'}}
+    }
+}
+paths['/manual_packet/{id}'] = {
+    'get': {
+        'summary': 'Retrieve manual packet (stub)',
+        'responses': {'200': {'description': 'OK'}}
+    }
+}
+
+openapi = {
+    'openapi': '3.0.0',
+    'info': {
+        'title': 'Retrorecon API',
+        'version': '1.1'
+    },
+    'paths': paths
+}
+
+with open('static/openapi.yaml', 'w') as fh:
+    yaml.dump(openapi, fh, sort_keys=False)

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1,46 +1,561 @@
 openapi: 3.0.0
 info:
   title: Retrorecon API
-  version: "1.0"
+  version: '1.1'
 paths:
-  /import_progress:
+  /favicon.ico:
     get:
-      summary: Get import progress status
+      summary: GET /favicon.ico
       responses:
         '200':
-          description: JSON progress data
-          content:
-            application/json:
-              schema:
-                type: object
+          description: Successful response
+  /favicon.svg:
+    get:
+      summary: GET /favicon.svg
+      responses:
+        '200':
+          description: Successful response
+  /:
+    get:
+      summary: GET /
+      responses:
+        '200':
+          description: Successful response
   /fetch_cdx:
     post:
-      summary: Fetch CDX records
-      requestBody:
-        required: true
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: object
-              properties:
-                domain:
-                  type: string
+      summary: POST /fetch_cdx
       responses:
-        '302':
-          description: Redirect to index with flash message
-components:
-  securitySchemes:
-    basicAuth:
-      type: http
-      scheme: basic
-    bearerAuth:
-      type: http
-      scheme: bearer
-    jwtAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-    customHeaderAuth:
-      type: apiKey
-      in: header
-      name: X-Custom-Auth
+        '200':
+          description: Successful response
+  /import_json:
+    post:
+      summary: POST /import_json
+      responses:
+        '200':
+          description: Successful response
+  /import_file:
+    post:
+      summary: POST /import_file
+      responses:
+        '200':
+          description: Successful response
+  /import_progress:
+    get:
+      summary: GET /import_progress
+      responses:
+        '200':
+          description: Successful response
+  /status:
+    get:
+      summary: GET /status
+      responses:
+        '200':
+          description: Successful response
+  /add_tag:
+    post:
+      summary: POST /add_tag
+      responses:
+        '200':
+          description: Successful response
+  /bulk_action:
+    post:
+      summary: POST /bulk_action
+      responses:
+        '200':
+          description: Successful response
+  /saved_tags:
+    get:
+      summary: GET /saved_tags
+      responses:
+        '200':
+          description: Successful response
+    post:
+      summary: POST /saved_tags
+      responses:
+        '200':
+          description: Successful response
+  /delete_saved_tag:
+    post:
+      summary: POST /delete_saved_tag
+      responses:
+        '200':
+          description: Successful response
+  /notes/{url_id}:
+    get:
+      summary: GET /notes/<int:url_id>
+      responses:
+        '200':
+          description: Successful response
+  /notes:
+    post:
+      summary: POST /notes
+      responses:
+        '200':
+          description: Successful response
+  /delete_note:
+    post:
+      summary: POST /delete_note
+      responses:
+        '200':
+          description: Successful response
+  /export_notes:
+    get:
+      summary: GET /export_notes
+      responses:
+        '200':
+          description: Successful response
+  /text_tools:
+    get:
+      summary: GET /text_tools
+      responses:
+        '200':
+          description: Successful response
+  /tools/text_tools:
+    get:
+      summary: GET /tools/text_tools
+      responses:
+        '200':
+          description: Successful response
+  /tools/base64_decode:
+    post:
+      summary: POST /tools/base64_decode
+      responses:
+        '200':
+          description: Successful response
+  /tools/base64_encode:
+    post:
+      summary: POST /tools/base64_encode
+      responses:
+        '200':
+          description: Successful response
+  /tools/url_decode:
+    post:
+      summary: POST /tools/url_decode
+      responses:
+        '200':
+          description: Successful response
+  /tools/url_encode:
+    post:
+      summary: POST /tools/url_encode
+      responses:
+        '200':
+          description: Successful response
+  /jwt_tools:
+    get:
+      summary: GET /jwt_tools
+      responses:
+        '200':
+          description: Successful response
+  /tools/jwt:
+    get:
+      summary: GET /tools/jwt
+      responses:
+        '200':
+          description: Successful response
+  /tools/jwt_decode:
+    post:
+      summary: POST /tools/jwt_decode
+      responses:
+        '200':
+          description: Successful response
+  /tools/jwt_encode:
+    post:
+      summary: POST /tools/jwt_encode
+      responses:
+        '200':
+          description: Successful response
+  /jwt_cookies:
+    get:
+      summary: GET /jwt_cookies
+      responses:
+        '200':
+          description: Successful response
+  /delete_jwt_cookies:
+    post:
+      summary: POST /delete_jwt_cookies
+      responses:
+        '200':
+          description: Successful response
+  /update_jwt_cookie:
+    post:
+      summary: POST /update_jwt_cookie
+      responses:
+        '200':
+          description: Successful response
+  /export_jwt_cookies:
+    get:
+      summary: GET /export_jwt_cookies
+      responses:
+        '200':
+          description: Successful response
+  /screenshotter:
+    get:
+      summary: GET /screenshotter
+      responses:
+        '200':
+          description: Successful response
+  /tools/screenshotter:
+    get:
+      summary: GET /tools/screenshotter
+      responses:
+        '200':
+          description: Successful response
+  /tools/screenshot:
+    post:
+      summary: POST /tools/screenshot
+      responses:
+        '200':
+          description: Successful response
+  /screenshots:
+    get:
+      summary: GET /screenshots
+      responses:
+        '200':
+          description: Successful response
+  /delete_screenshots:
+    post:
+      summary: POST /delete_screenshots
+      responses:
+        '200':
+          description: Successful response
+  /site2zip:
+    get:
+      summary: GET /site2zip
+      responses:
+        '200':
+          description: Successful response
+  /tools/site2zip:
+    post:
+      summary: POST /tools/site2zip
+      responses:
+        '200':
+          description: Successful response
+  /layerpeek:
+    get:
+      summary: GET /layerpeek
+      responses:
+        '200':
+          description: Successful response
+  /tools/layerpeek:
+    get:
+      summary: GET /tools/layerpeek
+      responses:
+        '200':
+          description: Successful response
+  /sitezips:
+    get:
+      summary: GET /sitezips
+      responses:
+        '200':
+          description: Successful response
+  /download_sitezip/{sid}:
+    get:
+      summary: GET /download_sitezip/<int:sid>
+      responses:
+        '200':
+          description: Successful response
+  /delete_sitezips:
+    post:
+      summary: POST /delete_sitezips
+      responses:
+        '200':
+          description: Successful response
+  /tools/webpack-zip:
+    post:
+      summary: POST /tools/webpack-zip
+      responses:
+        '200':
+          description: Successful response
+  /new_db:
+    post:
+      summary: POST /new_db
+      responses:
+        '200':
+          description: Successful response
+  /load_db:
+    post:
+      summary: POST /load_db
+      responses:
+        '200':
+          description: Successful response
+  /save_db:
+    get:
+      summary: GET /save_db
+      responses:
+        '200':
+          description: Successful response
+  /rename_db:
+    post:
+      summary: POST /rename_db
+      responses:
+        '200':
+          description: Successful response
+  /load_saved_db:
+    post:
+      summary: POST /load_saved_db
+      responses:
+        '200':
+          description: Successful response
+  /set_theme:
+    post:
+      summary: POST /set_theme
+      responses:
+        '200':
+          description: Successful response
+  /set_background:
+    post:
+      summary: POST /set_background
+      responses:
+        '200':
+          description: Successful response
+  /set_panel_opacity:
+    post:
+      summary: POST /set_panel_opacity
+      responses:
+        '200':
+          description: Successful response
+  /set_font_size:
+    post:
+      summary: POST /set_font_size
+      responses:
+        '200':
+          description: Successful response
+  /set_items_per_page:
+    post:
+      summary: POST /set_items_per_page
+      responses:
+        '200':
+          description: Successful response
+  /subdomonster:
+    get:
+      summary: GET /subdomonster
+      responses:
+        '200':
+          description: Successful response
+  /tools/subdomonster:
+    get:
+      summary: GET /tools/subdomonster
+      responses:
+        '200':
+          description: Successful response
+  /subdomains:
+    get:
+      summary: GET /subdomains
+      responses:
+        '200':
+          description: Successful response
+    post:
+      summary: POST /subdomains
+      responses:
+        '200':
+          description: Successful response
+  /export_subdomains:
+    get:
+      summary: GET /export_subdomains
+      responses:
+        '200':
+          description: Successful response
+  /mark_subdomain_cdx:
+    post:
+      summary: POST /mark_subdomain_cdx
+      responses:
+        '200':
+          description: Successful response
+  /scrape_subdomains:
+    post:
+      summary: POST /scrape_subdomains
+      responses:
+        '200':
+          description: Successful response
+  /delete_subdomain:
+    post:
+      summary: POST /delete_subdomain
+      responses:
+        '200':
+          description: Successful response
+  /subdomain_action:
+    post:
+      summary: POST /subdomain_action
+      responses:
+        '200':
+          description: Successful response
+  /docker_layers:
+    get:
+      summary: GET /docker_layers
+      responses:
+        '200':
+          description: Successful response
+  /download_layer:
+    get:
+      summary: GET /download_layer
+      responses:
+        '200':
+          description: Successful response
+  /registry_viewer:
+    get:
+      summary: GET /registry_viewer
+      responses:
+        '200':
+          description: Successful response
+  /tools/registry_viewer:
+    get:
+      summary: GET /tools/registry_viewer
+      responses:
+        '200':
+          description: Successful response
+  /registry_explorer:
+    get:
+      summary: GET /registry_explorer
+      responses:
+        '200':
+          description: Successful response
+  /dag_explorer:
+    get:
+      summary: GET /dag_explorer
+      responses:
+        '200':
+          description: Successful response
+  /tools/dag_explorer:
+    get:
+      summary: GET /tools/dag_explorer
+      responses:
+        '200':
+          description: Successful response
+  /dag/repo/{repo}:
+    get:
+      summary: GET /dag/repo/<path:repo>
+      responses:
+        '200':
+          description: Successful response
+  /dag/image/{image}:
+    get:
+      summary: GET /dag/image/<path:image>
+      responses:
+        '200':
+          description: Successful response
+  /dag/fs/{image}@{digest}/{path}:
+    get:
+      summary: GET /dag/fs/<path:image>@<digest>/<path:path>
+      responses:
+        '200':
+          description: Successful response
+  /dag/layer/{image}@{digest}:
+    get:
+      summary: GET /dag/layer/<path:image>@<digest>
+      responses:
+        '200':
+          description: Successful response
+  /tools/registry_explorer:
+    get:
+      summary: GET /tools/registry_explorer
+      responses:
+        '200':
+          description: Successful response
+  /repo/{repo}:
+    get:
+      summary: GET /repo/<path:repo>
+      responses:
+        '200':
+          description: Successful response
+  /image/{image}:
+    get:
+      summary: GET /image/<path:image>
+      responses:
+        '200':
+          description: Successful response
+  /image/{repo}@{digest}:
+    get:
+      summary: GET /image/<path:repo>@<digest>
+      responses:
+        '200':
+          description: Successful response
+  /size/{repo}@{digest}:
+    get:
+      summary: GET /size/<path:repo>@<digest>
+      responses:
+        '200':
+          description: Successful response
+  /fs/{repo}@{digest}:
+    get:
+      summary: GET /fs/<path:repo>@<digest>
+      responses:
+        '200':
+          description: Successful response
+  /fs/{repo}@{digest}/{subpath}:
+    get:
+      summary: GET /fs/<path:repo>@<digest>/<path:subpath>
+      responses:
+        '200':
+          description: Successful response
+  /layers/{image}/{subpath}:
+    get:
+      summary: GET /layers/<path:image>/<path:subpath>
+      responses:
+        '200':
+          description: Successful response
+  /layers/{image}@{digest}/:
+    get:
+      summary: GET /layers/<path:image>@<digest>/
+      responses:
+        '200':
+          description: Successful response
+  /layers/{image}@{digest}/{subpath}:
+    get:
+      summary: GET /layers/<path:image>@<digest>/<path:subpath>
+      responses:
+        '200':
+          description: Successful response
+  /r/{ref}:
+    get:
+      summary: GET /r/<path:ref>
+      responses:
+        '200':
+          description: Successful response
+  /fs/{digest}/{path}:
+    get:
+      summary: GET /fs/<digest>/<path:path>
+      responses:
+        '200':
+          description: Successful response
+  /layer/{digest}:
+    get:
+      summary: GET /layer/<digest>
+      responses:
+        '200':
+          description: Successful response
+  /size/{digest}:
+    get:
+      summary: GET /size/<digest>
+      responses:
+        '200':
+          description: Successful response
+  /export_urls:
+    get:
+      summary: GET /export_urls
+      responses:
+        '200':
+          description: Successful response
+  /swagger/{path}:
+    get:
+      summary: GET /swagger/<path:path>
+      responses:
+        '200':
+          description: Successful response
+  /swagger/:
+    get:
+      summary: GET /swagger/
+      responses:
+        '200':
+          description: Successful response
+  /manual_packet:
+    post:
+      summary: Craft a manual packet (stub)
+      responses:
+        '200':
+          description: OK
+  /manual_packet/{id}:
+    get:
+      summary: Retrieve manual packet (stub)
+      responses:
+        '200':
+          description: OK

--- a/tests/postman/retrorecon.postman.json
+++ b/tests/postman/retrorecon.postman.json
@@ -5,6 +5,38 @@
   },
   "item": [
     {
+      "name": "GET /favicon.ico",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/favicon.ico",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "favicon.ico"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /favicon.svg",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/favicon.svg",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "favicon.svg"
+          ]
+        }
+      }
+    },
+    {
       "name": "GET /",
       "request": {
         "method": "GET",
@@ -254,6 +286,23 @@
             "{{base_url}}"
           ],
           "path": [
+            "text_tools"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /tools/text_tools",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/text_tools",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
             "text_tools"
           ]
         }
@@ -574,6 +623,39 @@
       }
     },
     {
+      "name": "GET /layerpeek",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/layerpeek",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "layerpeek"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /tools/layerpeek",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/layerpeek",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "layerpeek"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /tools/site2zip",
       "request": {
         "method": "POST",
@@ -721,42 +803,10 @@
       }
     },
     {
-      "name": "GET /list_dbs",
-      "request": {
-        "method": "GET",
-        "header": [],
-        "url": {
-          "raw": "{{base_url}}/list_dbs?pattern=demo",
-          "host": [
-            "{{base_url}}"
-          ],
-          "path": [
-            "list_dbs"
-          ],
-          "query": [
-            {
-              "key": "pattern",
-              "value": "demo"
-            }
-          ]
-        }
-      }
-    },
-    {
       "name": "POST /load_saved_db",
       "request": {
         "method": "POST",
         "header": [],
-        "body": {
-          "mode": "formdata",
-          "formdata": [
-            {
-              "key": "db_file",
-              "value": "example.db",
-              "type": "text"
-            }
-          ]
-        },
         "url": {
           "raw": "{{base_url}}/load_saved_db",
           "host": [
@@ -882,6 +932,22 @@
       }
     },
     {
+      "name": "GET /subdomains",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/subdomains",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "subdomains"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /subdomains",
       "request": {
         "method": "POST",
@@ -893,6 +959,566 @@
           ],
           "path": [
             "subdomains"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /export_subdomains",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/export_subdomains",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "export_subdomains"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /mark_subdomain_cdx",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/mark_subdomain_cdx",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "mark_subdomain_cdx"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /scrape_subdomains",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/scrape_subdomains",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "scrape_subdomains"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /delete_subdomain",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/delete_subdomain",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "delete_subdomain"
+          ]
+        }
+      }
+    },
+    {
+      "name": "POST /subdomain_action",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/subdomain_action",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "subdomain_action"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /docker_layers",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/docker_layers",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "docker_layers"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /download_layer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/download_layer",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "download_layer"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /registry_viewer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/registry_viewer",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "registry_viewer"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /tools/registry_viewer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/registry_viewer",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "registry_viewer"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /registry_explorer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/registry_explorer",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "registry_explorer"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /dag_explorer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/dag_explorer",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "dag_explorer"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /tools/dag_explorer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/dag_explorer",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "dag_explorer"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /dag/repo/<path:repo>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/dag/repo/<path:repo>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "dag",
+            "repo",
+            "<path:repo>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /dag/image/<path:image>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/dag/image/<path:image>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "dag",
+            "image",
+            "<path:image>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /dag/fs/<path:image>@<digest>/<path:path>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/dag/fs/<path:image>@<digest>/<path:path>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "dag",
+            "fs",
+            "<path:image>@<digest>",
+            "<path:path>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /dag/layer/<path:image>@<digest>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/dag/layer/<path:image>@<digest>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "dag",
+            "layer",
+            "<path:image>@<digest>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /tools/registry_explorer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/registry_explorer",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "registry_explorer"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /repo/<path:repo>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/repo/<path:repo>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "repo",
+            "<path:repo>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /image/<path:image>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/image/<path:image>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "image",
+            "<path:image>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /image/<path:repo>@<digest>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/image/<path:repo>@<digest>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "image",
+            "<path:repo>@<digest>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /size/<path:repo>@<digest>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/size/<path:repo>@<digest>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "size",
+            "<path:repo>@<digest>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /fs/<path:repo>@<digest>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/fs/<path:repo>@<digest>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "fs",
+            "<path:repo>@<digest>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /fs/<path:repo>@<digest>/<path:subpath>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/fs/<path:repo>@<digest>/<path:subpath>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "fs",
+            "<path:repo>@<digest>",
+            "<path:subpath>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /layers/<path:image>/<path:subpath>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/layers/<path:image>/<path:subpath>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "layers",
+            "<path:image>",
+            "<path:subpath>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /layers/<path:image>@<digest>/",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/layers/<path:image>@<digest>/",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "layers",
+            "<path:image>@<digest>",
+            ""
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /layers/<path:image>@<digest>/<path:subpath>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/layers/<path:image>@<digest>/<path:subpath>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "layers",
+            "<path:image>@<digest>",
+            "<path:subpath>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /r/<path:ref>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/r/<path:ref>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "r",
+            "<path:ref>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /fs/<digest>/<path:path>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/fs/<digest>/<path:path>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "fs",
+            "<digest>",
+            "<path:path>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /layer/<digest>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/layer/<digest>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "layer",
+            "<digest>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /size/<digest>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/size/<digest>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "size",
+            "<digest>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /export_urls",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/export_urls",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "export_urls"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /swagger/<path:path>",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/swagger/<path:path>",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "swagger",
+            "<path:path>"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /swagger/",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/swagger/",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "swagger",
+            ""
           ]
         }
       }


### PR DESCRIPTION
## Summary
- regenerate Postman collection
- generate OpenAPI 3 spec including stub packet routes
- document Swagger UI and ER diagram
- mention OpenAPI in the test plan

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858449c8bb883329b7ccba2d61ece75