### PR TITLE
Refactor screenshot features into module

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ If screenshot capture shows a placeholder image, Playwright may not have the Chr
 Run `python -m playwright install` to download the browsers. If you previously
 set the `PLAYWRIGHT_BROWSERS_PATH` environment variable, remove it so Playwright
 can use its default location. Alternatively set `PLAYWRIGHT_CHROMIUM_PATH` to an
-existing Chrome executable. You can also assign a path to `app.executablePath`
-before calling screenshot functions to override the Chromium binary.
+existing Chrome executable. You can also assign a path to
+`retrorecon.screenshot_service.executable_path` before calling screenshot
+functions to override the Chromium binary.
 
 ### Secrets File
 Create a `secrets.json` file alongside `app.py` to store sensitive values like

--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ from retrorecon import (
     text_notes_utils,
     jwt_utils,
     search_utils,
-    screenshot_utils,
+    screenshot_service,
     sitezip_utils,
     subdomain_utils,
     status as status_mod,
@@ -279,25 +279,7 @@ def export_url_data(ids: Optional[List[int]] = None, query: str = '') -> List[Di
     return result
 
 
-SCREENSHOT_DIR = os.path.join(app.root_path, 'static', 'screenshots')
 SITEZIP_DIR = os.path.join(app.root_path, 'static', 'sitezips')
-executablePath: Optional[str] = None
-
-
-def save_screenshot_record(url: str, path: str, thumb: str, method: str = 'GET') -> int:
-    return screenshot_utils.save_record(SCREENSHOT_DIR, url, path, thumb, method)
-
-
-def list_screenshot_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
-    return screenshot_utils.list_data(ids)
-
-
-def delete_screenshots(ids: List[int]) -> None:
-    screenshot_utils.delete_records(SCREENSHOT_DIR, ids)
-
-
-def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False) -> bytes:
-    return screenshot_utils.take_screenshot(url, user_agent, spoof_referrer, executablePath)
 
 
 def save_sitezip_record(
@@ -317,7 +299,7 @@ def delete_sitezips(ids: List[int]) -> None:
 
 
 def capture_site(url: str, user_agent: str = '', spoof_referrer: bool = False) -> Tuple[bytes, bytes]:
-    return sitezip_utils.capture_site(url, user_agent, spoof_referrer, executablePath)
+    return sitezip_utils.capture_site(url, user_agent, spoof_referrer, screenshot_service.executable_path)
 
 
 def delete_subdomain(root_domain: str, subdomain: str) -> None:

--- a/retrorecon/screenshot_service.py
+++ b/retrorecon/screenshot_service.py
@@ -1,0 +1,33 @@
+import os
+from typing import Any, Dict, List, Optional
+from flask import current_app
+from . import screenshot_utils
+
+# Path to the Chromium executable used by screenshot capture.
+# Assign a string path to override Playwright's default.
+executable_path: Optional[str] = None
+
+
+def get_screenshot_dir() -> str:
+    """Return the absolute screenshots directory for the running app."""
+    return os.path.join(current_app.root_path, 'static', 'screenshots')
+
+
+def save_screenshot_record(url: str, path: str, thumb: str, method: str = 'GET') -> int:
+    """Insert a screenshot record in the database."""
+    return screenshot_utils.save_record(get_screenshot_dir(), url, path, thumb, method)
+
+
+def list_screenshot_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
+    """Return screenshot rows as dictionaries."""
+    return screenshot_utils.list_data(ids)
+
+
+def delete_screenshots(ids: List[int]) -> None:
+    """Remove screenshot records and files by ID."""
+    screenshot_utils.delete_records(get_screenshot_dir(), ids)
+
+
+def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False) -> bytes:
+    """Capture a screenshot of ``url`` and return PNG bytes."""
+    return screenshot_utils.take_screenshot(url, user_agent, spoof_referrer, executable_path)


### PR DESCRIPTION
## Summary
- extract screenshot helpers into `screenshot_service`
- use new module in routes and tests
- document new executable path option

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587a4300488332bca9178407ad2e08