### PR TITLE
Fix OCI explorer readability

### DIFF
--- a/templates/oci_base.html
+++ b/templates/oci_base.html
@@ -22,6 +22,10 @@
     body { background-image: url('{{ url_for('static', filename='img/' + current_background) }}'); }
   </style>
   {% endif %}
+  {% set panel_opacity = session.get('panel_opacity', 0.75) %}
+  <style>
+    :root { --panel-opacity: {{ panel_opacity }}; }
+  </style>
   <link rel="stylesheet" href="{{ url_for('static', filename='oci.css') }}">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- set `--panel-opacity` in `oci_base.html` using session settings

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a15bdb7208332b954e4b2a0db96e0