### PR TITLE
Fix table opacity

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -731,7 +731,7 @@ body {
 .retrorecon-root .url-table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--bg-color);
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
   margin-bottom: 0.4em;
   border-radius: 8px;
 }
@@ -757,7 +757,7 @@ body {
 
 /* Table header style this seems wrong to me JB*/
 .retrorecon-root .url-table thead {
-  background: var(--bg-color);
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
   color: var(--color-contrast);
   opacity: 1;
 }
@@ -847,7 +847,7 @@ body {
 
 /* URL row button cells */
 .retrorecon-root .url-row-buttons {
-  background: var(--bg-color);
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
   transition: background-color 0.2s;
 }
 .retrorecon-root .url-row-buttons td {
@@ -872,11 +872,11 @@ body {
 }
 .retrorecon-root .url-row-main:nth-child(4n),
 .retrorecon-root .url-row-main:nth-child(4n + 2) {
-  background: rgb(var(--bg-rgb));
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
 }
 .retrorecon-root .url-row-buttons:nth-child(4n + 1),
 .retrorecon-root .url-row-buttons:nth-child(4n + 3) {
-  background: var(--bg-color);
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
 }
 
 /* Main row: cursor pointer for entire row */

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -1,7 +1,7 @@
 /* Neon midnight dark theme */
 :root {
   --bg-main: #00000000;
-  --bg-panel: rgb(0 0 0 / 0%);
+  --bg-panel: rgb(var(--bg-rgb)/var(--panel-opacity));
   --font-main: #ffffff;
   --font-accent: #8be9fd;
   --border-color: rgba(139, 233, 253, 0.4);
@@ -45,7 +45,7 @@ body.bg-hidden {
 
 .retrorecon-root .url-table th,
 .retrorecon-root .url-table td {
-  background: transparent;
+  background: rgb(var(--bg-rgb)/var(--panel-opacity));
   color: var(--font-main);
   border-bottom: 1px solid var(--border-color);
   font-size: 13.333px;


### PR DESCRIPTION
## Summary
- use `--panel-opacity` for the URL table to respect the slider
- ensure the neon theme honors `--panel-opacity`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c8dfc760c83328bb258840d5e2ca7