### PR TITLE
Ensure log directories exist for debug screenshots

### DIFF
--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -267,6 +267,7 @@ def screenshot_route():
     debug_log = request.form.get('debug', '0') == '1'
     ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
     log_path = None
+    os.makedirs(app.SCREENSHOT_DIR, exist_ok=True)
     if debug_log:
         log_path = os.path.join(app.SCREENSHOT_DIR, f'shot_{ts}.log')
     try:
@@ -275,7 +276,6 @@ def screenshot_route():
         return (f'Error taking screenshot: {e}', 500)
     fname = f'shot_{ts}.png'
     thumb = f'shot_{ts}_th.png'
-    os.makedirs(app.SCREENSHOT_DIR, exist_ok=True)
     full_path = os.path.join(app.SCREENSHOT_DIR, fname)
     with open(full_path, 'wb') as f:
         f.write(img_bytes)
@@ -355,6 +355,7 @@ def httpolaroid_route():
     debug_log = request.form.get('debug', '0') == '1'
     ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
     log_path = None
+    os.makedirs(app.SITEZIP_DIR, exist_ok=True)
     if debug_log:
         log_path = os.path.join(app.SITEZIP_DIR, f'site_{ts}.log')
     try:
@@ -364,7 +365,6 @@ def httpolaroid_route():
     zip_name = f'site_{ts}.zip'
     shot_name = f'site_{ts}.png'
     thumb_name = f'site_{ts}_th.png'
-    os.makedirs(app.SITEZIP_DIR, exist_ok=True)
     with open(os.path.join(app.SITEZIP_DIR, zip_name), 'wb') as f:
         f.write(zip_bytes)
     shot_path = os.path.join(app.SITEZIP_DIR, shot_name)

--- a/tests/test_debug_logs.py
+++ b/tests/test_debug_logs.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    monkeypatch.setattr(app, "SCREENSHOT_DIR", str(tmp_path / "static" / "screenshots"))
+    monkeypatch.setattr(app, "SITEZIP_DIR", str(tmp_path / "static" / "sitezips"))
+    with app.app.app_context():
+        app.create_new_db("test")
+
+
+def test_screenshot_route_debug_logs(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+
+    def fake_take(url, agent='', spoof=False, log_path=None):
+        assert log_path is not None
+        assert os.path.isdir(os.path.dirname(log_path))
+        return b"IMG", 200, "1.1.1.1"
+
+    monkeypatch.setattr(app, "take_screenshot", fake_take)
+
+    with app.app.test_client() as client:
+        resp = client.post(
+            "/tools/screenshot",
+            data={"url": "http://example.com", "debug": "1"},
+        )
+        assert resp.status_code == 200
+
+
+def test_httpolaroid_route_debug_logs(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+
+    def fake_capture(url, agent="", spoof=False, log_path=None):
+        assert log_path is not None
+        assert os.path.isdir(os.path.dirname(log_path))
+        return b"ZIP", b"IMG", 200, "1.1.1.1"
+
+    monkeypatch.setattr(app, "capture_snap", fake_capture)
+
+    with app.app.test_client() as client:
+        resp = client.post(
+            "/tools/httpolaroid",
+            data={"url": "http://example.com", "debug": "1"},
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- ensure static directories exist before using debug log paths in screenshot routes
- add regression tests for debug logging without existing directories

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c59aca1d8833296edbb44f82e8bfa