### PR TITLE
Add Terminal CSS integration

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -13,6 +13,11 @@
   --radius: 8px;
   --select-bg-color: var(--color-base);
   --select-border-color: var(--color-contrast);
+
+  /* Terminal.css compatibility */
+  --background-color: var(--color-base);
+  --font-color: var(--color-contrast);
+  --primary-color: var(--color-accent);
 }
 
 body {

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
   {% if current_theme %}
   {% if current_theme == 'terminal-sans-dark.css' %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='vendor/terminal.min.css') }}" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@latest" />
   {% endif %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
   {% endif %}
@@ -1427,8 +1427,14 @@
     }
 
     const urlTable = document.querySelector('.url-table');
-    if(urlTable) makeResizable(urlTable, 'url-col-widths');
+  if(urlTable) makeResizable(urlTable, 'url-col-widths');
   </script>
+  <div class="terminal mt-05">
+    <section class="terminal-card">
+      <header>New Styled Panel</header>
+      <div>This area uses Terminal CSS.</div>
+    </section>
+  </div>
 </div>
 <script src="{{ url_for('static', filename='index_page.js') }}"></script>
 </body>

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -12,7 +12,7 @@
   {% set current_theme = session.get('theme') %}
   {% if current_theme %}
   {% if current_theme == 'terminal-sans-dark.css' %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='vendor/terminal.min.css') }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@latest">
   {% endif %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}">
   {% endif %}

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
   {% if current_theme %}
   {% if current_theme == 'terminal-sans-dark.css' %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='vendor/terminal.min.css') }}" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@latest" />
   {% endif %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
   {% endif %}

--- a/templates/swaggerui.html
+++ b/templates/swaggerui.html
@@ -10,7 +10,7 @@
   {% set current_theme = session.get('theme') %}
   {% if current_theme %}
   {% if current_theme == 'terminal-sans-dark.css' %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='vendor/terminal.min.css') }}" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@latest" />
   {% endif %}
   <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
   {% endif %}


### PR DESCRIPTION
## Summary
- load Terminal CSS via CDN when terminal-sans-dark theme is active
- map Retrorecon variables to Terminal CSS names
- add sample `.terminal` block in index.html

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858fb46d2148332a40c0f5aa8a1527a