### PR TITLE
Fix text tools overlay layout

### DIFF
--- a/static/text_tools.js
+++ b/static/text_tools.js
@@ -84,7 +84,14 @@ function initTextTools(){
     });
   });
 
-  closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+  closeBtn.addEventListener('click', () => {
+    if(typeof hideTextTools === 'function'){
+      hideTextTools();
+    } else {
+      overlay.classList.add('hidden');
+      document.body.style.overflow = '';
+    }
+  });
 }
 
 if(document.readyState === 'loading'){

--- a/static/tools.css
+++ b/static/tools.css
@@ -53,6 +53,9 @@
 .retrorecon-root #text-tools-overlay .btn {
   margin-right: 0.25em;
 }
+.retrorecon-root .emoji-badge {
+  margin-right: 0.25em;
+}
 
 /* JWT Tools overlay */
 .retrorecon-root #jwt-tools-overlay .btn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -925,6 +925,7 @@
           textToolsLoaded = true;
         }
         document.getElementById('text-tools-overlay').classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
         if(!skipPush){
           history.pushState({tool:'text'}, '', '/tools/text_tools');
         }
@@ -933,6 +934,7 @@
       function hideTextTools(){
         const ov = document.getElementById('text-tools-overlay');
         if(ov) ov.classList.add('hidden');
+        document.body.style.overflow = '';
       }
 
       if (textToolsLink) {

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -1,13 +1,13 @@
 <div id="text-tools-overlay" class="notes-overlay hidden">
+  <button type="button" class="btn overlay-close-btn" id="text-tools-close-btn"><mark>Close</mark></button>
   <textarea id="text-tool-input" class="form-input notes-textarea" rows="6"></textarea>
   <div class="mt-05">
-    <button type="button" class="btn" id="b64-decode-btn">Base64 Decode</button>
-    <button type="button" class="btn" id="b64-encode-btn">Base64 Encode</button>
-    <button type="button" class="btn" id="url-decode-btn">URL Decode</button>
-    <button type="button" class="btn" id="url-encode-btn">URL Encode</button>
-    <button type="button" class="btn" id="text-copy-btn">Copy</button>
-    <button type="button" class="btn" id="text-save-btn">Save As</button>
-    <button type="button" class="btn" id="text-save-note-btn">Save Note</button>
-    <button type="button" class="btn" id="text-tools-close-btn">Close</button>
+    <button type="button" class="btn" id="b64-decode-btn"><span class="emoji-badge" aria-hidden="true">🔓</span>Base64 Decode</button>
+    <button type="button" class="btn" id="b64-encode-btn"><span class="emoji-badge" aria-hidden="true">🔒</span>Base64 Encode</button>
+    <button type="button" class="btn" id="url-decode-btn"><span class="emoji-badge" aria-hidden="true">🡇</span>URL Decode</button>
+    <button type="button" class="btn" id="url-encode-btn"><span class="emoji-badge" aria-hidden="true">🡅</span>URL Encode</button>
+    <button type="button" class="btn" id="text-copy-btn"><span class="emoji-badge" aria-hidden="true">📋</span>Copy</button>
+    <button type="button" class="btn" id="text-save-btn"><span class="emoji-badge" aria-hidden="true">💾</span>Save As</button>
+    <button type="button" class="btn" id="text-save-note-btn"><span class="emoji-badge" aria-hidden="true">📝</span>Save Note</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- move close button to overlay top right
- prevent background scroll when text tools is open
- add emoji badges in text tools buttons

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cb5118f088332acae8b39e4c21bc5