### PR TITLE
Outline send dropdown

### DIFF
--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -100,6 +100,9 @@ body.bg-hidden {
   cursor: pointer;
   transition: background-color 0.2s;
 }
+.retrorecon-root .dropbtn.send-btn {
+  border: 1px solid #fff;
+}
 .retrorecon-root .dropbtn:hover,
 .retrorecon-root .dropbtn:focus {
   background: rgb(var(--bg-rgb)/var(--panel-opacity));


### PR DESCRIPTION
## Summary
- outline the `Send to` dropdown button in neon theme

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858686192e083328002e448b7fa0155