### PR TITLE
Fix OCI explorer routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -811,7 +811,7 @@ from retrorecon.routes import (
     settings_bp,
     domains_bp,
     docker_bp,
-    registry_bp,
+    oci_explorer_bp,
     dag_bp,
     oci_bp,
     dagdotdev_bp,
@@ -827,7 +827,7 @@ app.register_blueprint(db_bp)
 app.register_blueprint(settings_bp)
 app.register_blueprint(domains_bp)
 app.register_blueprint(docker_bp)
-app.register_blueprint(registry_bp)
+app.register_blueprint(oci_explorer_bp)
 app.register_blueprint(dag_bp)
 app.register_blueprint(oci_bp)
 app.register_blueprint(dagdotdev_bp)

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -586,25 +586,25 @@ curl -L "http://localhost:5000/download_layer?image=ubuntu:latest&digest=sha256:
 ```
 Include `insecure=1` when downloading from insecure registries.
 
-### `GET /registry_viewer`
-Serve the Registry Explorer overlay.
+### `GET /oci_explorer`
+Serve the OCI Explorer overlay.
 
 ```
-curl http://localhost:5000/registry_viewer
+curl http://localhost:5000/oci_explorer
 ```
 
-### `GET /tools/registry_viewer`
-Full-page Registry Explorer.
+### `GET /tools/oci_explorer`
+Full-page OCI Explorer.
 
 ```
-curl http://localhost:5000/tools/registry_viewer
+curl http://localhost:5000/tools/oci_explorer
 ```
 
-### `GET /registry_explorer`
+### `GET /oci_explorer_api`
 Query manifest information for an image.
 
 ```
-curl -G --data-urlencode "image=ubuntu:latest" http://localhost:5000/registry_explorer
+curl -G --data-urlencode "image=ubuntu:latest" http://localhost:5000/oci_explorer_api
 ```
 
 Pass `insecure=1` to disable TLS validation or when connecting to self-signed registries.

--- a/docs/oci_explorer_user_journey.md
+++ b/docs/oci_explorer_user_journey.md
@@ -3,11 +3,11 @@
 This document walks through a typical workflow using the Dag/OCI Explorer in Retrorecon.
 
 1. **Open the tool**
-   - From the Retrorecon interface choose **Tools → OCI Explorer**. This opens the overlay at `/dag_explorer`.
+   - From the Retrorecon interface choose **Tools → OCI Explorer**. This opens the overlay at `/oci_explorer`.
 
 2. **Enter an image reference**
    - In the text field, provide a full image reference such as `ghcr.io/stargz-containers/node:13.13.0-esgz`.
-   - Press **Fetch**. Retrorecon sends `GET /registry_explorer?image=<ref>` to retrieve the manifest.
+   - Press **Fetch**. Retrorecon sends `GET /oci_explorer_api?image=<ref>` to retrieve the manifest.
 
 3. **View manifest and layers**
    - The manifest details are displayed including media type, config and layer digests.

--- a/docs/oci_registry_table_project_tasks.md
+++ b/docs/oci_registry_table_project_tasks.md
@@ -4,13 +4,13 @@ This document breaks down the design from `docs/oci_registry_table_spec.md` (iss
 
 ## Implementation Steps for Codex
 1. **Route Enhancements**
-   - Add address type detection in `retrorecon/routes/registry.py` before invoking existing helper functions.
+   - Add address type detection in `retrorecon/routes/oci_explorer.py` before invoking existing helper functions.
    - Provide optional registry credentials via configuration for private registries.
 2. **Data Processing**
    - Extend `registry_explorer.py` with helpers that convert manifests into hierarchical table structures.
    - Expose JSON endpoints returning these structures for the frontend.
 3. **Frontend Updates**
-   - Modify `static/registry_explorer.js` and templates to display expandable tables and a toggle for raw JSON.
+   - Modify `static/oci_explorer.js` and templates to display expandable tables and a toggle for raw JSON.
    - Include indexed menus so users can quickly jump between layers and files.
 4. **Testing**
    - Expand the PyTest suite with new route and detection logic coverage.

--- a/docs/oci_registry_table_spec.md
+++ b/docs/oci_registry_table_spec.md
@@ -27,7 +27,7 @@ The current registry explorer returns raw JSON when a user fetches an image refe
    - Each entry stores digest, size, permissions and path.
    - Generate download URLs referencing `/layers/<image>@<digest>/<path>` to reuse existing layer browsing routes.
 4. **UI Rendering**
-   - Extend `registry_explorer.js` to populate a new table layout.
+   - Extend `oci_explorer.js` to populate a new table layout.
    - Show a top level table summarizing manifest info with collapsible rows for each layer.
    - Nested tables or `<details>` elements display directory contents.
    - A “Raw JSON” toggle reveals the original manifest for advanced users.
@@ -40,13 +40,13 @@ The current registry explorer returns raw JSON when a user fetches an image refe
 
 ## Implementation Steps for Codex
 1. **Route Enhancements**
-   - Add detection logic in `retrorecon/routes/registry.py` before calling the existing helper functions.
+   - Add detection logic in `retrorecon/routes/oci_explorer.py` before calling the existing helper functions.
    - Introduce optional credentials in configuration for private registries.
 2. **Data Processing**
    - Expand `registry_explorer.py` with functions to map the manifest to a hierarchical table structure.
    - Provide JSON endpoints returning this structured data.
 3. **Frontend Updates**
-   - Update `static/registry_explorer.js` and templates to render expandable tables and a JSON toggle.
+   - Update `static/oci_explorer.js` and templates to render expandable tables and a JSON toggle.
    - Include indexed menus for layer and file navigation.
 4. **Testing**
    - Extend the PyTest suite to cover new routes and detection logic.

--- a/docs/template_overview.md
+++ b/docs/template_overview.md
@@ -21,7 +21,7 @@ This document catalogs the HTML templates currently present in the repository an
 | `oci_layer.html` | Presents metadata for a specific layer and includes a sorted file list from `crane blob`. |
 | `oci_overlay.html` | Lists files extracted from an image using `crane export` and shows HTTP vs OCI views. |
 | `oci_repo.html` | Renders repository details including child repos and tags with links to manifests. |
-| `registry_explorer.html` | Overlay calling `/registry_explorer` to fetch image information via multiple methods (extension, layerslayer). |
+| `registry_explorer.html` | Overlay calling `/oci_explorer_api` to fetch image information via multiple methods (extension, layerslayer). |
 | `screenshotter.html` | Overlay for capturing website screenshots with optional user agent and referrer spoofing. Displays existing shots in a table. |
 | `site2zip.html` | Overlay similar to Screenshotter but crawls a URL and packages all assets into a downloadable ZIP. |
 | `subdomonster.html` | Overlay that fetches subdomains from crt.sh or VirusTotal, supports tagging and export with pagination. |

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -4,7 +4,7 @@ from .db import bp as db_bp
 from .settings import bp as settings_bp
 from .domains import bp as domains_bp
 from .docker import bp as docker_bp
-from .registry import bp as registry_bp
+from .oci_explorer import bp as oci_explorer_bp
 from .dag import bp as dag_bp
 from .oci import bp as oci_bp
 from .dagdotdev import bp as dagdotdev_bp
@@ -14,4 +14,4 @@ from .overview import bp as overview_bp
 from .help import bp as help_bp
 from .dynamic import bp as dynamic_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'registry_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'help_bp', 'dynamic_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'oci_explorer_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'help_bp', 'dynamic_bp']

--- a/retrorecon/routes/oci_explorer.py
+++ b/retrorecon/routes/oci_explorer.py
@@ -8,21 +8,23 @@ from aiohttp import ClientConnectorCertificateError
 from layerslayer.utils import parse_image_ref
 from .. import registry_explorer as rex
 
-bp = Blueprint('registry', __name__)
+bp = Blueprint('oci_explorer', __name__)
 
 
-@bp.route('/registry_viewer', methods=['GET'])
-def registry_viewer_page():
+@bp.route('/oci_explorer', methods=['GET'])
+def oci_explorer_page():
+    """Serve the OCI Explorer overlay."""
     return dynamic_template('registry_explorer.html')
 
 
-@bp.route('/tools/registry_viewer', methods=['GET'])
-def registry_viewer_full_page():
+@bp.route('/tools/oci_explorer', methods=['GET'])
+def oci_explorer_full_page():
+    """Serve the main dashboard so the overlay can open on load."""
     return app.index()
 
 
-@bp.route('/registry_explorer', methods=['GET'])
-def registry_explorer_route():
+@bp.route('/oci_explorer_api', methods=['GET'])
+def oci_explorer_route():
     image = request.args.get('image')
     files_flag = request.args.get('files', 'false').lower() in {'1', 'true', 'yes'}
     insecure_flag = request.args.get('insecure', 'false').lower() in {'1', 'true', 'yes'}
@@ -86,8 +88,8 @@ def registry_explorer_route():
     return jsonify(result)
 
 
-@bp.route('/registry_table', methods=['GET'])
-def registry_table_route():
+@bp.route('/oci_table', methods=['GET'])
+def oci_table_route():
     """Return manifest contents as a hierarchical table."""
     image = request.args.get('image')
     insecure_flag = request.args.get('insecure', 'false').lower() in {'1', 'true', 'yes'}

--- a/static/base.css
+++ b/static/base.css
@@ -1159,12 +1159,12 @@ body {
   color: inherit;
 }
 
-/* <<<<<<< codex/improve-dashboard-layout-and-pagination
 .retrorecon-root #layout-d {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  margin-top: 0.25em;
 }
 
 /* Reduce spacing around pagination and results sections */
@@ -1175,11 +1175,7 @@ body {
   margin-top: 0;
   margin-bottom: 0;
 }
-.retrorecon-root #layout-d {
-  margin-top: 0.25em;
-}
 
-/* --- End of update --- */
 body.bg-hidden {
   background-image: none !important;
   background-color: var(--color-base) !important;

--- a/static/oci_explorer.js
+++ b/static/oci_explorer.js
@@ -1,4 +1,4 @@
-/* File: static/registry_explorer.js */
+/* File: static/oci_explorer.js */
 function initRegistryExplorer(){
   const overlay = document.getElementById('registry-explorer-overlay');
   if(!overlay) return;
@@ -206,7 +206,7 @@ function initRegistryExplorer(){
     const img = imageInput.value.trim();
     if(!img) return;
     const methods = Array.from(methodChecks).filter(c=>c.checked).map(c=>c.value);
-    let url = '/registry_explorer?image=' + encodeURIComponent(img);
+    let url = '/oci_explorer_api?image=' + encodeURIComponent(img);
     if(methods.length === 1){
       url += '&method=' + encodeURIComponent(methods[0]);
     }else if(methods.length > 1){
@@ -232,7 +232,7 @@ function initRegistryExplorer(){
 
   closeBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');
-    if(location.pathname === '/tools/registry_viewer'){
+    if(location.pathname === '/tools/oci_explorer'){
       history.pushState({}, '', '/');
     }
   });

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -432,21 +432,21 @@ paths:
       responses:
         '200':
           description: Successful response
-  /registry_viewer:
+  /oci_explorer:
     get:
-      summary: GET /registry_viewer
+      summary: GET /oci_explorer
       responses:
         '200':
           description: Successful response
-  /tools/registry_viewer:
+  /tools/oci_explorer:
     get:
-      summary: GET /tools/registry_viewer
+      summary: GET /tools/oci_explorer
       responses:
         '200':
           description: Successful response
-  /registry_explorer:
+  /oci_explorer_api:
     get:
-      summary: GET /registry_explorer
+      summary: GET /oci_explorer_api
       parameters:
         - in: query
           name: insecure
@@ -492,9 +492,9 @@ paths:
       responses:
         '200':
           description: Successful response
-  /tools/registry_explorer:
+  /oci_table:
     get:
-      summary: GET /tools/registry_explorer
+      summary: GET /oci_table
       responses:
         '200':
           description: Successful response

--- a/templates/index.html
+++ b/templates/index.html
@@ -223,7 +223,7 @@
           <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">ScreenShotter</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="demo-link">Demo</a></div>
-          <div class="menu-row"><a href="#" class="menu-btn" id="dag-explorer-link">OCI Explorer</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="oci-explorer-link">OCI Explorer</a></div>
           <div class="menu-row"><a href="/swagger" class="menu-btn" id="swagger-ui-link" target="_blank">Swagger UI</a></div>
       </div>
     </div>
@@ -1269,23 +1269,23 @@
         showDemo(true);
       }
 
-      const registryLink = document.getElementById('registry-viewer-link');
+      const registryLink = document.getElementById('oci-explorer-link');
       let registryLoaded = false;
 
       async function showRegistryViewer(skipPush){
         if(!registryLoaded){
-          const resp = await fetch('/registry_viewer');
+          const resp = await fetch('/oci_explorer');
           const html = await resp.text();
           const root = document.querySelector('.retrorecon-root') || document.body;
           root.insertAdjacentHTML('beforeend', html);
           const script = document.createElement('script');
-          script.src = '/static/registry_explorer.js';
+          script.src = '/static/oci_explorer.js';
           document.body.appendChild(script);
           registryLoaded = true;
         }
         document.getElementById('registry-explorer-overlay').classList.remove('hidden');
         if(!skipPush){
-          history.pushState({tool:'registry'}, '', '/tools/registry_viewer');
+          history.pushState({tool:'registry'}, '', '/tools/oci_explorer');
         }
       }
 
@@ -1302,14 +1302,14 @@
       }
 
       window.addEventListener('popstate', () => {
-        if(location.pathname === '/tools/registry_viewer'){
+        if(location.pathname === '/tools/oci_explorer'){
           showRegistryViewer(true);
         } else {
           hideRegistryViewer();
         }
       });
 
-      if(location.pathname === '/tools/registry_viewer' || openTool === 'registry'){
+      if(location.pathname === '/tools/oci_explorer' || openTool === 'registry'){
         showRegistryViewer(true);
       }
 
@@ -1346,7 +1346,7 @@
       }
 
       window.addEventListener('popstate', () => {
-        if(location.pathname === '/tools/registry_viewer'){
+        if(location.pathname === '/tools/oci_explorer'){
           showRegistryViewer(true);
         } else if(location.pathname === '/tools/dag_explorer'){
           showDagExplorer(true);


### PR DESCRIPTION
## Summary
- rename registry routes module to `oci_explorer`
- standardize explorer endpoints (`/oci_explorer`, `/oci_explorer_api`)
- load `oci_explorer.js` in index page
- update docs and OpenAPI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b516b46908332b2264aa158b01aab