### PR TITLE
Enforce table style compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ node_modules/
 frontend/package-lock.json
 package-lock.json
 __pycache__/
-!reports/report.json
+reports/
 last_db.txt
 static/screenshots/
 static/sitezips/

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -48,3 +48,14 @@ Key element defaults derived from `static/base.css`:
 Inputs, dropdowns, and other controls follow the same naming pattern (`.input`, `.dropdown`, `.dropdown--open`). Ensure every rule is scoped under `.retrorecon-root`.
 
 Adhering to these conventions keeps Retrorecon styles clear, maintainable, and easy to extend with additional themes.
+
+## 4. Visual Defaults
+
+New templates should present a clean look by default. Avoid using glow effects
+such as `box-shadow` or heavy `text-shadow` unless a design specifically
+requires it. Common interface elements &mdash; including buttons, inputs and
+table containers &mdash; should have slightly rounded corners using a
+`border-radius` of around `4px` to `6px`.
+
+Following these defaults ensures consistency between pages and keeps the
+interface simple to theme.

--- a/scripts/table_compliance_report.py
+++ b/scripts/table_compliance_report.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Generate an HTML report of tables that do not follow the style guide."""
+from pathlib import Path
+from bs4 import BeautifulSoup, element
+
+TEMPLATE_DIR = Path('templates')
+REPORT_DIR = Path('reports')
+REPORT_DIR.mkdir(exist_ok=True)
+
+rows = [
+    '<html><head><title>Table Compliance Report</title>',
+    '<style>table{border-collapse:collapse;}td,th{border:1px solid #ccc;padding:4px;}</style>',
+    '</head><body>',
+    '<h1>Table Compliance Report</h1>',
+    '<table><tr><th>File</th><th>Issue</th><th>Excerpt</th></tr>'
+]
+
+non_compliant = 0
+
+for html_file in sorted(TEMPLATE_DIR.glob('*.html')):
+    soup = BeautifulSoup(html_file.read_text(), 'html.parser')
+    for table in soup.find_all('table'):
+        issues = []
+        parent = table
+        within_root = False
+        while isinstance(parent, element.Tag):
+            if 'retrorecon-root' in parent.get('class', []):
+                within_root = True
+                break
+            parent = parent.parent
+        if not within_root:
+            issues.append('not inside .retrorecon-root')
+        if table.has_attr('style'):
+            issues.append('inline style')
+        if issues:
+            non_compliant += 1
+            excerpt = (str(table)[:60]
+                       .replace('<', '&lt;')
+                       .replace('>', '&gt;'))
+            rows.append(f"<tr><td>{html_file}</td><td>{', '.join(issues)}</td><td><code>{excerpt}...</code></td></tr>")
+
+if non_compliant == 0:
+    rows.append("<tr><td colspan='3'>All tables comply with the style guide.</td></tr>")
+
+rows.append('</table></body></html>')
+
+(REPORT_DIR / 'table_compliance.html').write_text('\n'.join(rows), encoding='utf-8')
+print(f"Found {non_compliant} non-compliant tables.")


### PR DESCRIPTION
## Summary
- ignore all reports
- document "no glow" and "rounded corners" defaults
- add tool to list tables that break the style guide

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`
- `python scripts/table_compliance_report.py`

------
https://chatgpt.com/codex/tasks/task_e_685988d975a483329b097be22895c2eb