### PR TITLE
Fix Swagger close button location

### DIFF
--- a/templates/swaggerui.html
+++ b/templates/swaggerui.html
@@ -11,9 +11,19 @@
   <link rel="stylesheet" type="text/css" href="{{ base_url }}/swagger-ui.css" />
   <link rel="icon" type="image/png" href="{{ base_url }}/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="{{ base_url }}/favicon-16x16.png" sizes="16x16" />
+  <style>
+    #swagger-close-btn {
+      position: absolute;
+      top: 0.5em;
+      right: 0.5em;
+      border-radius: 999px;
+      padding: 2px 12px;
+      cursor: pointer;
+    }
+  </style>
 </head>
 <body>
-<button type="button" onclick="history.back();">Close</button>
+<button id="swagger-close-btn" type="button" onclick="history.back();">Close</button>
 <div id="swagger-ui"></div>
 <script src="{{ base_url }}/swagger-ui-bundle.js"></script>
 <script src="{{ base_url }}/swagger-ui-standalone-preset.js"></script>


### PR DESCRIPTION
## Summary
- fix mispositioned Swagger close button

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d30f42bc8332ab244945d4db5094