### PR TITLE
Fix scrollbar for empty result list

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -187,7 +187,7 @@ body {
   font-family: var(--font-main);
   font-size: 14px;
   margin: 0;
-  height: 100vh;
+  height: calc(100vh - 10px);
   padding: 0 0 10px;
   overflow: hidden;
   color: #ffffff;


### PR DESCRIPTION
## Summary
- remove extra vertical scroll bar when the results table isn't displayed

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68586492a0908332a8e278e463da5700