### PR TITLE
Fix OCI Explorer overlay link

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -620,15 +620,15 @@ curl -G --data-urlencode "image=ubuntu:latest" http://localhost:5000/registry_ta
 ```
 Add `insecure=1` to fetch manifests from registries with self-signed certificates.
 
-### `GET /dag_explorer`
-Serve the Dag Explorer overlay.
+### `GET /dag_explorer` (legacy)
+Alias for `/oci_explorer` used by older bookmarks.
 
 ```
 curl http://localhost:5000/dag_explorer
 ```
 
-### `GET /tools/dag_explorer`
-Full-page Dag Explorer overlay.
+### `GET /tools/dag_explorer` (legacy)
+Full-page alias for `/tools/oci_explorer`.
 
 ```
 curl http://localhost:5000/tools/dag_explorer

--- a/docs/dagdotdev_porting_prd.md
+++ b/docs/dagdotdev_porting_prd.md
@@ -23,7 +23,7 @@ The table below lists routes implemented in `dagdotdev` and whether an equivalen
 | `/blob/<digest>` | **No** |
 | `/oauth` | **No** |
 | `/zurl/<digest>` | **No** |
-| *(Retrorecon only)* `/dag_explorer`, `/tools/dag_explorer`, `/dag/repo/<repo>`, `/dag/image/<image>`, `/dag/fs/<digest>/<path>`, `/dag/layer/<digest>` | Not present in `dagdotdev` |
+| *(Retrorecon only)* `/oci_explorer`, `/tools/oci_explorer`, `/dag/repo/<repo>`, `/dag/image/<image>`, `/dag/fs/<digest>/<path>`, `/dag/layer/<digest>` | Not present in `dagdotdev` |
 
 All `dagdotdev` routes are currently missing from Retrorecon, which implements only a minimal explorer.
 

--- a/docs/menu_mapping.md
+++ b/docs/menu_mapping.md
@@ -5,7 +5,7 @@ This table lists each HTML template in the project alongside the dynamic pattern
 | Classic Template | Dynamic Schema / Lambda |
 |------------------|------------------------|
 | _webpack_exploder_form.html | static_html |
-| dag_explorer.html | static_html |
+| registry_explorer.html | static_html |
 | demo.html | static_html |
 | fetching.html | static_html |
 | help_about.html | help_about_page |

--- a/docs/oci_explorer_project_tasks.md
+++ b/docs/oci_explorer_project_tasks.md
@@ -24,7 +24,7 @@ This document breaks down the user story from issue #560 into actionable tasks f
 7. **Performance and Caching**
    - Cache partial tar data so repeated navigation is fast and comparable to https://oci.dag.dev/.
 8. **UI Integration**
-   - Extend the current `dag_explorer` overlay or create new templates as needed.
+   - Extend the current `oci_explorer` overlay or create new templates as needed.
    - Ensure metadata tables can be collapsed and progress indicators show during fetches.
 9. **Documentation and Testing**
    - Document new routes in `docs/api_routes.md` and update the README feature list.

--- a/docs/template_overview.md
+++ b/docs/template_overview.md
@@ -5,7 +5,7 @@ This document catalogs the HTML templates currently present in the repository an
 | Template | Purpose / Unique Features |
 |---------|---------------------------|
 | `_webpack_exploder_form.html` | Standalone form for entering a `.js.map` URL and either listing modules or downloading a ZIP of sources. Used inside the Webpack Exploder tool. |
-| `dag_explorer.html` | Overlay for browsing OCI image manifests and layer contents. Provides example links and fetches tags or manifests on demand. |
+| `registry_explorer.html` | Overlay for browsing OCI image manifests and layer contents. Provides example links and fetches tags or manifests on demand. |
 | `fetching.html` | Simple progress page polling the server while CDX data is imported from the Wayback Machine. Redirects back to `/` when finished. |
 | `index.html` | Main interface listing URLs. Includes search, pagination, menus and the Notes overlay. Loads other overlays like Text Tools and Screenshotter. |
 | `overview.html` | Presents project-level counts and lists subdomains grouped by domain. |

