### PR TITLE
Fix registry explorer HTML meta

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ title or 'Registry Explorer' }}</title>
   <link rel="icon" href="{{ url_for('favicon_svg') }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- ensure OCI explorer pages include charset and viewport meta tags to avoid odd layout quirks

## Testing
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858df5d484c8332a7c583aa3dc549e3