### PR TITLE
Fix favicon route references

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,7 +65,7 @@ def favicon_ico() -> Response:
     return send_from_directory(app.root_path, 'favicon.ico', mimetype='image/vnd.microsoft.icon')
 
 
-@app.route('/favicon.svg')
+@app.route('/favicon.svg', endpoint='core.favicon_svg')
 def favicon_svg() -> Response:
     """Serve the favicon.svg from the application root."""
     return send_from_directory(app.root_path, 'favicon.svg', mimetype='image/svg+xml')

--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -2,7 +2,7 @@
 <div id="dag-explorer-overlay" class="notes-overlay hidden">
   <h1>
     <a class="top" href="/">
-      <img class="crane" src="{{ url_for('favicon_svg') }}"/>
+      <img class="crane" src="{{ url_for('core.favicon_svg') }}"/>
       <span class="link">Registry Explorer</span>
     </a>
   </h1>

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>{{ title or 'Registry Explorer' }}</title>
-  <link rel="icon" href="{{ url_for('favicon_svg') }}">
+  <link rel="icon" href="{{ url_for('core.favicon_svg') }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">

--- a/templates/oci_overlay.html
+++ b/templates/oci_overlay.html
@@ -1,6 +1,6 @@
 {% extends 'oci_base.html' %}
 {% block body %}
-<h1><a class="top" href="/"><img class="crane" src="{{ url_for('favicon_svg') }}"/> <span class="link">Registry Explorer</span></a></h1>
+<h1><a class="top" href="/"><img class="crane" src="{{ url_for('core.favicon_svg') }}"/> <span class="link">Registry Explorer</span></a></h1>
 <h2><a class="mt" href="/?repo={{ repo }}">{{ repo }}</a>@<a class="mt" href="/?image={{ image }}&mt={{ headers['Content-Type']|urlencode }}">{{ digest }}</a></h2>
 <input type="radio" name="tabs" id="tab1" checked>
 <label for="tab1">HTTP</label>

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -1,7 +1,7 @@
 <!-- File: templates/oci_repo.html -->
 {% extends 'oci_base.html' %}
 {% block body %}
-<h1><a class="top" href="/"><img class="crane" src="{{ url_for('favicon_svg') }}"/> <span class="link">Registry Explorer</span></a></h1>
+<h1><a class="top" href="/"><img class="crane" src="{{ url_for('core.favicon_svg') }}"/> <span class="link">Registry Explorer</span></a></h1>
 <h2>{{ repo }}</h2>
 <h4><span style="padding:0;" class="noselect">$ </span>curl -sL "{{ data_url }}" | jq .</h4>
 


### PR DESCRIPTION
## Summary
- ensure favicon SVG route is namespaced under `core`
- update templates to use the namespaced favicon route

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68589eb615fc83328ab9c5cf6c23e58d