### PR TITLE
Improve OCI manifest tables

### DIFF
--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -232,15 +232,20 @@ def manifest_table(manifest: Dict[str, Any], image: str) -> Markup:
     layers = manifest.get("layers")
     if layers:
         parts.append(
-            '<table class="fs-table"><thead><tr><th>#</th><th>Size</th><th>Digest</th><th>Media Type</th></tr></thead><tbody>'
+            '<table class="fs-table"><thead><tr><th>#</th><th>Size</th><th>Digest</th><th>Media Type</th><th class="text-center">💾</th><th class="text-center">🔍</th></tr></thead><tbody>'
         )
         for idx, layer in enumerate(layers, 1):
             d = str(layer.get("digest", ""))
             size = layer.get("size", 0)
             mt = str(layer.get("mediaType", ""))
             size_hr = human_readable_size(int(size) if str(size).isdigit() else 0)
+            download_link = f'/download_layer?image={image}&digest={d}'
+            browse_link = f'/fs/{repo_full}@{d}'
             parts.append(
-                f'<tr><td>{idx}</td><td>{size} <span class="text-muted">({size_hr})</span></td><td>{_link_digest(d)}</td><td>{escape(mt)}</td></tr>'
+                f'<tr><td>{idx}</td><td>{size} <span class="text-muted">({size_hr})</span></td>'
+                f'<td>{_link_digest(d, False)}</td><td>{escape(mt)}</td>'
+                f'<td class="text-center"><a href="{download_link}" title="Download">💾</a></td>'
+                f'<td class="text-center"><a href="{browse_link}" title="Browse">🔍</a></td></tr>'
             )
         parts.append("</tbody></table>")
     elif manifest.get("manifests"):

--- a/templates/oci_image.html
+++ b/templates/oci_image.html
@@ -19,7 +19,10 @@
   </div>
 </details>
 <h4><span class="noselect">$ </span><a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md">crane</a> <a class="mt" href="https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_manifest.md">manifest</a> {{ display_image or image }} | jq .</h4>
-<pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest, link_size=False) }}</pre>
+<details class="meta-details">
+  <summary>JSON</summary>
+  <pre class="manifest-json">{{ data.manifest|manifest_links(image, data.descriptor.digest, link_size=False) }}</pre>
+</details>
 <div class="mt-05">
   {{ data.manifest|manifest_table(image) }}
 </div>

--- a/templates/oci_repo.html
+++ b/templates/oci_repo.html
@@ -5,6 +5,8 @@
 <h2>{{ repo }}</h2>
 <h4><span class="noselect noselect--tight">$ </span>curl -sL "{{ data_url }}" | jq .</h4>
 
+<details class="meta-details">
+<summary>JSON</summary>
 <div>{
 <div class="indent">
   <div>"name": &#34;{{ data.name }}&#34;,</div>
@@ -25,4 +27,5 @@
   <div>"manifest": {{ data.manifest|oci_obj(repo) }}</div>
 </div>
 }</div>
+</details>
 {% endblock %}

--- a/tests/test_manifest_table.py
+++ b/tests/test_manifest_table.py
@@ -22,6 +22,7 @@ def test_manifest_table_basic():
     html = manifest_table(manifest, "user/repo:tag")
     assert "sha256:l1" in html
     assert "/download_layer?image=user/repo:tag&digest=sha256:l1" in html
+    assert "/fs/user/repo@sha256:l1" in html
     assert "10.0 B" in html
     assert "100.0 B" in html
     assert "<table" in html


### PR DESCRIPTION
## Summary
- hide manifest JSON under collapsible details in oci_image.html and oci_repo.html
- add download and browse buttons to the manifest_table filter
- update tests for new fs links

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3ddc4fe4833287f30d2a4395bbaf