### PR TITLE
Add debug log panel to screenshot tools

### DIFF
--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -231,6 +231,7 @@ def register_demo_schemas(registry: SchemaRegistry) -> None:
                             ],
                         },
                         {"tag": "div", "attrs": {"id": "screenshot-table", "class": "mt-05"}},
+                        {"tag": "textarea", "attrs": {"id": "screenshot-log", "class": "form-input debug-output mt-05", "rows": "6", "readonly": ""}},
                     ],
                 }
             ],

--- a/static/base.css
+++ b/static/base.css
@@ -1218,6 +1218,14 @@ body.bg-hidden {
   background: var(--bg-color);
   color: var(--fg-color);
 }
+.retrorecon-root .debug-output {
+  width: 100%;
+  font-family: monospace;
+  white-space: pre-wrap;
+  background: var(--bg-color);
+  color: var(--fg-color);
+  height: 12em;
+}
 .retrorecon-root .notes-list {
   flex: 1;
   overflow-y: auto;

--- a/static/httpolaroid.js
+++ b/static/httpolaroid.js
@@ -10,6 +10,11 @@ function initHttpolaroid(){
   const deleteBtn = document.getElementById('httpolaroid-delete-btn');
   const closeBtn = document.getElementById('httpolaroid-close-btn');
   const toggleBtn = document.getElementById('httpolaroid-toggle-btn');
+  const logBox = document.getElementById('httpolaroid-log');
+  const debugEnabled = new URLSearchParams(location.search).get('debug') === '1';
+  if(logBox && !debugEnabled){
+    logBox.style.display = 'none';
+  }
   let tableData = [];
   let sortField = 'created_at';
   let sortDir = 'desc';
@@ -144,8 +149,13 @@ function initHttpolaroid(){
     const url = urlInput.value.trim();
     if(!url) return;
     const params = new URLSearchParams({url, agent: agentSel.value, spoof_referrer: refChk.checked ? '1':'0'});
+    if(debugEnabled) params.set('debug', '1');
     const resp = await fetch('/tools/httpolaroid', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
-    if(resp.ok){ await loadRows(); } else { alert(await resp.text()); }
+    if(resp.ok){
+      const data = await resp.json();
+      if(debugEnabled && logBox) logBox.value = data.log || '';
+      await loadRows();
+    } else { alert(await resp.text()); }
   });
 
   deleteBtn.addEventListener('click', async () => {

--- a/static/screenshotter.js
+++ b/static/screenshotter.js
@@ -10,6 +10,11 @@ function initScreenshotter(){
   const deleteBtn = document.getElementById('screenshot-delete-btn');
   const closeBtn = document.getElementById('screenshot-close-btn');
   const toggleBtn = document.getElementById('screenshot-toggle-btn');
+  const logBox = document.getElementById('screenshot-log');
+  const debugEnabled = new URLSearchParams(location.search).get('debug') === '1';
+  if(logBox && !debugEnabled){
+    logBox.style.display = 'none';
+  }
   let tableData = [];
   let sortField = 'created_at';
   let sortDir = 'desc';
@@ -132,8 +137,13 @@ function initScreenshotter(){
     const url = urlInput.value.trim();
     if(!url) return;
     const params = new URLSearchParams({url, agent: agentSel.value, spoof: refChk.checked ? '1':'0'});
+    if(debugEnabled) params.set('debug', '1');
     const resp = await fetch('/tools/screenshot', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
-    if(resp.ok){ await loadShots(); } else { alert(await resp.text()); }
+    if(resp.ok){
+      const data = await resp.json();
+      if(debugEnabled && logBox) logBox.value = data.log || '';
+      await loadShots();
+    } else { alert(await resp.text()); }
   });
 
   deleteBtn.addEventListener('click', async () => {

--- a/templates/httpolaroid.html
+++ b/templates/httpolaroid.html
@@ -15,4 +15,5 @@
     <button type="button" class="btn" id="httpolaroid-close-btn">Close</button>
   </div>
   <div id="httpolaroid-table" class="mt-05"></div>
+  <textarea id="httpolaroid-log" class="form-input debug-output mt-05" rows="6" readonly></textarea>
 </div>


### PR DESCRIPTION
## Summary
- support debug output in the screenshotter and HTTPolaroid overlays
- show returned log text when debug mode is enabled
- style debug output textarea
- test that debug logging is included in the HTTP response

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c59e8ea748332a6027c7a5c91e14d