### PR TITLE
Add Help menu with README and About overlays

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,6 +96,7 @@ app.teardown_appcontext(close_connection)
 ITEMS_PER_PAGE = 10  # default results per page
 ITEMS_PER_PAGE_OPTIONS = [5, 10, 15, 20, 25]
 TEXT_TOOLS_LIMIT = 64 * 1024  # 64 KB limit for text transformations
+APP_VERSION = '1.5.0'
 
 THEMES_DIR = os.path.join(app.root_path, 'static', 'themes')
 if os.path.isdir(THEMES_DIR):
@@ -354,6 +355,10 @@ def index() -> str:
         tool = 'subdomonster'
     elif request.path == '/tools/text_tools':
         tool = 'text'
+    elif request.path == '/tools/readme':
+        tool = 'readme'
+    elif request.path == '/tools/about':
+        tool = 'about'
 
     sort = request.args.get('sort', 'id')
     direction = request.args.get('dir', 'desc').lower()
@@ -476,7 +481,8 @@ def index() -> str:
         current_sort=sort,
         current_dir=direction,
         open_tool=tool,
-        select_all_matching=select_all_matching
+        select_all_matching=select_all_matching,
+        app_version=APP_VERSION
     )
 
 @app.route('/fetch_cdx', methods=['POST'])
@@ -804,6 +810,7 @@ from retrorecon.routes import (
     urls_bp,
     swagger_bp,
     overview_bp,
+    help_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -818,6 +825,7 @@ app.register_blueprint(dagdotdev_bp)
 app.register_blueprint(urls_bp)
 app.register_blueprint(swagger_bp)
 app.register_blueprint(overview_bp)
+app.register_blueprint(help_bp)
 
 
 @app.after_request

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ playwright
 pyelftools
 tldextract
 flask-swagger-ui
+markdown

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -11,5 +11,6 @@ from .dagdotdev import bp as dagdotdev_bp
 from .urls import bp as urls_bp
 from .swagger import bp as swagger_bp
 from .overview import bp as overview_bp
+from .help import bp as help_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'help_bp']

--- a/retrorecon/routes/help.py
+++ b/retrorecon/routes/help.py
@@ -1,0 +1,32 @@
+import os
+import app
+import markdown
+from flask import Blueprint, render_template
+
+bp = Blueprint('help', __name__)
+
+@bp.route('/help/readme', methods=['GET'])
+def help_readme():
+    path = os.path.join(app.app.root_path, 'README.md')
+    content = ''
+    if os.path.isfile(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            content = markdown.markdown(f.read())
+    return render_template('help_readme.html', content=content)
+
+@bp.route('/help/about', methods=['GET'])
+def help_about():
+    credits = [
+        'the folks referenced in the README',
+        'dagdotdev / original registry explorer project',
+        'the shupandhack Discord',
+    ]
+    return render_template('help_about.html', version=app.APP_VERSION, credits=credits)
+
+@bp.route('/tools/readme', methods=['GET'])
+def help_readme_full():
+    return app.index()
+
+@bp.route('/tools/about', methods=['GET'])
+def help_about_full():
+    return app.index()

--- a/static/base.css
+++ b/static/base.css
@@ -1309,3 +1309,32 @@ body.bg-hidden {
   right: 0.5em;
   float: none;
 }
+
+.retrorecon-root .help-overlay {
+  max-width: 95%;
+  margin: 0 auto;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.retrorecon-root .help-overlay::-webkit-scrollbar {
+  display: none;
+}
+
+.retrorecon-root .credits-scroll {
+  overflow: hidden;
+  height: 6em;
+  position: relative;
+}
+.retrorecon-root .credits-scroll ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  position: absolute;
+  width: 100%;
+  animation: scroll-up 10s linear infinite;
+}
+
+@keyframes scroll-up {
+  from { top: 100%; }
+  to { top: -100%; }
+}

--- a/static/help_about.js
+++ b/static/help_about.js
@@ -1,0 +1,16 @@
+function initHelpAbout(){
+  const overlay = document.getElementById('help-about-overlay');
+  if(!overlay) return;
+  const closeBtn = document.getElementById('help-about-close-btn');
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/about'){
+      history.pushState({}, '', '/');
+    }
+  });
+}
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initHelpAbout);
+}else{
+  initHelpAbout();
+}

--- a/static/help_readme.js
+++ b/static/help_readme.js
@@ -1,0 +1,20 @@
+function initHelpReadme(){
+  const overlay = document.getElementById('help-readme-overlay');
+  if(!overlay) return;
+  const closeBtn = document.getElementById('help-readme-close-btn');
+  const backBtn = document.getElementById('help-readme-back-btn');
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/readme'){
+      history.pushState({}, '', '/');
+    }
+  });
+  backBtn.addEventListener('click', () => {
+    overlay.scrollTo({top:0, behavior:'smooth'});
+  });
+}
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initHelpReadme);
+}else{
+  initHelpReadme();
+}

