### PR TITLE
Fix Subdomonster overlay layout

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -53,6 +53,7 @@ body {
 
 .retrorecon-root .mt-1 { margin-top: 1em; }
 .retrorecon-root .mt-05 { margin-top: 0.5em; }
+.retrorecon-root .mb-05 { margin-bottom: 0.5em; }
 .retrorecon-root .ml-1 { margin-left: 1em; }
 .retrorecon-root .ml-05 { margin-left: 0.5em; }
 .retrorecon-root .ml-4px { margin-left: 4px; }

--- a/static/tools.css
+++ b/static/tools.css
@@ -115,7 +115,8 @@
   width: 120px;
 }
 .retrorecon-root #subdomonster-overlay {
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 .retrorecon-root #subdomonster-table {
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- add missing `.mb-05` margin utility
- allow the Subdomonster overlay to scroll vertically

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685caadbfe848332813a4f7f2930fcef