### PR TITLE
Fix issue 574: remove demo panel

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1423,12 +1423,6 @@
     const urlTable = document.querySelector('.url-table');
   if(urlTable) makeResizable(urlTable, 'url-col-widths');
   </script>
-  <div class="terminal mt-05">
-    <section class="terminal-card">
-      <header>New Styled Panel</header>
-      <div>This area uses Terminal CSS.</div>
-    </section>
-  </div>
 </div>
 <script src="{{ url_for('static', filename='index_page.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- clean up leftover demo "Terminal CSS" block on the index page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859d86f39ac8332812ff4205d94ea3e