### PR TITLE
Fix scroll on OCI explorer page

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -27,7 +27,6 @@ body {
 .retrorecon-root h1,
 .retrorecon-root h2 {
   margin: 1em 0;
-  text-align: center;
   font-weight: bold;
 }
 
@@ -1183,6 +1182,7 @@ body.bg-hidden {
   background: rgba(var(--bg-rgb) / 0.95);
   color: var(--fg-color);
   z-index: 1000;
+  box-sizing: border-box;
   padding: 1em;
   display: flex;
   flex-direction: column;
@@ -1263,4 +1263,11 @@ body.bg-hidden {
 .retrorecon-root .close-btn {
   float: right;
   margin-left: 1em;
+}
+
+.retrorecon-root .overlay-close-btn {
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  float: none;
 }

--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -1,6 +1,7 @@
 <!-- File: templates/dag_explorer.html -->
 <div id="dag-explorer-overlay" class="notes-overlay hidden">
-  <h1>
+  <button type="button" class="btn overlay-close-btn" id="dag-close-btn">Close</button>
+  <h1 class="text-center">
     <a class="top" href="/">
       <img class="crane" src="{{ url_for('favicon_svg') }}"/>
       <span class="link">Registry Explorer</span>
@@ -37,7 +38,6 @@
     <input type="text" id="dag-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
     <button type="button" class="btn" id="dag-fetch-btn">Fetch Manifest</button>
     <button type="button" class="btn" id="dag-tags-btn">List Tags</button>
-    <button type="button" class="btn close-btn" id="dag-close-btn">Close</button>
   </div>
   <div id="dag-manifest" class="mb-05"></div>
   <div id="dag-path" class="mb-05"></div>


### PR DESCRIPTION
## Summary
- fix vertical scrollbar on `/tools/dag_explorer`
- move close button to consistent top-right corner
- remove global header centering and explicitly center DAG heading

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598f081050833297cd6e2929f98380