### PR TITLE
Fix issue 593 registry bookmarks

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1257,13 +1257,17 @@ body.bg-hidden {
 }
 .retrorecon-root .dag-explorer-cols {
   display: flex;
-  gap: 1em;
+  gap: 2em;
   flex-wrap: wrap;
+  align-items: flex-start;
   margin-top: 0.5em;
 }
 .retrorecon-root .dag-explorer-cols .col {
   flex: 1;
   min-width: 250px;
+}
+.retrorecon-root .dag-explorer-cols .right-col {
+  margin-left: auto;
 }
 .retrorecon-root .bookmark-table {
   width: 100%;

--- a/static/dag_explorer.js
+++ b/static/dag_explorer.js
@@ -10,9 +10,7 @@ function initDagExplorer(){
   const pathDiv = document.getElementById('dag-path');
   const manifestDiv = document.getElementById('dag-manifest');
   const bkTableBody = document.getElementById('bookmark-table-body');
-  const bkAddr = document.getElementById('bookmark-address');
-  const bkNote = document.getElementById('bookmark-note');
-  const bkAddBtn = document.getElementById('bookmark-add-btn');
+  const bkAddCurrentBtn = document.getElementById('bookmark-add-btn');
 
   const SPEC_LINKS = {
     'application/vnd.docker.distribution.manifest.v2+json':
@@ -256,17 +254,16 @@ function initDagExplorer(){
     }
   });
 
-  if(bkAddBtn){
-    bkAddBtn.addEventListener('click', () => {
-      const addr = bkAddr.value.trim();
+  if(bkAddCurrentBtn){
+    bkAddCurrentBtn.addEventListener('click', () => {
+      const addr = imgInput.value.trim();
       if(!addr) return;
-      const note = bkNote.value.trim();
       const bks = loadBookmarks();
-      bks.push({addr, note});
-      saveBookmarks(bks);
-      bkAddr.value = '';
-      bkNote.value = '';
-      renderBookmarks();
+      if(!bks.find(b => b.addr === addr)){
+        bks.push({addr, note: ''});
+        saveBookmarks(bks);
+        renderBookmarks();
+      }
     });
   }
   if(bkTableBody){

--- a/static/registry_explorer.js
+++ b/static/registry_explorer.js
@@ -9,9 +9,7 @@ function initRegistryExplorer(){
   const tableDiv = document.getElementById('registry-table');
   const infoDiv = document.getElementById('registry-info');
   const bkTableBody = document.getElementById('registry-bookmark-table-body');
-  const bkAddr = document.getElementById('registry-bookmark-address');
-  const bkNote = document.getElementById('registry-bookmark-note');
-  const bkAddBtn = document.getElementById('registry-bookmark-add-btn');
+  const bkAddCurrentBtn = document.getElementById('registry-add-bookmark-btn');
 
   function escapeHtml(str){
     return str.replace(/[&<>\"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;'}[c]));
@@ -168,17 +166,16 @@ function initRegistryExplorer(){
     }
   });
 
-  if(bkAddBtn){
-    bkAddBtn.addEventListener('click', () => {
-      const addr = bkAddr.value.trim();
+  if(bkAddCurrentBtn){
+    bkAddCurrentBtn.addEventListener('click', () => {
+      const addr = imageInput.value.trim();
       if(!addr) return;
-      const note = bkNote.value.trim();
       const bks = loadBookmarks();
-      bks.push({addr, note});
-      saveBookmarks(bks);
-      bkAddr.value = '';
-      bkNote.value = '';
-      renderBookmarks();
+      if(!bks.find(b => b.addr === addr)){
+        bks.push({addr, note: ''});
+        saveBookmarks(bks);
+        renderBookmarks();
+      }
     });
   }
   if(bkTableBody){

--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -9,30 +9,13 @@
     </h1>
     <button type="button" class="btn overlay-close-btn" id="dag-close-btn">Close</button>
   </div>
-  <p>This beautiful tool allows you to <em>explore</em> the contents of a registry interactively.</p>
-  <p>You can even drill down into layers to explore an image's filesystem.</p>
   <div class="dag-explorer-cols">
     <div class="col left-col">
-      <p>Enter a <strong>public</strong> image, e.g. <tt>"ubuntu:latest"</tt>:</p>
-      <form action="/" method="GET" autocomplete="off" spellcheck="false">
-        <input size="100" type="text" name="image" value="ubuntu:latest"/>
-        <input type="submit" />
-      </form>
-      <p class="mt-05">Enter a <strong>public</strong> repository, e.g. <tt>"ubuntu"</tt>:</p>
-      <form action="/" method="GET" autocomplete="off" spellcheck="false">
-        <input size="100" type="text" name="repo" value="ubuntu"/>
-        <input type="submit" />
-      </form>
       <h4 class="mt-05">Bookmarks</h4>
       <table id="bookmark-table" class="bookmark-table">
         <thead><tr><th>Address</th><th>Notes</th><th></th></tr></thead>
         <tbody id="bookmark-table-body"></tbody>
       </table>
-      <div class="mt-05">
-        <input type="text" id="bookmark-address" class="form-input mr-05 w-20em" placeholder="address" />
-        <input type="text" id="bookmark-note" class="form-input mr-05 w-20em" placeholder="note" />
-        <button type="button" class="btn" id="bookmark-add-btn">Add</button>
-      </div>
     </div>
     <div class="col right-col">
       <h4>Interesting examples</h4>
@@ -54,6 +37,7 @@
     <input type="text" id="dag-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
     <button type="button" class="btn" id="dag-fetch-btn">Fetch Manifest</button>
     <button type="button" class="btn" id="dag-tags-btn">List Tags</button>
+    <button type="button" class="btn" id="bookmark-add-btn">Bookmark</button>
   </div>
   <div id="dag-manifest" class="mb-05"></div>
   <div id="dag-path" class="mb-05"></div>

--- a/templates/registry_explorer.html
+++ b/templates/registry_explorer.html
@@ -5,6 +5,7 @@
     <label class="mr-05"><input type="checkbox" name="registry-method" value="extension" checked> extension</label>
     <label class="mr-05"><input type="checkbox" name="registry-method" value="layerslayer" checked> layerslayer</label>
     <button type="button" class="btn" id="registry-fetch-btn">Fetch</button>
+    <button type="button" class="btn" id="registry-add-bookmark-btn">Bookmark</button>
     <button type="button" class="btn" id="registry-close-btn">Close</button>
   </div>
   <h4 class="mt-05">Bookmarks</h4>
@@ -12,11 +13,6 @@
     <thead><tr><th>Address</th><th>Notes</th><th></th></tr></thead>
     <tbody id="registry-bookmark-table-body"></tbody>
   </table>
-  <div class="mt-05">
-    <input type="text" id="registry-bookmark-address" class="form-input mr-05 w-20em" placeholder="address" />
-    <input type="text" id="registry-bookmark-note" class="form-input mr-05 w-20em" placeholder="note" />
-    <button type="button" class="btn" id="registry-bookmark-add-btn">Add</button>
-  </div>
   <div id="registry-info" class="mb-05"></div>
   <div id="registry-table" class="mt-05"></div>
 </div>


### PR DESCRIPTION
## Summary
- remove helper text and manual bookmark inputs from the DAG explorer
- add a one-click bookmark button that saves the current image
- style the columns so the examples panel sits further right

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a1e3f200483329e18bed40350164c