### PR TITLE
Add manifest table view

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,13 +55,14 @@ from retrorecon import (
     subdomain_utils,
     status as status_mod,
 )
-from retrorecon.filters import manifest_links, oci_obj
+from retrorecon.filters import manifest_links, oci_obj, manifest_table
 
 app = Flask(__name__)
 sys.modules.setdefault('app', sys.modules[__name__])
 app.config.from_object(Config)
 app.add_template_filter(manifest_links, name="manifest_links")
 app.add_template_filter(oci_obj, name="oci_obj")
+app.add_template_filter(manifest_table, name="manifest_table")
 
 
 @app.route('/favicon.ico', endpoint='core.favicon_ico')

--- a/layerslayer/client.py
+++ b/layerslayer/client.py
@@ -50,9 +50,10 @@ class DockerRegistryClient:
         token = self.token_cache.get(f"{user}/{repo}")
         if not token:
             token = await self._fetch_token(user, repo)
-        headers = {
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-        }
+        from .utils import guess_manifest_media_type
+
+        accept = guess_manifest_media_type(user)
+        headers = {"Accept": accept}
         if token:
             headers["Authorization"] = f"Bearer {token}"
         return headers

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -17,8 +17,10 @@
   <div class="tab content2">
   <pre class="manifest-json">{{ data.descriptor|tojson(indent=2) }}</pre>
   </div>
-
-  <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
-  <pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest, link_size=False) }}</pre>
 </details>
+<h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
+<pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest, link_size=False) }}</pre>
+<div class="mt-05">
+  {{ data.manifest|manifest_table(image) }}
+</div>
 {% endblock %}

--- a/tests/test_layerslayer_lib.py
+++ b/tests/test_layerslayer_lib.py
@@ -1,4 +1,9 @@
-from layerslayer import parse_image_ref, registry_base_url, human_readable_size
+from layerslayer import (
+    parse_image_ref,
+    registry_base_url,
+    human_readable_size,
+)
+from layerslayer.utils import guess_manifest_media_type
 
 
 def test_parse_image_ref():
@@ -30,4 +35,23 @@ def test_registry_base_url_custom():
     assert (
         registry_base_url("library", "ubuntu")
         == "https://registry-1.docker.io/v2/library/ubuntu"
+    )
+
+
+def test_guess_manifest_media_type():
+    assert (
+        guess_manifest_media_type("ubuntu")
+        == "application/vnd.docker.distribution.manifest.v2+json"
+    )
+    assert (
+        guess_manifest_media_type("gcr.io/project/app")
+        == "application/vnd.oci.image.manifest.v1+json"
+    )
+    assert (
+        guess_manifest_media_type("public.ecr.aws/repo")
+        == "application/vnd.docker.distribution.manifest.v2+json"
+    )
+    assert (
+        guess_manifest_media_type("registry.k8s.io/my/app")
+        == "application/vnd.oci.image.manifest.v1+json"
     )

--- a/tests/test_manifest_table.py
+++ b/tests/test_manifest_table.py
@@ -1,0 +1,25 @@
+import app
+from retrorecon.filters import manifest_table
+
+
+def test_manifest_table_basic():
+    manifest = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "size": 10,
+            "digest": "sha256:c1"
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "size": 100,
+                "digest": "sha256:l1"
+            }
+        ]
+    }
+    html = manifest_table(manifest, "user/repo:tag")
+    assert "sha256:l1" in html
+    assert "/download_layer?image=user/repo:tag&digest=sha256:l1" in html
+    assert "<table" in html


### PR DESCRIPTION
## Summary
- show OCI image manifest entries in configurable tables
- add `manifest_table` Jinja filter
- register the filter
- implement registry-aware media type detection
- test helper utilities for registry handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a3445f5548332831cb1cc1eeb37ef