### PR TITLE
Add project dashboard landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The CDX API is powerful but not particularly robust and not the fastest, and a s
   new ones
 - Rename the current database without leaving the application
 - Remembers and reloads the most recently used database on launch
-- **Project Overview** page summarizing domains and module counts
+- **Project Dashboard** landing page summarizing domains and module counts
 - Theme switching via Menu dropdown with optional background image toggle
 - Optional theming via CSS files in `static/themes/`, including a dark OpenAI-inspired style and hundreds of Midnight City combinations (generated via `scripts/generate_midnight_themes.py`)
 - Browser-side search history for quick queries

--- a/app.py
+++ b/app.py
@@ -338,6 +338,33 @@ def index() -> str:
         return image_view(image_param)
 
     q = request.args.get('q', '').strip()
+    is_tool_route = request.path in [
+        '/tools/jwt',
+        '/tools/screenshotter',
+        '/tools/subdomonster',
+        '/tools/text_tools'
+    ]
+    if not any([q, repo_param, image_param, request.args.get('tool'), is_tool_route]):
+        from retrorecon.routes.overview import _collect_counts, _collect_domains
+        if _db_loaded():
+            actual_name = os.path.basename(app.config['DATABASE'])
+            if actual_name == TEMP_DB_NAME:
+                actual_name = TEMP_DISPLAY_NAME
+        else:
+            actual_name = '(none)'
+        if session.get('db_display_name') != actual_name:
+            session['db_display_name'] = actual_name
+        db_name = session['db_display_name']
+        default_theme = 'nostalgia.css' if 'nostalgia.css' in AVAILABLE_THEMES else (AVAILABLE_THEMES[0] if AVAILABLE_THEMES else '')
+        current_theme = session.get('theme', default_theme)
+        data = {
+            'db_name': db_name,
+            'counts': _collect_counts(),
+            'domains': _collect_domains(),
+            'current_theme': current_theme,
+        }
+        return render_template('overview.html', **data)
+
     select_all_matching = request.args.get('select_all_matching', 'false').lower() == 'true'
     try:
         page = int(request.args.get('page', 1))

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -15,7 +15,9 @@ The complete route map can also be browsed via the built-in Swagger UI at
 ## Routes
 
 ### `GET /`
-Render the main search page.
+Render the Project Dashboard summarizing domains and module counts when no
+search parameters are provided. Supplying `q` or other search options shows the
+traditional results page.
 
 ```
 curl http://localhost:5000/

--- a/docs/template_overview.md
+++ b/docs/template_overview.md
@@ -8,7 +8,7 @@ This document catalogs the HTML templates currently present in the repository an
 | `dag_explorer.html` | Overlay for browsing OCI image manifests and layer contents. Provides example links and fetches tags or manifests on demand. |
 | `fetching.html` | Simple progress page polling the server while CDX data is imported from the Wayback Machine. Redirects back to `/` when finished. |
 | `index.html` | Main interface listing URLs. Includes search, pagination, menus and the Notes overlay. Loads other overlays like Text Tools and Screenshotter. |
-| `overview.html` | Presents project-level counts and lists subdomains grouped by domain. |
+| `overview.html` | Project Dashboard landing page with counts and subdomains grouped by domain. |
 | `jwt_tools.html` | Overlay providing encode/decode operations for JWTs and a cookie jar for storing tokens. |
 | `layerslayer.html` | Overlay that fetches a Docker image and lists each layer with filesystem stats using the layerslayer backend. |
 | `oci_base.html` | Base layout for all OCI Explorer pages. Handles theming and provides the `.retrorecon-root` wrapper. |

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -155,7 +155,10 @@ This ensures database workflow tests are executed along with the existing suite 
    - Create a database with URLs and subdomains.
    - GET `/overview` should return status 200 and list the domain name.
 
-2. **JSON Data**
+2. **Dashboard Root Loads**
+   - GET `/` with no parameters should return status 200 and show the domain name.
+
+3. **JSON Data**
    - GET `/overview.json` should return counts for `urls` and `domains` reflecting the inserted records.
 
 ## API Spec Tests

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -4,12 +4,16 @@
   <meta charset="UTF-8" />
   <title>Project Overview - {{ db_name }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
+  {% set current_theme = current_theme or session.get('theme') %}
   {% if current_theme %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
   {% endif %}
 </head>
 <body class="retrorecon-root">
-  <h1>Project Overview - {{ db_name }}</h1>
+  <div class="navbar__title mb-05">
+    <span class="glow" id="db-display">[ {{ db_name }} ]</span>
+  </div>
+  <h1>Project Overview</h1>
   <p class="mb-05">URLs: {{ counts['urls'] }} | Domains: {{ counts['domains'] }} | Screenshots: {{ counts['screenshots'] }} | SiteZips: {{ counts['sitezips'] }} | JWTs: {{ counts['jwt_cookies'] }} | Notes: {{ counts['notes'] }}</p>
   {% for dom in domains %}
   <h2>{{ dom.root_domain }} ({{ dom.count }})</h2>

--- a/tests/test_index_sanitization.py
+++ b/tests/test_index_sanitization.py
@@ -21,7 +21,7 @@ def test_no_inline_url_js(tmp_path, monkeypatch):
         app.create_new_db("test")
         app.execute_db("INSERT INTO urls (url, tags) VALUES (?, ?)", ["http://a.com", ""])
     with app.app.test_client() as client:
-        resp = client.get("/")
+        resp = client.get("/", query_string={'q': 'a.com'})
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
         assert 'onclick="window.open' not in html

--- a/tests/test_project_overview.py
+++ b/tests/test_project_overview.py
@@ -38,3 +38,11 @@ def test_overview_json(tmp_path, monkeypatch):
         data = client.get('/overview.json').get_json()
         assert data['counts']['urls'] == 1
         assert data['counts']['domains'] == 1
+
+
+def test_dashboard_root(tmp_path, monkeypatch):
+    init_sample(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 200
+        assert b'example.com' in resp.data


### PR DESCRIPTION
## Summary
- show project dashboard when visiting `/`
- expose theme for the overview template and display active DB name
- mention dashboard landing page in docs
- update tests for new behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858696b58c8833285ecc22a206c7b2e