### PR TITLE
Fix missing tool templates

### DIFF
--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -1,0 +1,18 @@
+<div id="jwt-tools-overlay" class="notes-overlay hidden">
+  <textarea id="jwt-tool-input" class="form-input notes-textarea" rows="6"></textarea>
+  <div class="mt-05">
+    <input type="text" id="jwt-secret" class="form-input mr-05 w-10em" placeholder="secret" />
+    <button type="button" class="btn" id="jwt-decode-btn">Decode</button>
+    <button type="button" class="btn" id="jwt-encode-btn">Encode</button>
+    <button type="button" class="btn" id="jwt-copy-btn">Copy</button>
+    <button type="button" class="btn" id="jwt-save-btn">Save As</button>
+    <button type="button" class="btn" id="jwt-clear-btn">Clear</button>
+    <button type="button" class="btn" id="jwt-close-btn">Close</button>
+  </div>
+  <div class="mt-05">
+    <button type="button" class="btn btn--small" id="jwt-delete-btn">Delete</button>
+    <button type="button" class="btn btn--small" id="jwt-export-btn">Export</button>
+    <button type="button" class="btn btn--small" id="jwt-edit-btn">Edit</button>
+  </div>
+  <div id="jwt-cookie-jar" class="mt-05"></div>
+</div>

--- a/templates/registry_explorer.html
+++ b/templates/registry_explorer.html
@@ -1,0 +1,18 @@
+<div id="registry-explorer-overlay" class="notes-overlay hidden">
+  <div class="mb-05">
+    <input type="text" id="registry-image" class="form-input mr-05 w-20em" placeholder="ubuntu:latest" />
+    <label class="mr-05"><input type="checkbox" name="registry-method" value="extension" class="form-checkbox" checked /> Extension</label>
+    <label class="mr-05"><input type="checkbox" name="registry-method" value="layerslayer" class="form-checkbox" /> Layerslayer</label>
+    <label class="mr-05"><input type="checkbox" id="registry-insecure" class="form-checkbox" /> Insecure</label>
+    <button type="button" class="btn" id="registry-fetch-btn">Fetch</button>
+    <button type="button" class="btn" id="registry-close-btn">Close</button>
+  </div>
+  <div class="mb-05">
+    <button type="button" class="btn btn--small" id="registry-add-bookmark-btn">Add Bookmark</button>
+    <table class="table url-table mt-05" id="registry-bookmark-table">
+      <tbody id="registry-bookmark-table-body"></tbody>
+    </table>
+  </div>
+  <div id="registry-info" class="mt-05"></div>
+  <div id="registry-table" class="mt-05"></div>
+</div>

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -1,0 +1,13 @@
+<div id="text-tools-overlay" class="notes-overlay hidden">
+  <textarea id="text-tool-input" class="form-input notes-textarea" rows="6"></textarea>
+  <div class="mt-05">
+    <button type="button" class="btn" id="b64-decode-btn">Base64 Decode</button>
+    <button type="button" class="btn" id="b64-encode-btn">Base64 Encode</button>
+    <button type="button" class="btn" id="url-decode-btn">URL Decode</button>
+    <button type="button" class="btn" id="url-encode-btn">URL Encode</button>
+    <button type="button" class="btn" id="text-copy-btn">Copy</button>
+    <button type="button" class="btn" id="text-save-btn">Save As</button>
+    <button type="button" class="btn" id="text-save-note-btn">Save Note</button>
+    <button type="button" class="btn" id="text-tools-close-btn">Close</button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add HTML overlays for Text Tools, JWT Tools, and OCI Explorer

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cad523b3c833290cb4b422e21d4bc