### PR TITLE
Refactor dynamic routes

### DIFF
--- a/retrorecon/routes/help.py
+++ b/retrorecon/routes/help.py
@@ -1,7 +1,9 @@
 import os
 import app
 import markdown
-from flask import Blueprint, render_template
+from flask import Blueprint, request
+from markupsafe import escape
+from .dynamic import dynamic_template, render_from_payload, schema_registry, html_generator
 
 bp = Blueprint('help', __name__)
 
@@ -12,7 +14,7 @@ def help_readme():
     if os.path.isfile(path):
         with open(path, 'r', encoding='utf-8') as f:
             content = markdown.markdown(f.read())
-    return render_template('help_readme.html', content=content)
+    return dynamic_template('help_readme.html', content=content)
 
 @bp.route('/help/about', methods=['GET'])
 def help_about():
@@ -21,7 +23,18 @@ def help_about():
         'dagdotdev / original registry explorer project',
         'the shupandhack Discord',
     ]
-    return render_template('help_about.html', version=app.APP_VERSION, credits=credits)
+    if request.args.get('legacy') == '1':
+        return dynamic_template('help_about.html', version=app.APP_VERSION, credits=credits, use_legacy=True)
+    credits_html = '<ul>' + ''.join(f'<li>{escape(c)}</li>' for c in credits) + '</ul>'
+    payload = {
+        'schema': 'help_about_page',
+        'data': {
+            'title': 'About RetroRecon',
+            'version': app.APP_VERSION,
+            'credits_html': credits_html,
+        },
+    }
+    return render_from_payload(payload, schema_registry, html_generator)
 
 @bp.route('/tools/readme', methods=['GET'])
 def help_readme_full():

--- a/retrorecon/routes/overview.py
+++ b/retrorecon/routes/overview.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 import os
-from flask import Blueprint, render_template, jsonify
+from flask import Blueprint, jsonify
+from .dynamic import dynamic_template
 import app
 
 bp = Blueprint('overview', __name__)
@@ -51,7 +52,7 @@ def overview_page():
         'counts': _collect_counts(),
         'domains': _collect_domains(),
     }
-    return render_template('overview.html', **data)
+    return dynamic_template('overview.html', **data)
 
 
 @bp.route('/overview.json', methods=['GET'])

--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -19,12 +19,13 @@ from flask import (
     send_file,
     current_app,
 )
+from .dynamic import dynamic_template, render_from_payload, schema_registry, html_generator
 
 bp = Blueprint('tools', __name__)
 
 @bp.route('/text_tools', methods=['GET'])
 def text_tools_page():
-    return render_template('text_tools.html')
+    return dynamic_template('text_tools.html')
 
 
 @bp.route('/tools/text_tools', methods=['GET'])
@@ -85,7 +86,7 @@ def url_encode_route():
 
 @bp.route('/jwt_tools', methods=['GET'])
 def jwt_tools_page():
-    return render_template('jwt_tools.html')
+    return dynamic_template('jwt_tools.html')
 
 
 @bp.route('/tools/jwt', methods=['GET'])
@@ -240,7 +241,10 @@ def export_jwt_cookies_route():
 
 @bp.route('/screenshotter', methods=['GET'])
 def screenshotter_page():
-    return render_template('screenshotter.html')
+    if request.args.get('legacy') == '1':
+        return dynamic_template('screenshotter.html', use_legacy=True)
+    payload = {'schema': 'screenshotter_page', 'data': {}}
+    return render_from_payload(payload, schema_registry, html_generator)
 
 
 @bp.route('/tools/screenshotter', methods=['GET'])
@@ -250,7 +254,7 @@ def screenshotter_full_page():
 
 @bp.route('/demo', methods=['GET'])
 def demo_page():
-    return render_template('demo.html')
+    return dynamic_template('demo.html')
 
 
 @bp.route('/tools/demo', methods=['GET'])
@@ -316,7 +320,7 @@ def delete_screenshots_route():
 
 @bp.route('/site2zip', methods=['GET'])
 def site2zip_page():
-    return render_template('site2zip.html')
+    return dynamic_template('site2zip.html')
 
 
 @bp.route('/tools/site2zip', methods=['GET'])
@@ -325,7 +329,7 @@ def site2zip_full_page():
 
 @bp.route('/layerpeek', methods=['GET'])
 def layerpeek_page():
-    return render_template('layerslayer.html')
+    return dynamic_template('layerslayer.html')
 
 @bp.route('/tools/layerpeek', methods=['GET'])
 def layerpeek_full_page():


### PR DESCRIPTION
## Summary
- add helper `dynamic_template`
- render help pages with dynamic renderer
- refactor subdomain and tool overlays to dynamic mode
- use dynamic renderer for the overview page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b278232608332bc8a3ad34c9112cb