### PR TITLE
Implement client-side theme engine

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -14,6 +14,12 @@
   --select-bg-color: var(--color-base);
   --select-border-color: var(--color-contrast);
 
+  /* Generic variable names for dynamic theming */
+  --color-bg: var(--bg-color);
+  --color-text: var(--fg-color);
+  --color-border: var(--select-border-color);
+  --font-family-base: var(--font-main);
+
   /* Terminal.css compatibility */
   --background-color: var(--color-base);
   --font-color: var(--color-contrast);

--- a/static/index_page.js
+++ b/static/index_page.js
@@ -9,6 +9,30 @@ function sanitizeUrl(u){
   return null;
 }
 
+// ----- Theme Engine -----
+function applyTheme({bg, text, accent, border, fontFamily}){
+  const root = document.documentElement;
+  root.style.setProperty('--color-bg', bg || '#000');
+  root.style.setProperty('--color-text', text || '#fff');
+  root.style.setProperty('--color-accent', accent || '#0af');
+  root.style.setProperty('--color-border', border || '#888');
+  root.style.setProperty('--font-family-base', fontFamily || 'monospace');
+}
+
+function loadTheme(){
+  try{
+    const t = JSON.parse(localStorage.getItem('retroTheme') || '{}');
+    if(Object.keys(t).length){ applyTheme(t); }
+  }catch{}
+}
+
+function saveTheme(t){
+  localStorage.setItem('retroTheme', JSON.stringify(t));
+}
+
+// Apply stored theme on load
+loadTheme();
+
 document.addEventListener('DOMContentLoaded', function(){
   document.querySelectorAll('.url-row-main[data-url]').forEach(row => {
     row.addEventListener('click', () => {
@@ -66,6 +90,21 @@ document.addEventListener('DOMContentLoaded', function(){
       }
       exportForm.submit();
       exportSel.value = '';
+    });
+  }
+
+  const saveThemeBtn = document.getElementById('save-theme-btn');
+  if(saveThemeBtn){
+    saveThemeBtn.addEventListener('click', () => {
+      const theme = {
+        bg: document.getElementById('bg-color-input').value,
+        text: document.getElementById('text-color-input').value,
+        accent: document.getElementById('accent-color-input').value,
+        border: document.getElementById('border-color-input').value,
+        fontFamily: document.getElementById('font-family-select').value
+      };
+      applyTheme(theme);
+      saveTheme(theme);
     });
   }
 });

--- a/static/themes/terminal-sans-dark.css
+++ b/static/themes/terminal-sans-dark.css
@@ -11,4 +11,10 @@
   --select-bg-color: #3f3f44;
   --select-border-color: var(--color-contrast);
   --panel-opacity: 0.9;
+
+  /* Generic variable names for dynamic theming */
+  --color-bg: var(--bg-color);
+  --color-text: var(--fg-color);
+  --color-border: var(--select-border-color);
+  --font-family-base: var(--font-main);
 }

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -14,6 +14,13 @@
   --panel-opacity: 0.92;
   --fg-color: var(--font-main);
   --accent-color: var(--font-accent);
+
+  /* Generic variable names for dynamic theming */
+  --color-bg: var(--bg-color);
+  --color-text: var(--fg-color);
+  --color-accent: var(--font-accent);
+  --color-border: var(--border-color);
+  --font-family-base: var(--font-main);
 }
 
 .retrorecon-root {

--- a/templates/index.html
+++ b/templates/index.html
@@ -180,6 +180,34 @@
             <label for="opacity-range" class="form-label menu-label">Panel opacity:</label>
             <input type="range" id="opacity-range" min="10" max="100" value="{{ (panel_opacity * 100)|int }}" class="form-range">
           </div>
+          <hr>
+          <div class="menu-row mb-4px">
+            <label for="font-family-select" class="form-label menu-label">Font:</label>
+            <select id="font-family-select" class="form-select menu-btn">
+              <option value="monospace">monospace</option>
+              <option value="sans-serif">sans-serif</option>
+              <option value="serif">serif</option>
+            </select>
+          </div>
+          <div class="menu-row mb-4px">
+            <label for="accent-color-input" class="form-label menu-label">Accent:</label>
+            <input type="color" id="accent-color-input" class="form-input menu-btn" value="#00aaff">
+          </div>
+          <div class="menu-row mb-4px">
+            <label for="text-color-input" class="form-label menu-label">Text:</label>
+            <input type="color" id="text-color-input" class="form-input menu-btn" value="#ffffff">
+          </div>
+          <div class="menu-row mb-4px">
+            <label for="bg-color-input" class="form-label menu-label">Background:</label>
+            <input type="color" id="bg-color-input" class="form-input menu-btn" value="#000000">
+          </div>
+          <div class="menu-row mb-4px">
+            <label for="border-color-input" class="form-label menu-label">Border:</label>
+            <input type="color" id="border-color-input" class="form-input menu-btn" value="#888888">
+          </div>
+          <div class="menu-row">
+            <button type="button" id="save-theme-btn" class="menu-btn">Save Theme</button>
+          </div>
       </div>
     </div>
     <div class="dropdown">


### PR DESCRIPTION
## Summary
- enable dynamic theme customization from dropdowns
- store selected theme colors and font family in `localStorage`
- load saved preferences on page load
- expose new CSS variables for theme engine

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2ba3adcc8332995988aa341ce807