### PR TITLE
Remove forced white text style

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -25,11 +25,6 @@ body {
   font-weight: bold;
 }
 
-/* Force all text to white 14px */
-.retrorecon-root * {
-  color: #ffffff !important;
-  font-size: 14px !important;
-}
 
 .retrorecon-root .hidden { display: none; }
 


### PR DESCRIPTION
## Summary
- remove global color and font-size override from base styles

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b9d3e258833286ab44ace6ec2c53