### PR TITLE
Fix fs table opacity

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -729,6 +729,8 @@ body {
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.5em;
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
+  border-radius: var(--radius);
 }
 .retrorecon-root .fs-table th,
 .retrorecon-root .fs-table td {


### PR DESCRIPTION
## Summary
- use panel opacity for fs table backgrounds

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a08e53bd0833282eec80e5144ca7f