### PR TITLE
Add dynamic rendering utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ RetroRecon digs through the internet’s attic to find forgotten, buried, or qui
 | Suspicious Pattern Detection  | Scans downloaded files for API keys, JWTs, secrets, etc.                   |
 | Filtering & Grouping          | Smart filters by type (e.g., `.js`, `.env`, `.php`, `.map`, etc.)          |
 | HTML Report Output (WIP)      | Generate browsable summaries with tagged snapshots and visual comparisons  |
+| Dynamic Rendering API         | Programmatically render pages from schemas with managed assets             |
 | OCI Registry Table Explorer   | Browse container images as tables with direct download links |
 
 ---

--- a/app.py
+++ b/app.py
@@ -814,6 +814,7 @@ from retrorecon.routes import (
     swagger_bp,
     overview_bp,
     help_bp,
+    dynamic_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -829,6 +830,7 @@ app.register_blueprint(urls_bp)
 app.register_blueprint(swagger_bp)
 app.register_blueprint(overview_bp)
 app.register_blueprint(help_bp)
+app.register_blueprint(dynamic_bp)
 
 
 @app.after_request

--- a/reports/report.json
+++ b/reports/report.json
@@ -1,23 +1,27 @@
 {
   "coverage": {
     "button": {
-      "total": 69,
-      "styled": 68
+      "total": 71,
+      "styled": 70
     },
     "input": {
-      "total": 43,
-      "styled": 23
+      "total": 41,
+      "styled": 20
     },
     "select": {
       "total": 12,
       "styled": 12
     },
     "checkbox": {
-      "total": 7,
+      "total": 8,
       "styled": 5
     }
   },
   "unscoped_selectors": {
+    "static/base.css": [
+      "from",
+      "to"
+    ],
     "static/swagger-dark.css": [
       "a",
       "::-webkit-scrollbar-track-piece",

--- a/retrorecon/dynamic_render.py
+++ b/retrorecon/dynamic_render.py
@@ -1,0 +1,86 @@
+# Minimal dynamic rendering utilities
+from __future__ import annotations
+
+from typing import Dict, List
+from bs4 import BeautifulSoup
+
+
+class AssetRegistry:
+    """Registry for CSS and JS assets used during dynamic rendering."""
+
+    def __init__(self) -> None:
+        self._assets: List[Dict[str, object]] = []
+
+    def register(self, path: str, asset_type: str, order: int = 0) -> None:
+        if asset_type not in {"css", "js"}:
+            raise ValueError("asset_type must be 'css' or 'js'")
+        self._assets.append({"path": path, "type": asset_type, "order": order})
+        self._assets.sort(key=lambda a: a["order"])
+
+    def for_render(self) -> Dict[str, List[str]]:
+        css = [a["path"] for a in self._assets if a["type"] == "css"]
+        js = [a["path"] for a in self._assets if a["type"] == "js"]
+        return {"css": css, "js": js}
+
+
+class SchemaRegistry:
+    """Registry of content schemas with simple validation."""
+
+    def __init__(self) -> None:
+        self._schemas: Dict[str, Dict[str, object]] = {}
+
+    def register(self, name: str, schema: Dict[str, object]) -> None:
+        self._schemas[name] = schema
+
+    def get(self, name: str) -> Dict[str, object]:
+        return self._schemas[name]
+
+    def validate(self, name: str, data: Dict[str, object]) -> None:
+        schema = self._schemas.get(name)
+        if not schema:
+            raise KeyError(name)
+        for field in schema.get("required", []):
+            if field not in data:
+                raise ValueError(f"Missing required field: {field}")
+
+
+class HTMLGenerator:
+    """Generate HTML content from a simple schema."""
+
+    def __init__(self, asset_registry: AssetRegistry | None = None) -> None:
+        self.asset_registry = asset_registry or AssetRegistry()
+
+    def render(self, schema: Dict[str, object], data: Dict[str, object]) -> str:
+        soup = BeautifulSoup("", "html.parser")
+        root = soup.new_tag("div", **{"class": "retrorecon-root"})
+        soup.append(root)
+
+        for node in schema.get("content", []):
+            tag = node.get("tag")
+            if not tag:
+                continue
+            el = soup.new_tag(tag)
+            text_key = node.get("text")
+            if text_key:
+                el.string = str(data.get(text_key, ""))
+            root.append(el)
+
+        assets = self.asset_registry.for_render()
+        for css in assets["css"]:
+            link = soup.new_tag("link", rel="stylesheet", href=css)
+            soup.head.insert(0, link) if soup.head else soup.insert(0, link)
+        for js in assets["js"]:
+            script = soup.new_tag("script", src=js)
+            soup.append(script)
+        return str(soup)
+
+
+def render_from_payload(payload: Dict[str, object], registry: SchemaRegistry, generator: HTMLGenerator) -> str:
+    name = payload.get("schema")
+    data = payload.get("data", {})
+    if not isinstance(name, str):
+        raise ValueError("schema field required")
+    schema = registry.get(name)
+    registry.validate(name, data)
+    return generator.render(schema, data)
+

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -12,5 +12,6 @@ from .urls import bp as urls_bp
 from .swagger import bp as swagger_bp
 from .overview import bp as overview_bp
 from .help import bp as help_bp
+from .dynamic import bp as dynamic_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'help_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'help_bp', 'dynamic_bp']

--- a/retrorecon/routes/dynamic.py
+++ b/retrorecon/routes/dynamic.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, request, jsonify
+from ..dynamic_render import AssetRegistry, SchemaRegistry, HTMLGenerator, render_from_payload
+
+bp = Blueprint('dynamic', __name__)
+
+asset_registry = AssetRegistry()
+schema_registry = SchemaRegistry()
+html_generator = HTMLGenerator(asset_registry)
+
+
+@bp.route('/api/render', methods=['POST'])
+def api_render():
+    """Render HTML from a JSON payload."""
+    if not request.is_json:
+        return jsonify({'error': 'invalid_payload'}), 400
+    payload = request.get_json()
+    try:
+        html = render_from_payload(payload, schema_registry, html_generator)
+    except (KeyError, ValueError) as exc:
+        return jsonify({'error': str(exc)}), 400
+    return html
+

--- a/tests/test_dynamic_rendering.py
+++ b/tests/test_dynamic_rendering.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_api_render(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        payload = {
+            "schema": "simple",
+            "data": {"title": "Demo"}
+        }
+        # register schema manually
+        from retrorecon.routes.dynamic import schema_registry
+        schema_registry.register("simple", {"required": ["title"], "content": [{"tag": "h1", "text": "title"}]})
+        resp = client.post("/api/render", json=payload)
+        assert resp.status_code == 200
+        assert "<h1>Demo</h1>" in resp.get_data(as_text=True)
+


### PR DESCRIPTION
## Summary
- implement dynamic HTML generator and asset registry
- add API endpoint `/api/render`
- register new dynamic blueprint
- document new Dynamic Rendering API feature
- test dynamic rendering endpoint

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_685aea4da5988332a0907628bf2225c8