### PR TITLE
Add demo panel and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Launch the Flask UI with the provided scripts. The optional `-l` flag sets the l
 These scripts export `RETRORECON_LISTEN` so `app.py` binds accordingly.
 **Never expose the app publicly without proper hardening.**
 
+For a quick walkthrough of the common workflow see
+[docs/new_user_guide.md](docs/new_user_guide.md).
+
 ---
 
 ## 🕶️ Philosophy

--- a/app.py
+++ b/app.py
@@ -359,6 +359,8 @@ def index() -> str:
         tool = 'readme'
     elif request.path == '/tools/about':
         tool = 'about'
+    elif request.path == '/tools/demo':
+        tool = 'demo'
 
     sort = request.args.get('sort', 'id')
     direction = request.args.get('dir', 'desc').lower()

--- a/docs/new_user_guide.md
+++ b/docs/new_user_guide.md
@@ -1,0 +1,25 @@
+# Getting Started with RetroRecon
+
+This short guide walks through the typical workflow of exploring archived URLs.
+
+1. **Fetch CDX data**
+   ```bash
+   curl -X POST http://localhost:5000/fetch_cdx -d "domain=example.com"
+   ```
+   This pulls Wayback Machine records into the local SQLite database.
+
+2. **Browse results**
+   Visit `http://localhost:5000/` in your browser. Use the search box to filter
+   URLs. Click a row to open the archived page.
+
+3. **Tag or remove URLs**
+   Select checkboxes and choose an action from the bulk menu to add tags or
+   delete entries.
+
+4. **Use built‑in tools**
+   Open the **Tools** menu for helpers like Subdomonster or the Screenshotter.
+   Each loads dynamically without leaving the page.
+
+5. **Try the Demo panel**
+   Under **Tools → Demo** you can preview modules in a single window. Choose a
+   module from the dropdown to load it in place and click **Close** to return.

--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -248,6 +248,16 @@ def screenshotter_full_page():
     return app.index()
 
 
+@bp.route('/demo', methods=['GET'])
+def demo_page():
+    return render_template('demo.html')
+
+
+@bp.route('/tools/demo', methods=['GET'])
+def demo_full_page():
+    return app.index()
+
+
 @bp.route('/tools/screenshot', methods=['POST'])
 def screenshot_route():
     if not app._db_loaded():

--- a/static/demo.js
+++ b/static/demo.js
@@ -1,0 +1,48 @@
+/* File: static/demo.js */
+function initDemo(){
+  const overlay = document.getElementById('demo-overlay');
+  if(!overlay) return;
+  const select = document.getElementById('demo-select');
+  const view = document.getElementById('demo-view');
+  const closeBtn = document.getElementById('demo-close-btn');
+
+  async function loadContent(name){
+    view.innerHTML = '';
+    if(!name) return;
+    let url = '';
+    if(name === 'index'){ url = '/'; }
+    else if(name === 'subdomonster'){ url = '/subdomonster'; }
+    else if(name === 'screenshotter'){ url = '/screenshotter'; }
+    else if(name === 'about'){ url = '/help/about'; }
+    if(!url) return;
+    const resp = await fetch(url);
+    const html = await resp.text();
+    view.innerHTML = html;
+    if(name === 'subdomonster'){
+      const script = document.createElement('script');
+      script.src = '/static/subdomonster.js';
+      document.body.appendChild(script);
+    }else if(name === 'screenshotter'){
+      const script = document.createElement('script');
+      script.src = '/static/screenshotter.js';
+      document.body.appendChild(script);
+    }else if(name === 'about'){
+      const script = document.createElement('script');
+      script.src = '/static/help_about.js';
+      document.body.appendChild(script);
+    }
+  }
+
+  select.addEventListener('change', () => loadContent(select.value));
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    if(location.pathname === '/tools/demo'){
+      history.pushState({}, '', '/');
+    }
+  });
+}
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initDemo);
+}else{
+  initDemo();
+}

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -217,6 +217,18 @@ paths:
       responses:
         '200':
           description: Successful response
+  /demo:
+    get:
+      summary: GET /demo
+      responses:
+        '200':
+          description: Successful response
+  /tools/demo:
+    get:
+      summary: GET /tools/demo
+      responses:
+        '200':
+          description: Successful response
   /tools/screenshot:
     post:
       summary: POST /tools/screenshot

--- a/static/tools.css
+++ b/static/tools.css
@@ -132,3 +132,6 @@
 .retrorecon-root #subdomonster-table th {
   overflow: visible;
 }
+
+.retrorecon-root #demo-view { flex: 1 1 auto; overflow-y: auto; }
+

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -1,0 +1,14 @@
+<!-- File: templates/demo.html -->
+<div id="demo-overlay" class="notes-overlay hidden">
+  <div class="d-flex flex-between mb-05">
+    <select id="demo-select" class="form-select mr-05">
+      <option value="">Demo…</option>
+      <option value="index">index</option>
+      <option value="subdomonster">subdomonster</option>
+      <option value="screenshotter">screenshotter</option>
+      <option value="about">about</option>
+    </select>
+    <button type="button" class="btn" id="demo-close-btn">Close</button>
+  </div>
+  <div id="demo-view" class="demo-view"></div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -194,6 +194,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="jwt-tools-link">JWT Tools</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">ScreenShotter</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="demo-link">Demo</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="dag-explorer-link">OCI Explorer</a></div>
           <div class="menu-row"><a href="/swagger" class="menu-btn" id="swagger-ui-link" target="_blank">Swagger UI</a></div>
       </div>
@@ -1194,6 +1195,50 @@
 
       if(location.pathname === '/tools/screenshotter' || openTool === 'screenshot'){
         showScreenshot(true);
+      }
+
+      const demoLink = document.getElementById('demo-link');
+      let demoLoaded = false;
+
+      async function showDemo(skipPush){
+        if(!demoLoaded){
+          const resp = await fetch('/demo');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/demo.js';
+          document.body.appendChild(script);
+          demoLoaded = true;
+        }
+        document.getElementById('demo-overlay').classList.remove('hidden');
+        if(!skipPush){
+          history.pushState({tool:'demo'}, '', '/tools/demo');
+        }
+      }
+
+      function hideDemo(){
+        const ov = document.getElementById('demo-overlay');
+        if(ov) ov.classList.add('hidden');
+      }
+
+      if(demoLink){
+        demoLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showDemo();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/demo'){
+          showDemo(true);
+        } else {
+          hideDemo();
+        }
+      });
+
+      if(location.pathname === '/tools/demo' || openTool === 'demo'){
+        showDemo(true);
       }
 
       const registryLink = document.getElementById('registry-viewer-link');

--- a/tests/postman/retrorecon.postman.json
+++ b/tests/postman/retrorecon.postman.json
@@ -541,6 +541,39 @@
       }
     },
     {
+      "name": "GET /demo",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/demo",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "demo"
+          ]
+        }
+      }
+    },
+    {
+      "name": "GET /tools/demo",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/tools/demo",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "tools",
+            "demo"
+          ]
+        }
+      }
+    },
+    {
       "name": "POST /tools/screenshot",
       "request": {
         "method": "POST",


### PR DESCRIPTION
## Summary
- add minimal new user guide
- link doc from README
- expose new `/demo` route with dropdown loading
- support Demo overlay in index page
- register endpoints in OpenAPI & Postman collection

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aefa90bf8833289bff7046a058651