### PR TITLE
Fix template for Site2Zip overlay

### DIFF
--- a/templates/site2zip.html
+++ b/templates/site2zip.html
@@ -1,0 +1,17 @@
+<div id="sitezip-overlay" class="notes-overlay hidden">
+  <div class="mb-05">
+    <input type="text" id="sitezip-url" class="form-input mr-05 w-20em" placeholder="https://example.com" />
+    <select id="sitezip-agent" class="form-select mr-05">
+      <option value="">Desktop</option>
+      <option value="android">Android</option>
+      <option value="bot">Search Engine</option>
+    </select>
+    <label class="mr-05">
+      <input type="checkbox" id="sitezip-ref" class="form-checkbox" /> Spoof referrer
+    </label>
+    <button type="button" class="btn" id="sitezip-capture-btn">Capture</button>
+    <button type="button" class="btn" id="sitezip-delete-btn">Delete</button>
+    <button type="button" class="btn" id="sitezip-close-btn">Close</button>
+  </div>
+  <div id="sitezip-table" class="mt-05"></div>
+</div>


### PR DESCRIPTION
## Summary
- add missing `site2zip.html` template so `/site2zip` renders correctly

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b92c2ae9083329f4a2083249a80aa