### PR TITLE
Listening address override

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ python retrorecon.py --domain example.com
 
 Use `--help` to view available options for filtering, exporting, and source map analysis.
 
+## 🖥️ Running the Web Interface
+
+Launch the Flask UI with the provided scripts. The optional `-l` flag sets the listening address (default `127.0.0.1`).
+
+```bash
+./launch_app.sh -l 0.0.0.0   # Linux/macOS
+.\launch_app.bat -l 0.0.0.0  # Windows
+```
+
+These scripts export `RETRORECON_LISTEN` so `app.py` binds accordingly.
+**Never expose the app publicly without proper hardening.**
+
 ---
 
 ## 🕶️ Philosophy

--- a/app.py
+++ b/app.py
@@ -833,4 +833,6 @@ if __name__ == '__main__':
             create_new_db(os.path.splitext(os.path.basename(env_db))[0])
         else:
             ensure_schema()
-    app.run(debug=True)
+    host = os.environ.get('RETRORECON_LISTEN', '127.0.0.1')
+    port = int(os.environ.get('RETRORECON_PORT', '5000'))
+    app.run(debug=True, host=host, port=port)

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -1,6 +1,11 @@
 @echo off
 cd /d "%~dp0"
 
+set LISTEN_ADDR=127.0.0.1
+if "%1"=="-l" (
+    set LISTEN_ADDR=%2
+)
+
 git pull
 
 if not exist venv (
@@ -11,5 +16,6 @@ venv\Scripts\python -m pip install --upgrade pip
 venv\Scripts\pip install -r requirements.txt
 
 set RETRORECON_LOG_LEVEL=DEBUG
+set RETRORECON_LISTEN=%LISTEN_ADDR%
 
 venv\Scripts\python app.py

--- a/launch_app.sh
+++ b/launch_app.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+git pull
+
+LISTEN_ADDR="127.0.0.1"
+while getopts "l:" opt; do
+  case $opt in
+    l)
+      LISTEN_ADDR="$OPTARG"
+      ;;
+  esac
+done
+
+if [ ! -d venv ]; then
+  python3 -m venv venv
+fi
+
+venv/bin/pip install --upgrade pip
+venv/bin/pip install -r requirements.txt
+
+export RETRORECON_LOG_LEVEL=DEBUG
+export RETRORECON_LISTEN="$LISTEN_ADDR"
+
+python_cmd="venv/bin/python"
+# On WSL, using win32 path may create issues; always use the venv python
+"$python_cmd" app.py


### PR DESCRIPTION
## Summary
- add `RETRORECON_LISTEN`/`RETRORECON_PORT` env vars in `app.py`
- update launch batch script to accept `-l` host argument
- add cross-platform `launch_app.sh` script
- document how to run the web interface in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad63e5da883329927ce8e3039b49e