### PR TITLE
Fix issue #545 - externalize OCI styles

### DIFF
--- a/static/oci.css
+++ b/static/oci.css
@@ -1,0 +1,47 @@
+/* File: static/oci.css */
+:root {
+  color-scheme: light dark;
+}
+
+.retrorecon-root {
+  font-family: monospace;
+  padding: 12px;
+}
+.retrorecon-root pre { white-space: pre; }
+.retrorecon-root .manifest-json { white-space: pre; }
+.retrorecon-root .indent { margin-left: 2em; }
+.retrorecon-root .mt { color: inherit; text-decoration: inherit; }
+.retrorecon-root .mt:hover { text-decoration: underline; }
+.retrorecon-root .link { position: relative; bottom: .125em; }
+.retrorecon-root .crane { height: 1em; width: 1em; }
+.retrorecon-root .top { color: inherit; text-decoration: inherit; }
+.retrorecon-root .noselect {
+  user-select: none;
+  -webkit-user-select: none;
+  padding-right: 1em;
+  text-align: right;
+  white-space: nowrap;
+}
+.retrorecon-root .noselect--tight {
+  padding-right: 0;
+}
+/* simple tab styling used by registry explorer pages */
+.retrorecon-root input + label {
+  display: inline-block;
+  border: 1px solid #999;
+  padding: 4px 12px;
+  border-radius: 4px 4px 0 0;
+  position: relative;
+  top: 1px;
+  opacity: 50%;
+}
+.retrorecon-root input { display: none; }
+.retrorecon-root input ~ .tab {
+  display: none;
+  border-top: 1px solid #999;
+  padding-top: 0.5em;
+}
+.retrorecon-root #tab1:checked ~ .tab.content1,
+.retrorecon-root #tab2:checked ~ .tab.content2 { display: block; }
+.retrorecon-root input:checked + label { opacity: 100%; }
+.retrorecon-root .close-btn { float: right; margin-left: 1em; }

--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -22,50 +22,7 @@
     body { background-image: url('{{ url_for('static', filename='img/' + current_background) }}'); }
   </style>
   {% endif %}
-  <style>
-  :root {
-    color-scheme: light dark;
-  }
-  .retrorecon-root {
-    font-family: monospace;
-    padding: 12px;
-  }
-  .retrorecon-root pre { white-space: pre; }
-  .retrorecon-root .manifest-json { white-space: pre; }
-  .retrorecon-root .indent { margin-left: 2em; }
-  .retrorecon-root .mt { color: inherit; text-decoration: inherit; }
-  .retrorecon-root .mt:hover { text-decoration: underline; }
-  .retrorecon-root .link { position: relative; bottom: .125em; }
-  .retrorecon-root .crane { height: 1em; width: 1em; }
-  .retrorecon-root .top { color: inherit; text-decoration: inherit; }
-  .retrorecon-root .noselect {
-    user-select: none;
-    -webkit-user-select: none;
-    padding-right: 1em;
-    text-align: right;
-    white-space: nowrap;
-  }
-  .retrorecon-root .noselect--tight {
-    padding-right: 0;
-  }
-  /* simple tab styling used by registry explorer pages */
-  .retrorecon-root input + label { display: inline-block; }
-  .retrorecon-root input { display: none; }
-  .retrorecon-root input ~ .tab { display: none; }
-  .retrorecon-root #tab1:checked ~ .tab.content1,
-  .retrorecon-root #tab2:checked ~ .tab.content2 { display: block; }
-  .retrorecon-root input + label {
-    border: 1px solid #999;
-    padding: 4px 12px;
-    border-radius: 4px 4px 0 0;
-    position: relative;
-    top: 1px;
-    opacity: 50%;
-  }
-  .retrorecon-root input:checked + label { opacity: 100%; }
-  .retrorecon-root input ~ .tab { border-top: 1px solid #999; padding-top: 0.5em; }
-  .retrorecon-root .close-btn { float: right; margin-left: 1em; }
-  </style>
+  <link rel="stylesheet" href="{{ url_for('static', filename='oci.css') }}">
 </head>
 <body>
 <div class="retrorecon-root">


### PR DESCRIPTION
## Summary
- move styles for OCI explorer pages into `static/oci.css`
- link the new stylesheet from `oci_base.html`

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a071ff0c83329901b608a2044af7