### PR TITLE
Fix overlay offset

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -64,3 +64,19 @@ table containers &mdash; should have slightly rounded corners using a
 
 Following these defaults ensures consistency between pages and keeps the
 interface simple to theme.
+
+## 5. Overlays
+
+Interactive tools use overlay panels such as `.notes-overlay`. These panels must
+never hide the main navigation bar or status area at the top of the page. The
+base stylesheet defines `--navbar-height` to reserve space for this menu:
+
+```css
+:root {
+  --navbar-height: 3em; /* adjust if the navbar layout changes */
+}
+```
+
+The `.notes-overlay` rule positions overlays using `top: var(--navbar-height)` so
+the menu bar remains visible. Every overlay should also include a close button to
+return to the previous view.

--- a/static/base.css
+++ b/static/base.css
@@ -11,6 +11,7 @@
   --accent-color: var(--color-accent);
   --panel-opacity: 0.25;
   --radius: 8px;
+  --navbar-height: 3em;
   --select-bg-color: var(--color-base);
   --select-border-color: var(--color-contrast);
 
@@ -1189,7 +1190,10 @@ body.bg-hidden {
 
 .retrorecon-root .notes-overlay {
   position: fixed;
-  inset: 0;
+  top: var(--navbar-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
   background: rgba(var(--bg-rgb) / 0.95);
   color: var(--fg-color);
   z-index: 1000;


### PR DESCRIPTION
## Summary
- ensure overlays never cover the navbar
- document overlay rules in the style guide

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c96a7381c8332a98a6cbc7b67a2dd