### PR TITLE
Fix dynamic render text fields

### DIFF
--- a/retrorecon/dynamic_render.py
+++ b/retrorecon/dynamic_render.py
@@ -108,8 +108,11 @@ class HTMLGenerator:
                 for k, v in attrs.items():
                     el.attrs[k] = v
                 text_key = node.get("text")
-                if text_key:
-                    el.string = str(data.get(text_key, ""))
+                if text_key is not None:
+                    # If the key exists in the provided data use that value,
+                    # otherwise treat the text attribute as a literal string.
+                    value = data.get(text_key, text_key)
+                    el.string = str(value)
                 if node.get("children"):
                     add_nodes(el, node["children"])
                 parent.append(el)


### PR DESCRIPTION
## Summary
- fix HTMLGenerator text handling so static strings render correctly

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b3f72c9248332aaea80ce9e4f3f2d