### PR TITLE
Fix OCI explorer close button alignment

### DIFF
--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -37,7 +37,7 @@
     <input type="text" id="dag-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
     <button type="button" class="btn" id="dag-fetch-btn">Fetch Manifest</button>
     <button type="button" class="btn" id="dag-tags-btn">List Tags</button>
-    <button type="button" class="btn" id="dag-close-btn">Close</button>
+    <button type="button" class="btn close-btn" id="dag-close-btn">Close</button>
   </div>
   <div id="dag-manifest" class="mb-05"></div>
   <div id="dag-path" class="mb-05"></div>


### PR DESCRIPTION
## Summary
- ensure the close button in `dag_explorer.html` floats right using `.close-btn`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6858d25dde208332a985cae3f4c7f069