### PR TITLE
Hide OCI metadata behind collapsible details

### DIFF
--- a/static/oci.css
+++ b/static/oci.css
@@ -64,3 +64,6 @@
   display: flex;
   gap: 0.5em;
 }
+.retrorecon-root details.meta-details {
+  margin-top: 1em;
+}

--- a/templates/oci_fs.html
+++ b/templates/oci_fs.html
@@ -7,19 +7,22 @@
   <input type="text" name="q" value="{{ q }}" placeholder="Filter" class="form-input mr-05" />
   <button type="submit" class="btn">Apply</button>
 </form>
-<input type="radio" name="tabs" id="tab1" checked>
-<label for="tab1">HTTP</label>
-<input type="radio" name="tabs" id="tab2">
-<label for="tab2">OCI</label>
-<div class="tab content1">
-Content-Type: <a class="mt" href="https://github.com/opencontainers/image-spec/blob/main/layer.md">{{ media_type }}</a><br>
-Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type|urlencode }}&size={{ size }}">{{ digest }}</a><br>
-<span title="{{ size_hr }}">Content-Length: {{ size }}</span><br>
-</div>
-<div class="tab content2">
-<pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
-</div>
-<h4><span class="noselect noselect--tight">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz{% if subpath %}  {{ subpath }}{% endif %}</h4>
+<details class="meta-details">
+  <summary>Details</summary>
+  <input type="radio" name="tabs" id="tab1" checked>
+  <label for="tab1">HTTP</label>
+  <input type="radio" name="tabs" id="tab2">
+  <label for="tab2">OCI</label>
+  <div class="tab content1">
+  Content-Type: <a class="mt" href="https://github.com/opencontainers/image-spec/blob/main/layer.md">{{ media_type }}</a><br>
+  Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type|urlencode }}&size={{ size }}">{{ digest }}</a><br>
+  <span title="{{ size_hr }}">Content-Length: {{ size }}</span><br>
+  </div>
+  <div class="tab content2">
+  <pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
+  </div>
+  <h4><span class="noselect noselect--tight">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz{% if subpath %}  {{ subpath }}{% endif %}</h4>
+</details>
 <table class="fs-table">
   <thead>
     <tr><th>Perms</th><th>Owner</th><th>Size</th><th>Modified</th><th>Name</th></tr>

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -2,20 +2,23 @@
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2>{{ display_image or image }}</h2>
-<input type="radio" name="tabs" id="tab1" checked>
-<label for="tab1">HTTP</label>
-<input type="radio" name="tabs" id="tab2">
-<label for="tab2">OCI</label>
-<div class="tab content1">
-{% for k, v in data.headers.items() %}
-{{ k }}: {{ v }}<br>
-{% endfor %}
-<pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
-</div>
-<div class="tab content2">
-<pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
-</div>
+<details class="meta-details">
+  <summary>Details</summary>
+  <input type="radio" name="tabs" id="tab1" checked>
+  <label for="tab1">HTTP</label>
+  <input type="radio" name="tabs" id="tab2">
+  <label for="tab2">OCI</label>
+  <div class="tab content1">
+  {% for k, v in data.headers.items() %}
+  {{ k }}: {{ v }}<br>
+  {% endfor %}
+  <pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
+  </div>
+  <div class="tab content2">
+  <pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
+  </div>
 
-<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
-<pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest, link_size=False) }}</pre>
+  <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
+  <pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest, link_size=False) }}</pre>
+</details>
 {% endblock %}

--- a/templates/oci_layer.html
+++ b/templates/oci_layer.html
@@ -3,18 +3,21 @@
 {% block body %}
 <h1><a class="mt" href="/">Registry Explorer</a></h1>
 <h2><a class="mt" href="/repo/{{ repo }}">{{ repo }}</a>@<a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type }}&size={{ size }}">{{ digest }}</a></h2>
-<input type="radio" name="tabs" id="tab1" checked>
-<label for="tab1">HTTP</label>
-<input type="radio" name="tabs" id="tab2">
-<label for="tab2">OCI</label>
-<div class="tab content1">
-Content-Type: <a class="mt" href="https://github.com/opencontainers/image-spec/blob/main/layer.md">{{ media_type }}</a><br>
-Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type }}&size={{ size }}">{{ digest }}</a><br>
-<span title="{{ size_hr }}">Content-Length: {{ size }}</span><br>
-</div>
-<div class="tab content2">
-<pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
-</div>
-<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz | sort -n -r -k3</h4>
+<details class="meta-details">
+  <summary>Details</summary>
+  <input type="radio" name="tabs" id="tab1" checked>
+  <label for="tab1">HTTP</label>
+  <input type="radio" name="tabs" id="tab2">
+  <label for="tab2">OCI</label>
+  <div class="tab content1">
+  Content-Type: <a class="mt" href="https://github.com/opencontainers/image-spec/blob/main/layer.md">{{ media_type }}</a><br>
+  Docker-Content-Digest: <a class="mt" href="/fs/{{ repo }}@{{ digest }}?mt={{ media_type }}&size={{ size }}">{{ digest }}</a><br>
+  <span title="{{ size_hr }}">Content-Length: {{ size }}</span><br>
+  </div>
+  <div class="tab content2">
+  <pre class="manifest-json">{{ {'mediaType': media_type, 'digest': digest, 'size': size}|tojson(indent=2) }}</pre>
+  </div>
+  <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_blob.md">blob</a> {{ repo }}@{{ digest }} | tar -tvz | sort -n -r -k3</h4>
+</details>
 <pre>{{ lines|join('\n') }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- hide verbose HTTP/OCI headers in a `<details>` block
- keep filesystem filter form and file listing intact

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a1bd10fd08332962572072e862b63