### PR TITLE
Fix subdomonster API key flow

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -521,7 +521,7 @@ Fetch subdomains from crt.sh, VirusTotal, or the local URL list.
 Parameters:
 - `domain` – target domain (optional when using the `local` source).
 - `source` – `crtsh`, `virustotal`, or `local`.
-- `api_key` – required for VirusTotal.
+- `api_key` – VirusTotal API key, optional if `VIRUSTOTAL_API` is configured.
 
 Use `source=local` to import subdomains discovered by scraping existing URLs.
 

--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -58,6 +58,7 @@ def register_demo_schemas(registry: SchemaRegistry) -> None:
                                         "id": "subdomonster-api-key",
                                         "class": "form-input mr-05 hidden",
                                         "placeholder": "API key",
+                                        "value": app.app.config.get("VIRUSTOTAL_API", ""),
                                     },
                                 },
                                 {

--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -2,7 +2,7 @@ import io
 import csv
 import re
 import json
-from flask import Blueprint, request, jsonify, Response
+from flask import Blueprint, request, jsonify, Response, current_app
 from .dynamic import dynamic_template, render_from_payload, schema_registry, html_generator
 import app
 from retrorecon import subdomain_utils, status as status_mod
@@ -63,7 +63,7 @@ def subdomains_route():
 
     domain = request.form.get('domain', '').strip().lower()
     source = request.form.get('source', 'crtsh')
-    api_key = request.form.get('api_key', '').strip()
+    api_key = request.form.get('api_key', '').strip() or current_app.config.get('VIRUSTOTAL_API', '')
 
     if source == 'local':
         # Allow single-label hostnames or IPs when scraping local URLs. A very


### PR DESCRIPTION
## Summary
- default Subdomonster VirusTotal API key to configuration value
- expose API key in dynamic schema so it's pre-filled
- document optional API key when `VIRUSTOTAL_API` is set

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_685c9185f5908332ac88d0de42ab012e