### PR TITLE
Add issue-on-failure GitHub workflow

### DIFF
--- a/.github/workflows/issue_on_failure.yml
+++ b/.github/workflows/issue_on_failure.yml
@@ -1,0 +1,32 @@
+name: Issue on CI Failure
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+jobs:
+  create-issue:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = context.payload.workflow_run;
+            const sha = run.head_sha.substring(0,7);
+            const title = `CI failure on ${sha}`;
+            const { owner, repo } = context.repo;
+            const existing = await github.rest.issues.listForRepo({ owner, repo, state: 'open', labels: 'ci-failure' });
+            if (existing.data.some(issue => issue.title === title)) {
+              console.log('Issue already exists');
+              return;
+            }
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body: `CI workflow failed on branch ${run.head_branch} for commit ${sha}.\n\nSee details: ${run.html_url}`,
+              labels: ['ci-failure']
+            });


### PR DESCRIPTION
## Summary
- trigger a new workflow when the CI workflow completes
- open a GitHub Issue if the CI workflow fails

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858b3393a9083328772e5ec13c523a2