### PR TITLE
Add Swagger UI dark theme

### DIFF
--- a/static/themes/swagger-dark.css
+++ b/static/themes/swagger-dark.css
@@ -1,0 +1,19 @@
+@media (prefers-color-scheme: dark) {
+  .retrorecon-root body {
+    background-color: #1f1f1f;
+    color: #bfbfbf;
+  }
+  .retrorecon-root a {
+    color: #8c8cfa;
+  }
+  .retrorecon-root .swagger-ui .topbar,
+  .retrorecon-root .swagger-ui section,
+  .retrorecon-root .swagger-ui .information-container {
+    background-color: #1f1f1f;
+  }
+  .retrorecon-root .swagger-ui .btn,
+  .retrorecon-root .swagger-ui select {
+    background-color: #303030;
+    color: #e0e0e0;
+  }
+}

--- a/templates/swaggerui.html
+++ b/templates/swaggerui.html
@@ -11,10 +11,13 @@
   <link rel="stylesheet" type="text/css" href="{{ base_url }}/swagger-ui.css" />
   <link rel="icon" type="image/png" href="{{ base_url }}/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="{{ base_url }}/favicon-16x16.png" sizes="16x16" />
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='themes/swagger-dark.css') }}" />
 </head>
 <body>
-<button type="button" onclick="history.back();">Close</button>
-<div id="swagger-ui"></div>
+<div class="retrorecon-root">
+  <button type="button" class="close-btn" onclick="history.back();">Close</button>
+  <div id="swagger-ui"></div>
+</div>
 <script src="{{ base_url }}/swagger-ui-bundle.js"></script>
 <script src="{{ base_url }}/swagger-ui-standalone-preset.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- style Swagger UI with new dark theme stylesheet
- wrap Swagger UI in retrorecon container and add styled close button

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c2511a9883329fb7d09d35d3421c