### PR TITLE
Enhance screenshotter logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -286,8 +286,23 @@ SITEZIP_DIR = os.path.join(app.root_path, 'static', 'sitezips')
 executablePath: Optional[str] = None
 
 
-def save_screenshot_record(url: str, path: str, thumb: str, method: str = 'GET') -> int:
-    return screenshot_utils.save_record(SCREENSHOT_DIR, url, path, thumb, method)
+def save_screenshot_record(
+    url: str,
+    path: str,
+    thumb: str,
+    method: str = 'GET',
+    status_code: int = 0,
+    ip_addresses: str = '',
+) -> int:
+    return screenshot_utils.save_record(
+        SCREENSHOT_DIR,
+        url,
+        path,
+        thumb,
+        method,
+        status_code,
+        ip_addresses,
+    )
 
 
 def list_screenshot_data(ids: Optional[List[int]] = None) -> List[Dict[str, Any]]:
@@ -298,15 +313,34 @@ def delete_screenshots(ids: List[int]) -> None:
     screenshot_utils.delete_records(SCREENSHOT_DIR, ids)
 
 
-def take_screenshot(url: str, user_agent: str = '', spoof_referrer: bool = False) -> bytes:
-    return screenshot_utils.take_screenshot(url, user_agent, spoof_referrer, executablePath)
+def take_screenshot(
+    url: str,
+    user_agent: str = '',
+    spoof_referrer: bool = False,
+) -> Tuple[bytes, int, str]:
+    return screenshot_utils.take_screenshot(
+        url, user_agent, spoof_referrer, executablePath
+    )
 
 
 def save_sitezip_record(
-    url: str, zip_name: str, screenshot_name: str, thumb_name: str, method: str = 'GET'
+    url: str,
+    zip_name: str,
+    screenshot_name: str,
+    thumb_name: str,
+    method: str = 'GET',
+    status_code: int = 0,
+    ip_addresses: str = '',
 ) -> int:
     return sitezip_utils.save_record(
-        SITEZIP_DIR, url, zip_name, screenshot_name, thumb_name, method
+        SITEZIP_DIR,
+        url,
+        zip_name,
+        screenshot_name,
+        thumb_name,
+        method,
+        status_code,
+        ip_addresses,
     )
 
 
@@ -318,8 +352,14 @@ def delete_sitezips(ids: List[int]) -> None:
     sitezip_utils.delete_records(SITEZIP_DIR, ids)
 
 
-def capture_site(url: str, user_agent: str = '', spoof_referrer: bool = False) -> Tuple[bytes, bytes]:
-    return sitezip_utils.capture_site(url, user_agent, spoof_referrer, executablePath)
+def capture_site(
+    url: str,
+    user_agent: str = '',
+    spoof_referrer: bool = False,
+) -> Tuple[bytes, bytes, int, str]:
+    return sitezip_utils.capture_site(
+        url, user_agent, spoof_referrer, executablePath
+    )
 
 
 def delete_subdomain(root_domain: str, subdomain: str) -> None:

--- a/database.py
+++ b/database.py
@@ -47,10 +47,18 @@ def ensure_schema() -> None:
             cols = [row[1] for row in cur.fetchall()]
             if 'thumbnail_path' not in cols:
                 conn.execute("ALTER TABLE screenshots ADD COLUMN thumbnail_path TEXT")
+            if 'status_code' not in cols:
+                conn.execute("ALTER TABLE screenshots ADD COLUMN status_code INTEGER DEFAULT 0")
+            if 'ip_addresses' not in cols:
+                conn.execute("ALTER TABLE screenshots ADD COLUMN ip_addresses TEXT DEFAULT ''")
             cur = conn.execute("PRAGMA table_info(sitezips)")
             cols = [row[1] for row in cur.fetchall()]
             if 'thumbnail_path' not in cols:
                 conn.execute("ALTER TABLE sitezips ADD COLUMN thumbnail_path TEXT")
