### PR TITLE
Move SQLite export into dropdown

### DIFF
--- a/static/index_page.js
+++ b/static/index_page.js
@@ -37,6 +37,15 @@ document.addEventListener('DOMContentLoaded', function(){
     exportSel.addEventListener('change', () => {
       const fmt = exportSel.value;
       if(!fmt) return;
+      if(fmt === 'db'){
+        exportSel.value = '';
+        const nm = prompt('Enter database name:', 'waybax');
+        if(nm){
+          const enc = encodeURIComponent(nm.trim());
+          window.location = '/save_db?name=' + enc;
+        }
+        return;
+      }
       exportFmt.value = fmt;
       if(exportQ){
         const box = document.getElementById('searchbox');

--- a/templates/index.html
+++ b/templates/index.html
@@ -110,14 +110,12 @@
             <option value="md">Markdown</option>
             <option value="csv">CSV</option>
             <option value="json">JSON</option>
+            <option value="db">SQLite (.db)</option>
           </select>
           <form id="url-export-form" class="hidden" action="/export_urls" method="GET" target="_blank">
             <input type="hidden" name="format" id="url-export-format" />
             <input type="hidden" name="q" id="url-export-q" value="{{ q }}" />
             <input type="hidden" name="select_all_matching" id="url-export-sam" value="{{ 'true' if select_all_matching else 'false' }}" />
-          </form>
-          <form method="GET" action="/save_db" id="save-db-form" class="menu-row">
-            <button type="submit" class="menu-btn">Export SQLite (.db)</button>
           </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- integrate SQLite option in the export select menu
- remove redundant Export SQLite menu row
- trigger `/save_db` when the new option is chosen

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585969e2308332b90ff4c05fd22aee