### PR TITLE
Refactor tag routes into dedicated module

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,14 +142,6 @@ def clear_import_progress() -> None:
     import_utils.clear_import_progress(IMPORT_PROGRESS_FILE)
 
 
-def load_saved_tags() -> List[str]:
-    return saved_tags_mod.load_tags(SAVED_TAGS_FILE)
-
-
-def save_saved_tags(tags: List[str]) -> None:
-    saved_tags_mod.save_tags(SAVED_TAGS_FILE, tags)
-
-
 
 def export_url_data(ids: Optional[List[int]] = None, query: str = '') -> List[Dict[str, Any]]:
     """Return URL records filtered by ids or search query."""
@@ -506,93 +498,6 @@ def status_route() -> Response:
         return ('', 204)
     return jsonify({'code': last[0], 'message': last[1]})
 
-@app.route('/add_tag', methods=['POST'])
-def add_tag() -> Response:
-    """Append a tag to the selected URL entry."""
-    if not _db_loaded():
-        flash('No database loaded.', 'error')
-        return redirect(url_for('index'))
-    entry_id = request.form.get('entry_id', type=int)
-    new_tag = request.form.get('new_tag', '').strip()
-    if not entry_id or not new_tag:
-        flash("Missing URL ID or tag for adding.", "error")
-        return redirect(url_for('index'))
-
-    if not tag_utils.entry_exists(entry_id):
-        flash("URL not found.", "error")
-        return redirect(url_for('index'))
-
-    tag_utils.add_tag(entry_id, new_tag)
-    flash(f"Added tag '{new_tag}' to entry {entry_id}.", "success")
-    return redirect(url_for('index'))
-
-@app.route('/bulk_action', methods=['POST'])
-def bulk_action() -> Response:
-    """Apply a bulk action (tag or delete) to selected URLs."""
-    if not _db_loaded():
-        flash('No database loaded.', 'error')
-        return redirect(url_for('index'))
-    action = request.form.get('action', '')
-    tag = request.form.get('tag', '').strip()
-    selected_ids = request.form.getlist('selected_ids')
-    select_all_matching = (request.form.get('select_all_matching', 'false').lower() == 'true')
-
-    if select_all_matching:
-        q = request.form.get('q', '').strip()
-
-        where_sql = ""
-        params: List[str] = []
-        if q:
-            try:
-                search_sql, params = search_utils.build_search_sql(q)
-                where_sql = f"WHERE {search_sql}"
-            except Exception:
-                where_sql = (
-                    "WHERE ("
-                    "url LIKE ? OR tags LIKE ? OR "
-                    "CAST(timestamp AS TEXT) LIKE ? OR "
-                    "CAST(status_code AS TEXT) LIKE ? OR "
-                    "mime_type LIKE ?"
-                    ")"
-                )
-                params = [f"%{q}%"] * 5
-
-        rows = query_db(f"SELECT id FROM urls {where_sql}", params)
-        selected_ids = [str(r['id']) for r in rows]
-
-    if not selected_ids:
-        flash("No entries selected for bulk action.", "error")
-        return redirect(url_for('index'))
-
-    if action == 'add_tag':
-        if not tag:
-            flash("No tag provided for bulk add.", "error")
-            return redirect(url_for('index'))
-        count = tag_utils.bulk_add_tag([int(s) for s in selected_ids], tag)
-        flash(f"Added tag '{tag}' to {count} entries.", "success")
-
-    elif action == 'remove_tag':
-        if not tag:
-            flash("No tag provided for removal.", "error")
-            return redirect(url_for('index'))
-        count = tag_utils.bulk_remove_tag([int(s) for s in selected_ids], tag)
-        flash(f"Removed tag '{tag}' from {count} entries.", "success")
-
-    elif action == 'clear_tags':
-        count = tag_utils.bulk_clear_tags([int(s) for s in selected_ids])
-        flash(f"Cleared tags from {count} entries.", "success")
-
-    elif action == 'delete':
-        count = 0
-        for sid in selected_ids:
-            execute_db("DELETE FROM urls WHERE id = ?", [sid])
-            count += 1
-        flash(f"Deleted {count} entries.", "success")
-
-    else:
-        flash(f"Unknown bulk action: {action}", "error")
-
-    return redirect(url_for('index'))
 
 
 
@@ -610,6 +515,7 @@ from retrorecon.routes import (
     urls_bp,
     swagger_bp,
     overview_bp,
+    tags_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -624,6 +530,7 @@ app.register_blueprint(dagdotdev_bp)
 app.register_blueprint(urls_bp)
 app.register_blueprint(swagger_bp)
 app.register_blueprint(overview_bp)
+app.register_blueprint(tags_bp)
 
 
 @app.after_request

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -11,5 +11,6 @@ from .dagdotdev import bp as dagdotdev_bp
 from .urls import bp as urls_bp
 from .swagger import bp as swagger_bp
 from .overview import bp as overview_bp
+from .tags import bp as tags_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'tags_bp']

--- a/retrorecon/routes/notes.py
+++ b/retrorecon/routes/notes.py
@@ -1,22 +1,23 @@
 import app
 from flask import Blueprint, request, jsonify
 from retrorecon import notes_service
+from .tags import load_saved_tags, save_saved_tags
 
 bp = Blueprint('notes', __name__)
 
 @bp.route('/saved_tags', methods=['GET', 'POST'])
 def saved_tags_route():
     if request.method == 'GET':
