### PR TITLE
Add project overview routes and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
   new ones
 - Rename the current database without leaving the application
 - Remembers and reloads the most recently used database on launch
+- **Project Overview** page summarizing domains and module counts
 - Theme switching via Menu dropdown with optional background image toggle
 - Optional theming via CSS files in `static/themes/`, including a dark OpenAI-inspired style and hundreds of Midnight City combinations (generated via `scripts/generate_midnight_themes.py`)
 - Browser-side search history for quick queries

--- a/app.py
+++ b/app.py
@@ -802,6 +802,7 @@ from retrorecon.routes import (
     dagdotdev_bp,
     urls_bp,
     swagger_bp,
+    overview_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -815,6 +816,7 @@ app.register_blueprint(oci_bp)
 app.register_blueprint(dagdotdev_bp)
 app.register_blueprint(urls_bp)
 app.register_blueprint(swagger_bp)
+app.register_blueprint(overview_bp)
 
 
 @app.after_request

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -662,3 +662,17 @@ Return the uncompressed size of a layer.
 curl http://localhost:5000/size/library/ubuntu@sha256:abcd
 ```
 
+### `GET /overview`
+Render the project overview page summarizing domains and module counts.
+
+```
+curl http://localhost:5000/overview
+```
+
+### `GET /overview.json`
+Return the same overview data as JSON.
+
+```
+curl http://localhost:5000/overview.json
+```
+

--- a/docs/project_overview_spec.md
+++ b/docs/project_overview_spec.md
@@ -1,0 +1,22 @@
+# Project Overview Design
+
+This document outlines the new **Project Overview** feature. Each SQLite database represents a project. The overview page provides a quick summary of domains and related module data so users can navigate from a high level down to individual tools.
+
+## Goals
+- Treat every loaded `.db` file as its own project.
+- Display counts for URLs, domains, screenshots, site zips, JWT cookies and notes.
+- Group subdomains by root domain similar to the URL results table.
+- Allow each subdomain to be sent to other Retrorecon tools.
+
+## Routes
+- `GET /overview` – Render the HTML overview with tables for each domain.
+- `GET /overview.json` – Return the same data in JSON format.
+
+## UI
+The layout mirrors the search results page with a table for each domain. A summary line shows total counts for every module. Subdomain rows will include tool actions in future revisions.
+
+## Database
+No schema changes are required. Counts are derived from the existing `urls`, `domains`, `screenshots`, `sitezips`, `jwt_cookies` and `notes` tables.
+
+## Implementation Notes
+The Flask blueprint `overview.py` collects table counts and domain lists. It is registered in `app.py` so the page is accessible once a database is loaded.

--- a/docs/template_overview.md
+++ b/docs/template_overview.md
@@ -8,6 +8,7 @@ This document catalogs the HTML templates currently present in the repository an
 | `dag_explorer.html` | Overlay for browsing OCI image manifests and layer contents. Provides example links and fetches tags or manifests on demand. |
 | `fetching.html` | Simple progress page polling the server while CDX data is imported from the Wayback Machine. Redirects back to `/` when finished. |
 | `index.html` | Main interface listing URLs. Includes search, pagination, menus and the Notes overlay. Loads other overlays like Text Tools and Screenshotter. |
+| `overview.html` | Presents project-level counts and lists subdomains grouped by domain. |
 | `jwt_tools.html` | Overlay providing encode/decode operations for JWTs and a cookie jar for storing tokens. |
 | `layerslayer.html` | Overlay that fetches a Docker image and lists each layer with filesystem stats using the layerslayer backend. |
 | `oci_base.html` | Base layout for all OCI Explorer pages. Handles theming and provides the `.retrorecon-root` wrapper. |

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -149,6 +149,15 @@ This ensures database workflow tests are executed along with the existing suite 
 5. **Delete Capture**
    - POST `/delete_sitezips` with the capture ID and confirm it is removed from `/sitezips`.
 
+## Project Overview Tests
+
+1. **Overview Page Loads**
+   - Create a database with URLs and subdomains.
+   - GET `/overview` should return status 200 and list the domain name.
+
+2. **JSON Data**
+   - GET `/overview.json` should return counts for `urls` and `domains` reflecting the inserted records.
+
 ## API Spec Tests
 
 1. **OpenAPI Generation**

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -10,5 +10,6 @@ from .oci import bp as oci_bp
 from .dagdotdev import bp as dagdotdev_bp
 from .urls import bp as urls_bp
 from .swagger import bp as swagger_bp
+from .overview import bp as overview_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp']

--- a/retrorecon/routes/overview.py
+++ b/retrorecon/routes/overview.py
@@ -1,0 +1,64 @@
+from typing import Dict, Any
+import os
+from flask import Blueprint, render_template, jsonify
+import app
+
+bp = Blueprint('overview', __name__)
+
+
+def _collect_counts() -> Dict[str, int]:
+    tables = [
+        'urls',
+        'domains',
+        'screenshots',
+        'sitezips',
+        'jwt_cookies',
+        'notes'
+    ]
+    counts = {}
+    for tbl in tables:
+        row = app.query_db(f'SELECT COUNT(*) as cnt FROM {tbl}', one=True) if app._db_loaded() else None
+        counts[tbl] = row['cnt'] if row else 0
+    return counts
+
+
+def _collect_domains() -> list:
+    if not app._db_loaded():
+        return []
+    roots = app.query_db('SELECT root_domain, COUNT(*) AS cnt FROM domains GROUP BY root_domain ORDER BY root_domain')
+    domains = []
+    for r in roots:
+        rows = app.query_db(
+            'SELECT subdomain, tags, cdx_indexed FROM domains WHERE root_domain = ? ORDER BY subdomain',
+            [r['root_domain']]
+        )
+        subs = [
+            {
+                'subdomain': s['subdomain'],
+                'tags': s['tags'],
+                'cdx_indexed': bool(s['cdx_indexed'])
+            }
+            for s in rows
+        ]
+        domains.append({'root_domain': r['root_domain'], 'count': r['cnt'], 'subdomains': subs})
+    return domains
+
+
+@bp.route('/overview', methods=['GET'])
+def overview_page():
+    data = {
+        'db_name': os.path.basename(app.app.config.get('DATABASE') or '(none)'),
+        'counts': _collect_counts(),
+        'domains': _collect_domains(),
+    }
+    return render_template('overview.html', **data)
+
+
+@bp.route('/overview.json', methods=['GET'])
+def overview_json():
+    data = {
+        'db_name': os.path.basename(app.app.config.get('DATABASE') or '(none)'),
+        'counts': _collect_counts(),
+        'domains': _collect_domains(),
+    }
+    return jsonify(data)

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Project Overview - {{ db_name }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
+  {% if current_theme %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
+  {% endif %}
+</head>
+<body class="retrorecon-root">
+  <h1>Project Overview - {{ db_name }}</h1>
+  <p class="mb-05">URLs: {{ counts['urls'] }} | Domains: {{ counts['domains'] }} | Screenshots: {{ counts['screenshots'] }} | SiteZips: {{ counts['sitezips'] }} | JWTs: {{ counts['jwt_cookies'] }} | Notes: {{ counts['notes'] }}</p>
+  {% for dom in domains %}
+  <h2>{{ dom.root_domain }} ({{ dom.count }})</h2>
+  <table class="url-table">
+    <thead>
+      <tr>
+        <th>Subdomain</th>
+        <th>Tags</th>
+        <th class="text-center">CDX</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for sub in dom.subdomains %}
+      <tr>
+        <td>{{ sub['subdomain'] }}</td>
+        <td>{{ sub['tags'] or '' }}</td>
+        <td class="text-center">{% if sub['cdx_indexed'] %}✓{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endfor %}
+  <script src="{{ url_for('static', filename='index_page.js') }}"></script>
+</body>
+</html>

--- a/tests/test_project_overview.py
+++ b/tests/test_project_overview.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def init_sample(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db("proj")
+        app.execute_db("INSERT INTO urls (url, domain, tags) VALUES (?, ?, '')", ["http://a.example/", "a.example"])
+        from retrorecon import subdomain_utils
+        subdomain_utils.insert_records("example.com", ["a.example"], "crtsh")
+
+
+def test_overview_page(tmp_path, monkeypatch):
+    init_sample(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/overview')
+        assert resp.status_code == 200
+        assert b'example.com' in resp.data
+
+
+def test_overview_json(tmp_path, monkeypatch):
+    init_sample(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        data = client.get('/overview.json').get_json()
+        assert data['counts']['urls'] == 1
+        assert data['counts']['domains'] == 1


### PR DESCRIPTION
## Summary
- design new Project Overview architecture
- document new routes and test plan updates
- implement overview blueprint and template
- register blueprint and add unit tests

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q tests/test_project_overview.py`

------
https://chatgpt.com/codex/tasks/task_e_685866f5ebe08332ac57380107c45056