### PR TITLE
Fix lint path and remove inline styles

### DIFF
--- a/frontend/scripts/check_inline_styles.js
+++ b/frontend/scripts/check_inline_styles.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const glob = require('glob');
 let failed = false;
 
-for (const file of glob.sync('templates/**/*.html')) {
+for (const file of glob.sync('../templates/**/*.html')) {
   if (file.includes('indexBack.html')) continue;
   const content = fs.readFileSync(file, 'utf8');
   const regex = /<[^>]+\sstyle=/i;

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -42,6 +42,9 @@
     text-align: right;
     white-space: nowrap;
   }
+  .retrorecon-root .noselect--tight {
+    padding-right: 0;
+  }
   /* simple tab styling used by registry explorer pages */
   input + label { display: inline-block; }
   input { display: none; }

--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -19,7 +19,7 @@ Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ med
 <div class="tab content2">
 <pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
 </div>
-<h4><span style="padding:0;" class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz{% if subpath %}  {{ subpath }}{% endif %}</h4>
+<h4><span class="noselect noselect--tight">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz{% if subpath %}  {{ subpath }}{% endif %}</h4>
 <pre>{%- for item in items %}
 {{ item.perms }} {{ item.owner }} <span title="{{ item.size_hr }}">{{ '%12s'|format(item.size) }}</span> {{ item.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ item.path }}">{{ item.name }}{% if item.is_dir %}/{% endif %}</a>{% if not loop.last %}\n{% endif %}
 {%- endfor %}</pre>

--- a/templates/oci_overlay.html
+++ b/templates/oci_overlay.html
@@ -14,7 +14,7 @@ Docker-Content-Digest: <a class="mt" href="/?image={{ repo }}@{{ digest }}&mt={{
 <div class="tab content2">
 <pre class="manifest-json">{{ descriptor|tojson(indent=2) }}</pre>
 </div>
-<h4><span style="padding:0;" class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md">export</a> {{ image }} | tar -tv{% if path %} {{ path }}{% endif %}</h4>
+<h4><span class="noselect noselect--tight">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md">export</a> {{ image }} | tar -tv{% if path %} {{ path }}{% endif %}</h4>
 <pre>{%- for it in items %}
 <a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a> {{ it.perms }} {{ it.owner }} <span title="{{ it.size_hr }}">{{ '%12s'|format(it.size) }}</span> {{ it.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a>{% if not loop.last %}\n{% endif %}
 {%- endfor %}</pre>

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -3,7 +3,7 @@
 {% block body %}
 <h1><a class="top" href="/"><img class="crane" src="{{ url_for('favicon_svg') }}"/> <span class="link">Registry Explorer</span></a></h1>
 <h2>{{ repo }}</h2>
-<h4><span style="padding:0;" class="noselect">$ </span>curl -sL "{{ data_url }}" | jq .</h4>
+<h4><span class="noselect noselect--tight">$ </span>curl -sL "{{ data_url }}" | jq .</h4>
 
 <div>{
 <div class="indent">


### PR DESCRIPTION
## Summary
- enforce a `noselect--tight` class to remove inline padding rules
- use that new class in OCI templates
- update `check_inline_styles` glob path so all templates are scanned

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858e78c713c8332b706f76d9971cf66