### PR TITLE
Refactor OCI explorer overlay

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1265,6 +1265,9 @@ body.bg-hidden {
   flex: 1;
   min-width: 250px;
 }
+.retrorecon-root .dag-explorer-cols .right-col {
+  margin-left: 0.5em;
+}
 .retrorecon-root .bookmark-table {
   width: 100%;
   border-collapse: collapse;

--- a/static/dag_explorer.js
+++ b/static/dag_explorer.js
@@ -194,7 +194,7 @@ function initDagExplorer(){
   }
 
   async function fetchManifest(){
-    const img = imgInput.value.trim();
+    const img = imgInput ? imgInput.value.trim() : '';
     if(!img) return;
     const resp = await fetch('/dag/image/' + encodeURIComponent(img));
     if(resp.ok){
@@ -206,21 +206,21 @@ function initDagExplorer(){
   }
 
   async function fetchTags(){
-    const img = imgInput.value.trim();
+    const img = imgInput ? imgInput.value.trim() : '';
     if(!img) return;
     const repo = img.split(':')[0];
     const resp = await fetch('/dag/repo/' + encodeURIComponent(repo));
     output.textContent = await resp.text();
   }
 
-  fetchBtn.addEventListener('click', fetchManifest);
-  tagsBtn.addEventListener('click', fetchTags);
+  if(fetchBtn) fetchBtn.addEventListener('click', fetchManifest);
+  if(tagsBtn) tagsBtn.addEventListener('click', fetchTags);
   manifestDiv.addEventListener('click', async ev => {
     const link = ev.target.closest('.layer-link');
     if(!link) return;
     ev.preventDefault();
     const digest = link.dataset.digest;
-    const img = imgInput.value.trim();
+    const img = imgInput ? imgInput.value.trim() : '';
     if(!digest || !img) return;
     const resp = await fetch(`/dag/layer/${encodeURIComponent(img)}@${encodeURIComponent(digest)}`);
     if(resp.ok){

--- a/templates/dag_explorer.html
+++ b/templates/dag_explorer.html
@@ -9,8 +9,6 @@
     </h1>
     <button type="button" class="btn overlay-close-btn" id="dag-close-btn">Close</button>
   </div>
-  <p>This beautiful tool allows you to <em>explore</em> the contents of a registry interactively.</p>
-  <p>You can even drill down into layers to explore an image's filesystem.</p>
   <div class="dag-explorer-cols">
     <div class="col left-col">
       <p>Enter a <strong>public</strong> image, e.g. <tt>"ubuntu:latest"</tt>:</p>
@@ -36,7 +34,7 @@
     </div>
     <div class="col right-col">
       <h4>Interesting examples</h4>
-      <ul>
+      <ul class="ml-05">
         <li><a href="/image/cgr.dev/chainguard/static:latest-glibc">cgr.dev/chainguard/static:latest-glibc</a></li>
         <li><a href="/image/gcr.io/distroless/static">gcr.io/distroless/static:latest</a></li>
         <li><a href="/repo/ghcr.io/homebrew/core/crane">ghcr.io/homebrew/core/crane</a></li>
@@ -50,11 +48,6 @@
     </div>
   </div>
 
-  <div class="mb-05">
-    <input type="text" id="dag-image" class="form-input mr-05 w-20em" placeholder="user/repo:tag" />
-    <button type="button" class="btn" id="dag-fetch-btn">Fetch Manifest</button>
-    <button type="button" class="btn" id="dag-tags-btn">List Tags</button>
-  </div>
   <div id="dag-manifest" class="mb-05"></div>
   <div id="dag-path" class="mb-05"></div>
   <div id="dag-output" class="mt-05"></div>


### PR DESCRIPTION
## Summary
- remove unused OCI explorer input/button elements
- tidy up explanatory text
- slightly indent interesting examples
- guard JS when optional elements are removed

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2ebdafc883328778f49d2a40c287