+            if 'status_code' not in cols:
+                conn.execute("ALTER TABLE sitezips ADD COLUMN status_code INTEGER DEFAULT 0")
+            if 'ip_addresses' not in cols:
+                conn.execute("ALTER TABLE sitezips ADD COLUMN ip_addresses TEXT DEFAULT ''")
             cur = conn.execute("PRAGMA table_info(domains)")
             cols = [row[1] for row in cur.fetchall()]
             if 'cdx_indexed' not in cols:

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -57,6 +57,8 @@ CREATE TABLE IF NOT EXISTS screenshots (
     method TEXT,
     screenshot_path TEXT,
     thumbnail_path TEXT,
+    status_code INTEGER DEFAULT 0,
+    ip_addresses TEXT DEFAULT '',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -67,6 +69,8 @@ CREATE TABLE IF NOT EXISTS sitezips (
     zip_path TEXT,
     screenshot_path TEXT,
     thumbnail_path TEXT,
+    status_code INTEGER DEFAULT 0,
+    ip_addresses TEXT DEFAULT '',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -364,6 +364,7 @@ Parameters:
 - `url` – page to fetch.
 - `agent` – optional user agent (`android`, `bot` or blank for desktop).
 - `spoof_referrer` – set to `1` to spoof the referrer header.
+The resulting record logs the HTTP status and resolved IPs for the initial request.
 
 ```
 curl -X POST -d "url=https://example.com" http://localhost:5000/tools/site2zip
@@ -466,6 +467,7 @@ Parameters:
 - `url` – target URL.
 - `user_agent` – optional agent string.
 - `spoof_referrer` – `1` to spoof the referrer header.
+The screenshot record stores the HTTP status and resolved IP addresses used for the request.
 
 ```
 curl -X POST -d "url=https://example.com" http://localhost:5000/tools/screenshot
@@ -473,6 +475,7 @@ curl -X POST -d "url=https://example.com" http://localhost:5000/tools/screenshot
 
 ### `GET /screenshots`
 List captured screenshots as JSON.
+Each object includes `status_code` and `ip_addresses` fields.
 
 ```
 curl http://localhost:5000/screenshots

--- a/docs/database_erd.md
+++ b/docs/database_erd.md
@@ -48,6 +48,8 @@ erDiagram
         TEXT method
         TEXT screenshot_path
         TEXT thumbnail_path
+        INTEGER status_code
+        TEXT ip_addresses
         TIMESTAMP created_at
     }
     sitezips {
@@ -57,6 +59,8 @@ erDiagram
         TEXT zip_path
         TEXT screenshot_path
         TEXT thumbnail_path
+        INTEGER status_code
+        TEXT ip_addresses
         TIMESTAMP created_at
     }
     domains {

--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -264,7 +264,7 @@ def screenshot_route():
     agent = request.form.get('user_agent', '').strip()
     spoof = request.form.get('spoof_referrer', '0') == '1'
     try:
-        img_bytes = app.take_screenshot(url, agent, spoof)
+        img_bytes, status_code, ips = app.take_screenshot(url, agent, spoof)
     except Exception as e:
         return (f'Error taking screenshot: {e}', 500)
     ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
@@ -284,7 +284,7 @@ def screenshot_route():
         app.logger.debug('thumbnail generation failed: %s', e)
         with open(thumb_path, 'wb') as f:
             f.write(img_bytes)
-    sid = app.save_screenshot_record(url, fname, thumb, 'GET')
+    sid = app.save_screenshot_record(url, fname, thumb, 'GET', status_code, ips)
     return jsonify({'id': sid})
 
 
@@ -338,7 +338,7 @@ def site2zip_route():
     agent = request.form.get('agent', '').strip()
     spoof = request.form.get('spoof_referrer', '0') == '1'
     try:
-        zip_bytes, shot_bytes = app.capture_site(url, agent, spoof)
+        zip_bytes, shot_bytes, status_code, ips = app.capture_site(url, agent, spoof)
     except Exception as e:
         return (f'Error capturing site: {e}', 500)
     ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
@@ -361,7 +361,9 @@ def site2zip_route():
         current_app.logger.debug('thumbnail generation failed: %s', e)
         with open(thumb_path, 'wb') as f:
             f.write(shot_bytes)
-    sid = app.save_sitezip_record(url, zip_name, shot_name, thumb_name, 'GET')
+    sid = app.save_sitezip_record(
+        url, zip_name, shot_name, thumb_name, 'GET', status_code, ips
+    )
     return jsonify({'id': sid})
 
 

--- a/static/screenshotter.js
+++ b/static/screenshotter.js
@@ -68,11 +68,13 @@ function initScreenshotter(){
       return 0;
     });
     let html = '<table class="table url-table w-100"><colgroup>'+
-      '<col class="w-2em"/><col/><col/><col/><col/>'+
+      '<col class="w-2em"/><col/><col/><col/><col/><col/><col/>'+
       '</colgroup><thead><tr>'+
       '<th class="w-2em checkbox-col no-resize text-center"><input type="checkbox" id="shot-select-all" class="form-checkbox" /></th>'+
       '<th class="sortable" data-field="created_at">Time</th>'+
       '<th class="sortable" data-field="url">URL</th>'+
+      '<th class="sortable" data-field="status_code">Status</th>'+
+      '<th class="sortable" data-field="ip_addresses">IPs</th>'+
       '<th class="sortable" data-field="method">Method</th>'+
       '<th>Thumbnail</th>'+
       '</tr></thead><tbody>';
@@ -81,6 +83,8 @@ function initScreenshotter(){
       html += `<tr data-id="${row.id}"><td class="checkbox-col"><input type="checkbox" class="row-checkbox" value="${row.id}"/></td>`+
         `<td>${row.created_at}</td>`+
         `<td><div class="cell-content">${row.url}</div></td>`+
+        `<td>${row.status_code}</td>`+
+        `<td>${row.ip_addresses}</td>`+
         `<td>${row.method}</td>`+
         `<td><a href="${row.file}" target="_blank">${img}</a></td></tr>`;
     }

--- a/static/site2zip.js
+++ b/static/site2zip.js
@@ -68,11 +68,13 @@ function initSite2Zip(){
       return 0;
     });
     let html = '<table class="table url-table w-100"><colgroup>'+
-      '<col class="w-2em"/><col/><col/><col/><col/><col/>'+
+      '<col class="w-2em"/><col/><col/><col/><col/><col/><col/><col/>'+
       '</colgroup><thead><tr>'+
       '<th class="w-2em checkbox-col no-resize text-center"><input type="checkbox" id="sitezip-select-all" class="form-checkbox" /></th>'+
       '<th class="sortable" data-field="created_at">Time</th>'+
       '<th class="sortable" data-field="url">URL</th>'+
+      '<th class="sortable" data-field="status_code">Status</th>'+
+      '<th class="sortable" data-field="ip_addresses">IPs</th>'+
       '<th class="sortable" data-field="method">Method</th>'+
       '<th>ZIP</th><th>Screenshot</th>'+
       '</tr></thead><tbody>';
@@ -81,6 +83,8 @@ function initSite2Zip(){
       html += `<tr data-id="${row.id}"><td class="checkbox-col"><input type="checkbox" class="row-checkbox" value="${row.id}"/></td>`+
         `<td>${row.created_at}</td>`+
         `<td><div class="cell-content">${row.url}</div></td>`+
+        `<td>${row.status_code}</td>`+
+        `<td>${row.ip_addresses}</td>`+
         `<td>${row.method}</td>`+
         `<td><a href="${row.zip}" download>ZIP</a></td>`+
         `<td><a href="${row.preview}" target="_blank">${img}</a></td></tr>`;


### PR DESCRIPTION
## Summary
- record HTTP status and IP addresses for screenshots and site zips
- expose metadata through `/screenshots` and `/sitezips`
- update schema and migrations for new columns
- display status/IP columns in Screenshotter and Site2Zip tables
- document new fields in API docs

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4f8fb46c8332b1406d2d1c900600