--- a/templates/help_about.html
+++ b/templates/help_about.html
@@ -1,0 +1,16 @@
+<!-- File: templates/help_about.html -->
+<div id="help-about-overlay" class="notes-overlay hidden help-overlay">
+  <div class="d-flex flex-between mb-4px">
+    <span>About RetroRecon</span>
+    <button type="button" class="btn" id="help-about-close-btn">Close</button>
+  </div>
+  <p><a href="https://github.com/thesavant42/retrorecon" target="_blank">Project on GitHub</a></p>
+  <p>Version {{ version }}</p>
+  <div class="credits-scroll">
+    <ul>
+      {% for c in credits %}
+      <li>{{ c }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>

--- a/templates/help_readme.html
+++ b/templates/help_readme.html
@@ -1,0 +1,8 @@
+<!-- File: templates/help_readme.html -->
+<div id="help-readme-overlay" class="notes-overlay hidden help-overlay">
+  <div class="d-flex flex-between mb-4px">
+    <button type="button" class="btn" id="help-readme-back-btn">Back</button>
+    <button type="button" class="btn" id="help-readme-close-btn">Close</button>
+  </div>
+  <div id="help-readme-content" class="help-content">{{ content|safe }}</div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -198,6 +198,13 @@
           <div class="menu-row"><a href="/swagger" class="menu-btn" id="swagger-ui-link" target="_blank">Swagger UI</a></div>
       </div>
     </div>
+    <div class="dropdown">
+      <button class="dropbtn" data-menu="help-menu">Help ▼</button>
+      <div class="dropdown-content" id="help-menu">
+          <div class="menu-row"><a href="#" class="menu-btn" id="help-readme-link">README</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="help-about-link">About</a></div>
+      </div>
+    </div>
   </div>
   <div class="navbar__title">
       <span class="cursor-pointer" id="db-display">[ {{ db_name }} ]</span>
@@ -342,7 +349,7 @@
     {{ render_pagination(page, total_pages, q, total_count, items_per_page, select_all_matching) }}
     <div class="footer">
       <a href="https://github.com/thesavant42/retrorecon" target="_blank" class="no-underline text-muted">
-        retrorecon - v1.5.0 by @savant42 &copy; 2025
+        retrorecon - v{{ app_version }} by @savant42 &copy; 2025
       </a>
     </div>
   </div>
@@ -1278,6 +1285,82 @@
 
       if(location.pathname === '/tools/dag_explorer' || openTool === 'dag'){
         showDagExplorer(true);
+      }
+
+      const helpReadmeLink = document.getElementById('help-readme-link');
+      let helpReadmeLoaded = false;
+      async function showHelpReadme(skipPush){
+        if(!helpReadmeLoaded){
+          const resp = await fetch('/help/readme');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/help_readme.js';
+          document.body.appendChild(script);
+          helpReadmeLoaded = true;
+        }
+        document.getElementById('help-readme-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'readme'}, '', '/tools/readme');
+        }
+      }
+      function hideHelpReadme(){
+        const ov = document.getElementById('help-readme-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+      if(helpReadmeLink){
+        helpReadmeLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showHelpReadme();
+        });
+      }
+
+      const helpAboutLink = document.getElementById('help-about-link');
+      let helpAboutLoaded = false;
+      async function showHelpAbout(skipPush){
+        if(!helpAboutLoaded){
+          const resp = await fetch('/help/about');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/help_about.js';
+          document.body.appendChild(script);
+          helpAboutLoaded = true;
+        }
+        document.getElementById('help-about-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'about'}, '', '/tools/about');
+        }
+      }
+      function hideHelpAbout(){
+        const ov = document.getElementById('help-about-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+      if(helpAboutLink){
+        helpAboutLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showHelpAbout();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/readme'){
+          showHelpReadme(true);
+        } else if(location.pathname === '/tools/about'){
+          showHelpAbout(true);
+        } else {
+          hideHelpReadme();
+          hideHelpAbout();
+        }
+      });
+
+      if(location.pathname === '/tools/readme' || openTool === 'readme'){
+        showHelpReadme(true);
+      }
+      if(location.pathname === '/tools/about' || openTool === 'about'){
+        showHelpAbout(true);
       }
 
     const themeSelect = document.getElementById('theme-select');

--- a/tests/test_help_pages.py
+++ b/tests/test_help_pages.py
@@ -1,0 +1,29 @@
+import app
+from pathlib import Path
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+    (tmp_path / "README.md").write_text("Demo")
+
+
+def test_help_readme_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/help/readme')
+        assert resp.status_code == 200
+        assert b'id="help-readme-overlay"' in resp.data
+
+
+def test_help_about_route(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/help/about')
+        assert resp.status_code == 200
+        assert b'id="help-about-overlay"' in resp.data


### PR DESCRIPTION
## Summary
- introduce new blueprint `help` with routes for README and About overlays
- add dropdown Help menu to the navbar
- create overlay templates and JavaScript for README and About
- expose app version constant and show it in footer
- extend base CSS for help overlay styles and scrolling credits
- add tests for the new help routes

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad97ac65c8332bd6b8e946a17390f