### PR TITLE
Enhance HTTPolaroid logging and thumbnail toggles

### DIFF
--- a/app.py
+++ b/app.py
@@ -317,9 +317,10 @@ def take_screenshot(
     url: str,
     user_agent: str = '',
     spoof_referrer: bool = False,
+    log_path: Optional[str] = None,
 ) -> Tuple[bytes, int, str]:
     return screenshot_utils.take_screenshot(
-        url, user_agent, spoof_referrer, executablePath
+        url, user_agent, spoof_referrer, executablePath, log_path
     )
 
 
@@ -356,9 +357,10 @@ def capture_snap(
     url: str,
     user_agent: str = '',
     spoof_referrer: bool = False,
+    log_path: Optional[str] = None,
 ) -> Tuple[bytes, bytes, int, str]:
     return httpolaroid_utils.capture_site(
-        url, user_agent, spoof_referrer, executablePath
+        url, user_agent, spoof_referrer, executablePath, log_path
     )
 
 

--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -220,6 +220,11 @@ def register_demo_schemas(registry: SchemaRegistry) -> None:
                                 },
                                 {
                                     "tag": "button",
+                                    "attrs": {"type": "button", "class": "btn", "id": "screenshot-toggle-btn"},
+                                    "text": "Toggle Thumbs",
+                                },
+                                {
+                                    "tag": "button",
                                     "attrs": {"type": "button", "class": "btn", "id": "screenshot-close-btn"},
                                     "text": "Close",
                                 },

--- a/retrorecon/httpolaroid_utils.py
+++ b/retrorecon/httpolaroid_utils.py
@@ -89,6 +89,7 @@ def capture_site(
     user_agent: str = '',
     spoof_referrer: bool = False,
     executable_path: Optional[str] = None,
+    log_path: Optional[str] = None,
 ) -> Tuple[bytes, bytes, int, str]:
     headers = {}
     if user_agent:
@@ -125,6 +126,7 @@ def capture_site(
         user_agent,
         spoof_referrer,
         executable_path,
+        log_path,
     )
     if not ip:
         ip = shot_ips

--- a/static/httpolaroid.js
+++ b/static/httpolaroid.js
@@ -9,6 +9,7 @@ function initHttpolaroid(){
   const tableDiv = document.getElementById('httpolaroid-table');
   const deleteBtn = document.getElementById('httpolaroid-delete-btn');
   const closeBtn = document.getElementById('httpolaroid-close-btn');
+  const toggleBtn = document.getElementById('httpolaroid-toggle-btn');
   let tableData = [];
   let sortField = 'created_at';
   let sortDir = 'desc';
@@ -102,6 +103,11 @@ function initHttpolaroid(){
     }
     html += '</tbody></table>';
     tableDiv.innerHTML = html;
+    tableDiv.querySelectorAll('.screenshot-thumb').forEach(img => {
+      img.addEventListener('click', () => {
+        img.classList.toggle('thumb-hidden');
+      });
+    });
     const selAll = document.getElementById('httpolaroid-select-all');
     if(selAll){
       selAll.addEventListener('change', () => {
@@ -150,6 +156,14 @@ function initHttpolaroid(){
     await fetch('/delete_httpolaroids', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
     loadRows();
   });
+
+  if(toggleBtn){
+    toggleBtn.addEventListener('click', () => {
+      const imgs = tableDiv.querySelectorAll('.screenshot-thumb');
+      const anyVisible = Array.from(imgs).some(img => !img.classList.contains('thumb-hidden'));
+      imgs.forEach(img => img.classList.toggle('thumb-hidden', anyVisible));
+    });
+  }
 
   closeBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');

--- a/static/screenshotter.js
+++ b/static/screenshotter.js
@@ -9,6 +9,7 @@ function initScreenshotter(){
   const tableDiv = document.getElementById('screenshot-table');
   const deleteBtn = document.getElementById('screenshot-delete-btn');
   const closeBtn = document.getElementById('screenshot-close-btn');
+  const toggleBtn = document.getElementById('screenshot-toggle-btn');
   let tableData = [];
   let sortField = 'created_at';
   let sortDir = 'desc';
@@ -90,6 +91,11 @@ function initScreenshotter(){
     }
     html += '</tbody></table>';
     tableDiv.innerHTML = html;
+    tableDiv.querySelectorAll('.screenshot-thumb').forEach(img => {
+      img.addEventListener('click', () => {
+        img.classList.toggle('thumb-hidden');
+      });
+    });
     const selAll = document.getElementById('shot-select-all');
     if(selAll){
       selAll.addEventListener('change', () => {
@@ -145,6 +151,14 @@ function initScreenshotter(){
       history.pushState({}, '', '/');
     }
   });
+
+  if(toggleBtn){
+    toggleBtn.addEventListener('click', () => {
+      const imgs = tableDiv.querySelectorAll('.screenshot-thumb');
+      const anyVisible = Array.from(imgs).some(img => !img.classList.contains('thumb-hidden'));
+      imgs.forEach(img => img.classList.toggle('thumb-hidden', anyVisible));
+    });
+  }
 
   loadShots();
 }

--- a/static/tools.css
+++ b/static/tools.css
@@ -96,6 +96,9 @@
   width: 80px;
   height: auto;
 }
+.retrorecon-root .screenshot-thumb.thumb-hidden {
+  display: none;
+}
 
 /* Subdomonster overlay */
 .retrorecon-root #subdomonster-table table {

--- a/templates/httpolaroid.html
+++ b/templates/httpolaroid.html
@@ -11,6 +11,7 @@
     </label>
     <button type="button" class="btn" id="httpolaroid-capture-btn">Capture</button>
     <button type="button" class="btn" id="httpolaroid-delete-btn">Delete</button>
+    <button type="button" class="btn" id="httpolaroid-toggle-btn">Toggle Thumbs</button>
     <button type="button" class="btn" id="httpolaroid-close-btn">Close</button>
   </div>
   <div id="httpolaroid-table" class="mt-05"></div>


### PR DESCRIPTION
## Summary
- support optional Playwright debug logs
- allow hiding screenshot thumbnails individually or in bulk
- wire up thumbnail toggles in HTTPolaroid and Screenshotter overlays

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685c453bd47083328b55330bb095e5d3