### PR TITLE
Fix issue #697: reorganize JWT Tools overlay

### DIFF
--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -1,18 +1,17 @@
 <div id="jwt-tools-overlay" class="notes-overlay hidden">
   <textarea id="jwt-tool-input" class="form-input notes-textarea" rows="6"></textarea>
+  <button type="button" class="btn overlay-close-btn" id="jwt-close-btn"><mark>Close</mark></button>
   <div class="mt-05">
     <input type="text" id="jwt-secret" class="form-input mr-05 w-10em" placeholder="secret" />
     <button type="button" class="btn" id="jwt-decode-btn">Decode</button>
     <button type="button" class="btn" id="jwt-encode-btn">Encode</button>
     <button type="button" class="btn" id="jwt-copy-btn">Copy</button>
-    <button type="button" class="btn" id="jwt-save-btn">Save As</button>
     <button type="button" class="btn" id="jwt-clear-btn">Clear</button>
-    <button type="button" class="btn" id="jwt-close-btn">Close</button>
   </div>
+  <div id="jwt-cookie-jar" class="mt-05"></div>
   <div class="mt-05">
     <button type="button" class="btn btn--small" id="jwt-delete-btn">Delete</button>
     <button type="button" class="btn btn--small" id="jwt-export-btn">Export</button>
     <button type="button" class="btn btn--small" id="jwt-edit-btn">Edit</button>
   </div>
-  <div id="jwt-cookie-jar" class="mt-05"></div>
 </div>


### PR DESCRIPTION
## Summary
- update `jwt_tools.html` layout
- remove Save As option
- move management buttons below the results table
- add a close button that floats in the overlay corner

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cb3c071f083328f658543f10cceb0