### PR TITLE
Fix issue #580: refine registry explorer layout

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1233,7 +1233,7 @@ body.bg-hidden {
 
 /* Ensure preformatted output boxes match the theme */
 .retrorecon-root pre {
-  background: var(--bg-color);
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
   color: var(--fg-color);
   padding: 0.5em;
   overflow-x: auto;

--- a/static/oci.css
+++ b/static/oci.css
@@ -56,3 +56,11 @@
   border-radius: 999px;
   padding: 2px 12px;
 }
+
+.retrorecon-root #filter-form {
+  position: absolute;
+  top: 0.5em;
+  right: 6em;
+  display: flex;
+  gap: 0.5em;
+}

--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -3,7 +3,7 @@
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ repo }}@{{ digest }}: {{ path }}</h2>
-<form method="get" class="mb-05">
+<form id="filter-form" method="get">
   <input type="text" name="q" value="{{ q }}" placeholder="Filter" class="form-input mr-05" />
   <button type="submit" class="btn">Apply</button>
 </form>


### PR DESCRIPTION
## Summary
- style preformatted text backgrounds with `--panel-opacity`
- add `filter-form` layout to match overlay close button
- move filter form in registry explorer files page

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859eb0a6ac88332bc1cdd2231ef89c0