-        return jsonify({'tags': app.load_saved_tags()})
+        return jsonify({'tags': load_saved_tags()})
     tag = request.form.get('tag', '').strip()
     if not tag:
         return ('', 400)
     if not tag.startswith('#'):
         tag = '#' + tag
-    tags = app.load_saved_tags()
+    tags = load_saved_tags()
     if tag not in tags:
         tags.append(tag)
-        app.save_saved_tags(tags)
+        save_saved_tags(tags)
     return ('', 204)
 
 @bp.route('/delete_saved_tag', methods=['POST'])
@@ -26,10 +27,10 @@ def delete_saved_tag():
         return ('', 400)
     if not tag.startswith('#'):
         tag = '#' + tag
-    tags = app.load_saved_tags()
+    tags = load_saved_tags()
     if tag in tags:
         tags.remove(tag)
-        app.save_saved_tags(tags)
+        save_saved_tags(tags)
     return ('', 204)
 
 @bp.route('/notes/<int:url_id>', methods=['GET'])

--- a/retrorecon/routes/tags.py
+++ b/retrorecon/routes/tags.py
@@ -1,0 +1,107 @@
+from typing import List
+
+import app
+from flask import Blueprint, request, redirect, url_for, flash
+from database import query_db, execute_db
+from retrorecon import tag_utils, search_utils
+
+bp = Blueprint('tags', __name__)
+
+
+def load_saved_tags() -> List[str]:
+    """Return saved tags from ``SAVED_TAGS_FILE``."""
+    return app.saved_tags_mod.load_tags(app.SAVED_TAGS_FILE)
+
+
+def save_saved_tags(tags: List[str]) -> None:
+    """Persist ``tags`` to ``SAVED_TAGS_FILE``."""
+    app.saved_tags_mod.save_tags(app.SAVED_TAGS_FILE, tags)
+
+
+@bp.route('/add_tag', methods=['POST'])
+def add_tag() -> "redirect":  # type: ignore[return-type]
+    """Append a tag to the selected URL entry."""
+    if not app._db_loaded():
+        flash('No database loaded.', 'error')
+        return redirect(url_for('index'))
+    entry_id = request.form.get('entry_id', type=int)
+    new_tag = request.form.get('new_tag', '').strip()
+    if not entry_id or not new_tag:
+        flash("Missing URL ID or tag for adding.", "error")
+        return redirect(url_for('index'))
+
+    if not tag_utils.entry_exists(entry_id):
+        flash("URL not found.", "error")
+        return redirect(url_for('index'))
+
+    tag_utils.add_tag(entry_id, new_tag)
+    flash(f"Added tag '{new_tag}' to entry {entry_id}.", "success")
+    return redirect(url_for('index'))
+
+
+@bp.route('/bulk_action', methods=['POST'])
+def bulk_action() -> "redirect":  # type: ignore[return-type]
+    """Apply a bulk action (tag or delete) to selected URLs."""
+    if not app._db_loaded():
+        flash('No database loaded.', 'error')
+        return redirect(url_for('index'))
+    action = request.form.get('action', '')
+    tag = request.form.get('tag', '').strip()
+    selected_ids = request.form.getlist('selected_ids')
+    select_all_matching = request.form.get('select_all_matching', 'false').lower() == 'true'
+
+    if select_all_matching:
+        q = request.form.get('q', '').strip()
+        where_sql = ""
+        params: List[str] = []
+        if q:
+            try:
+                search_sql, params = search_utils.build_search_sql(q)
+                where_sql = f"WHERE {search_sql}"
+            except Exception:
+                where_sql = (
+                    "WHERE ("
+                    "url LIKE ? OR tags LIKE ? OR "
+                    "CAST(timestamp AS TEXT) LIKE ? OR "
+                    "CAST(status_code AS TEXT) LIKE ? OR "
+                    "mime_type LIKE ?"
+                    ")"
+                )
+                params = [f"%{q}%"] * 5
+        rows = query_db(f"SELECT id FROM urls {where_sql}", params)
+        selected_ids = [str(r['id']) for r in rows]
+
+    if not selected_ids:
+        flash("No entries selected for bulk action.", "error")
+        return redirect(url_for('index'))
+
+    if action == 'add_tag':
+        if not tag:
+            flash("No tag provided for bulk add.", "error")
+            return redirect(url_for('index'))
+        count = tag_utils.bulk_add_tag([int(s) for s in selected_ids], tag)
+        flash(f"Added tag '{tag}' to {count} entries.", "success")
+
+    elif action == 'remove_tag':
+        if not tag:
+            flash("No tag provided for removal.", "error")
+            return redirect(url_for('index'))
+        count = tag_utils.bulk_remove_tag([int(s) for s in selected_ids], tag)
+        flash(f"Removed tag '{tag}' from {count} entries.", "success")
+
+    elif action == 'clear_tags':
+        count = tag_utils.bulk_clear_tags([int(s) for s in selected_ids])
+        flash(f"Cleared tags from {count} entries.", "success")
+
+    elif action == 'delete':
+        count = 0
+        for sid in selected_ids:
+            execute_db("DELETE FROM urls WHERE id = ?", [sid])
+            count += 1
+        flash(f"Deleted {count} entries.", "success")
+
+    else:
+        flash(f"Unknown bulk action: {action}", "error")
+
+    return redirect(url_for('index'))
+


### PR DESCRIPTION
## Summary
- move tag routes into `retrorecon/routes/tags.py`
- load and save saved-tags through the new module
- register `tags_bp` blueprint in the application

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685892ff47908332a26c44189225a783