### PR TITLE
Fix issue #553

### DIFF
--- a/reports/swagger_ui_theme_plan.md
+++ b/reports/swagger_ui_theme_plan.md
@@ -1,0 +1,29 @@
+# Swagger UI Theming Plan
+
+This document outlines a future approach for integrating Swagger UI with the Retrorecon theme selector while keeping the interface readable.
+
+## Goals
+
+- Allow Swagger UI to inherit the same color scheme as the main application when a theme is chosen.
+- Avoid overriding core Swagger UI styles that ensure readability.
+- Provide a simple mechanism to opt-in or opt-out of theming.
+
+## Proposed Approach
+
+1. **Isolated Style Sheet**
+   - Create a dedicated CSS file (e.g. `swagger-theme.css`) containing variable overrides for the standard Swagger UI classes.
+   - Include this file only when a Retrorecon theme is active.
+
+2. **Variable Mapping**
+   - Map Retrorecon CSS variables (`--bg-color`, `--fg-color`, etc.) to Swagger UI elements using the `:root` selector inside `swagger-theme.css`.
+   - Keep fonts and layout rules from the default Swagger UI bundle to preserve usability.
+
+3. **Toggle Support**
+   - Add a checkbox in the Preferences menu to enable or disable Swagger UI theming.
+   - Store the preference in the user session similar to the existing theme choice.
+
+4. **Testing**
+   - Verify that dark and light themes render without losing contrast in form inputs and code blocks.
+   - Manually check that disabling the theme falls back to the stock Swagger UI appearance.
+
+This plan keeps the Swagger interface legible while making it visually consistent with the rest of Retrorecon.

--- a/templates/swaggerui.html
+++ b/templates/swaggerui.html
@@ -6,37 +6,15 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
-  {% set current_theme = session.get('theme') %}
-  {% if current_theme %}
-  {% if current_theme == 'terminal-sans-dark.css' %}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@latest" />
-  {% endif %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='themes/' + current_theme) }}" />
-  {% endif %}
-  <style>
-    .retrorecon-root {
-      --color-base: #1b1b1b;
-      --bg-color: #1b1b1b;
-      --bg-rgb: 27 27 27;
-    }
-  </style>
-  {% set current_background = session.get('background') %}
-  {% if current_background %}
-  <style>
-    body { background-image: url('{{ url_for('static', filename='img/' + current_background) }}'); }
-  </style>
-  {% endif %}
+  <!-- Deliberately omit Retrorecon base and theme styles to keep Swagger UI legible -->
   <link rel="stylesheet" type="text/css" href="{{ base_url }}/index.css" />
   <link rel="stylesheet" type="text/css" href="{{ base_url }}/swagger-ui.css" />
   <link rel="icon" type="image/png" href="{{ base_url }}/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="{{ base_url }}/favicon-16x16.png" sizes="16x16" />
 </head>
-<body class="app">
-<div class="retrorecon-root">
-  <button type="button" class="btn btn--small close-btn" onclick="history.back();">Close</button>
-  <div id="swagger-ui"></div>
-</div>
+<body>
+<button type="button" onclick="history.back();">Close</button>
+<div id="swagger-ui"></div>
 <script src="{{ base_url }}/swagger-ui-bundle.js"></script>
 <script src="{{ base_url }}/swagger-ui-standalone-preset.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- reset Swagger UI template to avoid Retrorecon styles
- add a close button without custom CSS
- draft a plan for future Swagger theming

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859918e17bc8332aeb5eab389089c4a