### PR TITLE
Fix JWT overlay close button

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -53,6 +53,7 @@ body {
 
 .retrorecon-root .mt-1 { margin-top: 1em; }
 .retrorecon-root .mt-05 { margin-top: 0.5em; }
+.retrorecon-root .mt-2 { margin-top: 2em; }
 .retrorecon-root .mb-05 { margin-bottom: 0.5em; }
 .retrorecon-root .ml-1 { margin-left: 1em; }
 .retrorecon-root .ml-05 { margin-left: 0.5em; }

--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -1,6 +1,6 @@
 <div id="jwt-tools-overlay" class="notes-overlay hidden">
-  <textarea id="jwt-tool-input" class="form-input notes-textarea" rows="6"></textarea>
   <button type="button" class="btn overlay-close-btn" id="jwt-close-btn"><mark>Close</mark></button>
+  <textarea id="jwt-tool-input" class="form-input notes-textarea mt-2" rows="6"></textarea>
   <div class="mt-05">
     <input type="text" id="jwt-secret" class="form-input mr-05 w-10em" placeholder="secret" />
     <button type="button" class="btn" id="jwt-decode-btn">Decode</button>


### PR DESCRIPTION
## Summary
- ensure JWT overlay close button isn't blocked
- add `mt-2` spacing utility

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7c72d6d08332b4537d29d624d09d