### PR TITLE
Implement dynamic demo patterns

### DIFF
--- a/reports/report.json
+++ b/reports/report.json
@@ -1,16 +1,16 @@
 {
   "coverage": {
     "button": {
-      "total": 71,
-      "styled": 70
+      "total": 72,
+      "styled": 71
     },
     "input": {
       "total": 41,
       "styled": 20
     },
     "select": {
-      "total": 12,
-      "styled": 12
+      "total": 13,
+      "styled": 13
     },
     "checkbox": {
       "total": 8,
@@ -18,10 +18,6 @@
     }
   },
   "unscoped_selectors": {
-    "static/base.css": [
-      "from",
-      "to"
-    ],
     "static/swagger-dark.css": [
       "a",
       "::-webkit-scrollbar-track-piece",
@@ -338,6 +334,10 @@
       "::-webkit-scrollbar-button:vertical:end:increment",
       "::-webkit-scrollbar-button:horizontal:end:increment",
       "::-webkit-scrollbar-button:horizontal:start:decrement"
+    ],
+    "static/base.css": [
+      "from",
+      "to"
     ]
   }
 }

--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -1,0 +1,57 @@
+# Dynamic schema registration for demo pages
+from __future__ import annotations
+
+from flask import render_template
+import app
+from .dynamic_render import SchemaRegistry
+
+
+def register_demo_schemas(registry: SchemaRegistry) -> None:
+    """Register demo page schemas."""
+
+    registry.register(
+        "static_html",
+        {
+            "required": ["html"],
+            "content": [
+                {"html_field": "html"}
+            ],
+        },
+    )
+
+    def _index_html() -> str:
+        return app.index()
+
+    registry.register(
+        "demo_index",
+        {"callable": _index_html},
+    )
+
+    def _subdom_html() -> str:
+        return render_template("subdomonster.html", initial_data=[])
+
+    registry.register(
+        "demo_subdomonster",
+        {"callable": _subdom_html},
+    )
+
+    def _shot_html() -> str:
+        return render_template("screenshotter.html")
+
+    registry.register(
+        "demo_screenshotter",
+        {"callable": _shot_html},
+    )
+
+    def _about_html() -> str:
+        credits = [
+            "the folks referenced in the README",
+            "dagdotdev / original registry explorer project",
+            "the shupandhack Discord",
+        ]
+        return render_template("help_about.html", version=app.APP_VERSION, credits=credits)
+
+    registry.register(
+        "demo_about",
+        {"callable": _about_html},
+    )

--- a/retrorecon/routes/dynamic.py
+++ b/retrorecon/routes/dynamic.py
@@ -1,11 +1,14 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, render_template
 from ..dynamic_render import AssetRegistry, SchemaRegistry, HTMLGenerator, render_from_payload
+from ..dynamic_schemas import register_demo_schemas
+import app
 
-bp = Blueprint('dynamic', __name__)
+bp = Blueprint('dynamic', __name__, url_prefix='/dynamic')
 
 asset_registry = AssetRegistry()
 schema_registry = SchemaRegistry()
 html_generator = HTMLGenerator(asset_registry)
+register_demo_schemas(schema_registry)
 
 
 @bp.route('/api/render', methods=['POST'])
@@ -19,4 +22,30 @@ def api_render():
     except (KeyError, ValueError) as exc:
         return jsonify({'error': str(exc)}), 400
     return html
+
+
+@bp.route('/demo/<name>', methods=['GET'])
+def demo_dynamic(name: str):
+    """Return dynamic HTML for demo pages."""
+    if name == 'index':
+        html = app.index()
+    elif name == 'subdomonster':
+        html = render_template('subdomonster.html', initial_data=[])
+    elif name == 'screenshotter':
+        html = render_template('screenshotter.html')
+    elif name == 'about':
+        credits = [
+            'the folks referenced in the README',
+            'dagdotdev / original registry explorer project',
+            'the shupandhack Discord',
+        ]
+        html = render_template('help_about.html', version=app.APP_VERSION, credits=credits)
+    else:
+        return ('', 404)
+
+    payload = {
+        'schema': 'static_html',
+        'data': {'html': html},
+    }
+    return render_from_payload(payload, schema_registry, html_generator)
 

--- a/static/demo.js
+++ b/static/demo.js
@@ -10,10 +10,10 @@ function initDemo(){
     view.innerHTML = '';
     if(!name) return;
     let url = '';
-    if(name === 'index'){ url = '/'; }
-    else if(name === 'subdomonster'){ url = '/subdomonster'; }
-    else if(name === 'screenshotter'){ url = '/screenshotter'; }
-    else if(name === 'about'){ url = '/help/about'; }
+    if(name === 'index'){ url = '/dynamic/demo/index'; }
+    else if(name === 'subdomonster'){ url = '/dynamic/demo/subdomonster'; }
+    else if(name === 'screenshotter'){ url = '/dynamic/demo/screenshotter'; }
+    else if(name === 'about'){ url = '/dynamic/demo/about'; }
     if(!url) return;
     const resp = await fetch(url);
     const html = await resp.text();

--- a/tests/test_dynamic_rendering.py
+++ b/tests/test_dynamic_rendering.py
@@ -25,7 +25,7 @@ def test_api_render(tmp_path, monkeypatch):
         # register schema manually
         from retrorecon.routes.dynamic import schema_registry
         schema_registry.register("simple", {"required": ["title"], "content": [{"tag": "h1", "text": "title"}]})
-        resp = client.post("/api/render", json=payload)
+        resp = client.post("/dynamic/api/render", json=payload)
         assert resp.status_code == 200
         assert "<h1>Demo</h1>" in resp.get_data(as_text=True)
 


### PR DESCRIPTION
## Summary
- enhance HTMLGenerator to render nested nodes and HTML fields
- add demo schemas registry for dynamic templates
- expose `/dynamic/demo/<name>` route for rendering templates via the dynamic API
- update demo JS to fetch dynamic HTML
- fix dynamic route prefix for API calls
- update CSS audit report

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_685af3ea46448332b32ed6405abac013