### PR TITLE
Fix quirks mode in OCI explorer

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -1,5 +1,5 @@
-
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <title>{{ title or 'Registry Explorer' }}</title>
   <link rel="icon" href="{{ url_for('favicon_svg') }}">


### PR DESCRIPTION
## Summary
- add missing DOCTYPE and language attribute in oci_base.html

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d83167bc83329ac309903849ae6a