### PR TITLE
Fix invalid tar on overlay file links

### DIFF
--- a/templates/oci_overlay.html
+++ b/templates/oci_overlay.html
@@ -27,7 +27,7 @@ Docker-Content-Digest: <a class="mt" href="/?image={{ repo }}@{{ digest }}&mt={{
       <td class="text-mono">{{ it.owner }}</td>
       <td class="text-right" title="{{ it.size_hr }}">{{ it.size }}</td>
       <td>{{ it.ts }}</td>
-      <td><a href="/fs/{{ repo }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a></td>
+      <td><a href="/layers/{{ image }}@{{ digest }}{{ it.path }}">{{ it.name }}{% if it.is_dir %}/{% endif %}</a></td>
     </tr>
   {% endfor %}
   </tbody>

--- a/tests/test_oci_routes.py
+++ b/tests/test_oci_routes.py
@@ -363,7 +363,7 @@ def test_layers_overlay_listing(tmp_path, monkeypatch):
         assert "foo.txt" in html
         assert "bar.txt" in html
         assert '/fs/user/repo@sha256:a' in html
-        assert 'href="/fs/user/repo@sha256:m/foo.txt"' in html
+        assert 'href="/layers/user/repo:tag@sha256:m/foo.txt"' in html
 
         resp = client.get("/layers/user/repo:tag@sha256:m/foo.txt")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- overlay page should link through `/layers` route instead of `/fs`
- update tests to expect overlay links using `/layers`

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0fb30d008332a43d5e615b5321d5