### PR TITLE
Fix OCI explorer tab layout

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -14,6 +14,11 @@ Every Retrorecon page should wrap its content in a container element with the cl
 
 All selectors in custom styles should start with `.retrorecon-root` to avoid conflicts when embedding Retrorecon into other sites or when applying multiple themes. Scoping rules this way keeps project styles self-contained.
 
+Page-specific styles may override the `.retrorecon-root` layout when needed. For
+example, the OCI Explorer disables the flex layout defined in `base.css` so that
+tab labels render side by side. When adjusting the container's `display`
+property, ensure that descendant selectors remain scoped under `.retrorecon-root`.
+
 ## 2. Selector Naming Conventions
 
 Use a BEM‑style convention for class names. Base components have simple names (e.g. `.btn`, `.input`). Modifiers use a `--` suffix:

--- a/static/oci.css
+++ b/static/oci.css
@@ -7,6 +7,7 @@
   font-family: monospace;
   padding: 12px;
   position: relative;
+  display: block; /* avoid flex layout from base.css so tab labels align */
 }
 .retrorecon-root pre { white-space: pre; }
 .retrorecon-root .manifest-json {


### PR DESCRIPTION
## Summary
- fix tab layout for OCI explorer pages by overriding flex container
- document that pages may override `.retrorecon-root` layout when needed

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b9eac4648332989b89cd1a7371da