### PR TITLE
Implement CDX import queue

### DIFF
--- a/app.py
+++ b/app.py
@@ -542,8 +542,11 @@ def fetch_cdx() -> Response:
         )
         inserted += 1
 
-    flash(f"Fetched CDX for {domain}: inserted {inserted} new URLs.", "success")
+    message = f"Fetched CDX for {domain}: inserted {inserted} new URLs."
     status_mod.push_status('cdx_import_complete', str(inserted))
+    if request.form.get('ajax') == '1' or request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return jsonify({"inserted": inserted, "message": message})
+    flash(message, "success")
     return redirect(url_for('index'))
 
 def _background_import(file_content: bytes) -> None:


### PR DESCRIPTION
## Summary
- return JSON from `/fetch_cdx` when called via AJAX
- add async queue logic for the "Wayback Import" action in `subdomonster.js`
- sanitize domains and batch multiple selections for CDX import
- test AJAX CDX import

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_685ae281621483329bb133a94a6193cc