--- a/retrorecon/routes/oci.py
+++ b/retrorecon/routes/oci.py
@@ -29,7 +29,7 @@ from layerslayer.utils import human_readable_size
 bp = Blueprint("oci", __name__)
 
 
-@bp.route("/tools/registry_explorer", methods=["GET"])
+@bp.route("/tools/oci_explorer", methods=["GET"])
 def oci_index():
     return dynamic_template("oci_index.html")
 

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -458,13 +458,13 @@ paths:
           description: Successful response
   /dag_explorer:
     get:
-      summary: GET /dag_explorer
+      summary: GET /dag_explorer (legacy)
       responses:
         '200':
           description: Successful response
   /tools/dag_explorer:
     get:
-      summary: GET /tools/dag_explorer
+      summary: GET /tools/dag_explorer (legacy)
       responses:
         '200':
           description: Successful response

--- a/templates/index.html
+++ b/templates/index.html
@@ -204,7 +204,7 @@
             <input id="domain-input" type="hidden" name="domain" />
             <button type="button" class="menu-btn" id="fetch-cdx-btn">Hindsight (CDX API)</button>
           </form>
-          <div class="menu-row"><a href="#" class="menu-btn" id="dag-explorer-link">OCI Explorer</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="oci-explorer-link">OCI Explorer</a></div>
           <div class="menu-header">Active Recon</div>
           <div class="menu-row"><a href="#" class="menu-btn" id="screenshot-link">Screenshotter</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="httpolaroid-link">HTTPolaroid</a></div>
@@ -1303,52 +1303,21 @@
         showRegistryViewer(true);
       }
 
-      const dagLink = document.getElementById('dag-explorer-link');
-      let dagLoaded = false;
-
-      async function showDagExplorer(skipPush){
-        if(!dagLoaded){
-          const resp = await fetch('/dag_explorer');
-          const html = await resp.text();
-          const root = document.querySelector('.retrorecon-root') || document.body;
-          root.insertAdjacentHTML('beforeend', html);
-          const script = document.createElement('script');
-          script.src = '/static/dag_explorer.js';
-          document.body.appendChild(script);
-          dagLoaded = true;
-        }
-        document.getElementById('dag-explorer-overlay').classList.remove('hidden');
-        if(!skipPush){
-          history.pushState({tool:'dag'}, '', '/tools/dag_explorer');
-        }
-      }
-
-      function hideDagExplorer(){
-        const ov = document.getElementById('dag-explorer-overlay');
-        if(ov) ov.classList.add('hidden');
-      }
-
-      if(dagLink){
-        dagLink.addEventListener('click', async (e) => {
+      const ociLink = document.getElementById('oci-explorer-link');
+      if(ociLink){
+        ociLink.addEventListener('click', async (e) => {
           e.preventDefault();
-          showDagExplorer();
+          showRegistryViewer();
         });
       }
 
       window.addEventListener('popstate', () => {
         if(location.pathname === '/tools/oci_explorer'){
           showRegistryViewer(true);
-        } else if(location.pathname === '/tools/dag_explorer'){
-          showDagExplorer(true);
         } else {
           hideRegistryViewer();
-          hideDagExplorer();
         }
       });
-
-      if(location.pathname === '/tools/dag_explorer' || openTool === 'dag'){
-        showDagExplorer(true);
-      }
 
       const helpReadmeLink = document.getElementById('help-readme-link');
       let helpReadmeLoaded = false;


### PR DESCRIPTION
## Summary
- route `/tools/oci_explorer` correctly in `oci` blueprint
- open OCI Explorer overlay via `oci-explorer-link`
- update docs and OpenAPI to prefer OCI Explorer

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c972ddecc8332b0dba8f8e672ff0e