### PR TITLE
Fix OCI explorer layout

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -187,6 +187,7 @@ body {
   background-size: cover;
   display: flex;
   flex-direction: column;
+  position: relative;
   font-family: var(--font-main);
   font-size: 14px;
   margin: 0;
@@ -1261,8 +1262,11 @@ body.bg-hidden {
 
 /* Generic close button for standalone pages */
 .retrorecon-root .close-btn {
-  float: right;
-  margin-left: 1em;
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  border-radius: 999px;
+  padding: 2px 12px;
 }
 
 .retrorecon-root .overlay-close-btn {

--- a/static/oci.css
+++ b/static/oci.css
@@ -6,6 +6,7 @@
 .retrorecon-root {
   font-family: monospace;
   padding: 12px;
+  position: relative;
 }
 .retrorecon-root pre { white-space: pre; }
 .retrorecon-root .manifest-json {
@@ -48,7 +49,9 @@
 .retrorecon-root #tab2:checked ~ .tab.content2 { display: block; }
 .retrorecon-root input:checked + label { opacity: 100%; }
 .retrorecon-root .close-btn {
-  float: right;
-  margin-left: 1em;
-  clear: both;
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  border-radius: 999px;
+  padding: 2px 12px;
 }

--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -20,7 +20,20 @@ Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ med
 <pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
 </div>
 <h4><span class="noselect noselect--tight">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz{% if subpath %}  {{ subpath }}{% endif %}</h4>
-<pre>{%- for item in items %}
-{{ item.perms }} {{ item.owner }} <span title="{{ item.size_hr }}">{{ '%12s'|format(item.size) }}</span> {{ item.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ item.path }}">{{ item.name }}{% if item.is_dir %}/{% endif %}</a>{% if not loop.last %}\n{% endif %}
-{%- endfor %}</pre>
+<table class="fs-table">
+  <thead>
+    <tr><th>Perms</th><th>Owner</th><th>Size</th><th>Modified</th><th>Name</th></tr>
+  </thead>
+  <tbody>
+  {% for item in items %}
+    <tr>
+      <td class="text-mono">{{ item.perms }}</td>
+      <td class="text-mono">{{ item.owner }}</td>
+      <td class="text-right" title="{{ item.size_hr }}">{{ item.size }}</td>
+      <td>{{ item.ts }}</td>
+      <td><a href="/fs/{{ repo }}@{{ digest }}{{ item.path }}">{{ item.name }}{% if item.is_dir %}/{% endif %}</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/templates/oci_overlay.html
+++ b/templates/oci_overlay.html
@@ -15,7 +15,21 @@ Docker-Content-Digest: <a class="mt" href="/?image={{ repo }}@{{ digest }}&mt={{
 <pre class="manifest-json">{{ descriptor|tojson(indent=2) }}</pre>
 </div>
 <h4><span class="noselect noselect--tight">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_export.md">export</a> {{ image }} | tar -tv{% if path %} {{ path }}{% endif %}</h4>
-<pre>{%- for it in items %}
-<a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a> {{ it.perms }} {{ it.owner }} <span title="{{ it.size_hr }}">{{ '%12s'|format(it.size) }}</span> {{ it.ts }} <a href="/fs/{{ repo }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a>{% if not loop.last %}\n{% endif %}
-{%- endfor %}</pre>
+<table class="fs-table">
+  <thead>
+    <tr><th>Layer</th><th>Perms</th><th>Owner</th><th>Size</th><th>Modified</th><th>Name</th></tr>
+  </thead>
+  <tbody>
+  {% for it in items %}
+    <tr>
+      <td><a href="/fs/{{ repo }}@{{ it.digest }}">{{ it.digest[:8] }}</a></td>
+      <td class="text-mono">{{ it.perms }}</td>
+      <td class="text-mono">{{ it.owner }}</td>
+      <td class="text-right" title="{{ it.size_hr }}">{{ it.size }}</td>
+      <td>{{ it.ts }}</td>
+      <td><a href="/fs/{{ repo }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- keep `.retrorecon-root` positioned for absolutely placed controls
- style `.close-btn` as pill button in the corner
- convert OCI filesystem and overlay listings to proper tables

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859b41ec1708332b23dbde3dccfced0