### PR TITLE
Implement asset registry with DB storage

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -70,6 +70,14 @@ CREATE TABLE IF NOT EXISTS sitezips (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS assets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    path TEXT NOT NULL,
+    asset_type TEXT NOT NULL,
+    content_type_affinity TEXT DEFAULT '',
+    load_order INTEGER DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS domains (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     root_domain TEXT NOT NULL,
@@ -84,3 +92,4 @@ CREATE TABLE IF NOT EXISTS domains (
 CREATE INDEX IF NOT EXISTS idx_urls_domain ON urls(domain);
 CREATE INDEX IF NOT EXISTS idx_domains_root ON domains(root_domain);
 CREATE INDEX IF NOT EXISTS idx_domains_subdomain ON domains(subdomain);
+CREATE INDEX IF NOT EXISTS idx_assets_type ON assets(asset_type);

--- a/retrorecon/asset_utils.py
+++ b/retrorecon/asset_utils.py
@@ -1,0 +1,37 @@
+import logging
+from typing import Any, Dict, List
+
+from database import execute_db, query_db
+
+logger = logging.getLogger(__name__)
+
+
+def add_asset(path: str, asset_type: str, load_order: int = 0, affinity: str = "") -> int:
+    """Insert an asset record and return its row id."""
+    return execute_db(
+        "INSERT INTO assets (path, asset_type, content_type_affinity, load_order) VALUES (?, ?, ?, ?)",
+        [path, asset_type, affinity, load_order],
+    )
+
+
+def list_assets() -> List[Dict[str, Any]]:
+    """Return all asset records ordered by ``load_order``."""
+    rows = query_db(
+        "SELECT path, asset_type, content_type_affinity, load_order FROM assets ORDER BY load_order"
+    )
+    result: List[Dict[str, Any]] = []
+    for r in rows:
+        result.append(
+            {
+                "path": r["path"],
+                "asset_type": r["asset_type"],
+                "affinity": r["content_type_affinity"],
+                "load_order": r["load_order"],
+            }
+        )
+    return result
+
+
+def delete_asset(path: str) -> None:
+    """Remove an asset by path."""
+    execute_db("DELETE FROM assets WHERE path = ?", [path])

--- a/tests/test_asset_management.py
+++ b/tests/test_asset_management.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    (tmp_path / "db").mkdir()
+    (tmp_path / "data").mkdir()
+    orig = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(app.app, "template_folder", str(orig / "templates"))
+    (tmp_path / "db" / "schema.sql").write_text((orig / "db" / "schema.sql").read_text())
+
+
+def test_asset_injection(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.create_new_db("assets")
+        from retrorecon import asset_utils
+        asset_utils.add_asset("/foo.css", "css", 1)
+        asset_utils.add_asset("/bar.js", "js", 2)
+    with app.app.test_client() as client:
+        payload = {"schema": "simple", "data": {"title": "Demo"}}
+        from retrorecon.routes.dynamic import schema_registry, asset_registry
+        schema_registry.register("simple", {"required": ["title"], "content": [{"tag": "h1", "text": "title"}]})
+        asset_registry.loaded = False
+        resp = client.post("/dynamic/api/render", json=payload)
+        html = resp.get_data(as_text=True)
+        assert resp.status_code == 200
+        assert '/foo.css' in html
+        assert '<script src="/bar.js"' in html
+


### PR DESCRIPTION
## Summary
- add new SQLite table for assets with metadata fields
- add helper `asset_utils` for DB CRUD
- persist assets in AssetRegistry and load from DB on requests
- test asset injection through dynamic rendering

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afdd219f08332b9e6de3b90e74ea9