### PR TITLE
Fix navbar overlay issue

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -365,6 +365,9 @@ body {
   align-items: center;
   margin: 0 10px;
   width: 100%;
+  position: sticky;
+  top: 0;
+  z-index: 1100;
   background: rgb(var(--bg-rgb)/var(--panel-opacity));
   border-radius: var(--radius);
 }


### PR DESCRIPTION
## Summary
- keep the navbar visible when tool overlays are open

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cb58645e08332bd3fb7585384cd2c