### PR TITLE
Fix default page background

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -16,6 +16,9 @@
 
 body {
   margin: 0;
+  background-color: var(--color-base);
+  color: var(--color-contrast);
+  font-family: var(--font-main);
 }
 
 .retrorecon-root h1,


### PR DESCRIPTION
## Summary
- set body background color and font defaults so the theme text isn't white on white

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bc1a810c8332b0b0026a172be093