### PR TITLE
Add registry table API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ RetroRecon digs through the internet’s attic to find forgotten, buried, or qui
 | Suspicious Pattern Detection  | Scans downloaded files for API keys, JWTs, secrets, etc.                   |
 | Filtering & Grouping          | Smart filters by type (e.g., `.js`, `.env`, `.php`, `.map`, etc.)          |
 | HTML Report Output (WIP)      | Generate browsable summaries with tagged snapshots and visual comparisons  |
+| OCI Registry Table Explorer   | Browse container images as tables with direct download links |
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -44,3 +44,5 @@ class Config:
     LOG_LEVEL = os.environ.get('RETRORECON_LOG_LEVEL', 'WARNING')
     DOCKERHUB_API = os.environ.get('DOCKERHUB_API')
     VIRUSTOTAL_API = os.environ.get('VIRUSTOTAL_API')
+    REGISTRY_USERNAME = os.environ.get('REGISTRY_USERNAME')
+    REGISTRY_PASSWORD = os.environ.get('REGISTRY_PASSWORD')

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -613,6 +613,13 @@ Query manifest information for an image.
 curl -G --data-urlencode "image=ubuntu:latest" http://localhost:5000/registry_explorer
 ```
 
+### `GET /registry_table`
+Return manifest details as a hierarchical table structure.
+
+```
+curl -G --data-urlencode "image=ubuntu:latest" http://localhost:5000/registry_table
+```
+
 ### `GET /dag_explorer`
 Serve the Dag Explorer overlay.
 

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -1,5 +1,7 @@
 {
   "RETRORECON_SECRET": "change_me",
   "DOCKERHUB_API": "",
-  "VIRUSTOTAL_API": ""
+  "VIRUSTOTAL_API": "",
+  "REGISTRY_USERNAME": "",
+  "REGISTRY_PASSWORD": ""
 }


### PR DESCRIPTION
## Summary
- detect address types and expose manifest table data
- add registry credentials configuration options
- document new `/registry_table` endpoint
- list Registry Table Explorer in README
- provide sample config keys
- test address detection and new route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a2a762e048332a5ea29873dccd32f