### PR TITLE
Fix JWT tools close button

### DIFF
--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -193,9 +193,13 @@ function initJWTTools(){
   });
 
   closeBtn.addEventListener('click', () => {
-    overlay.classList.add('hidden');
-    if(location.pathname === '/tools/jwt'){
-      history.pushState({}, '', '/');
+    if(typeof hideJwtTools === 'function'){
+      hideJwtTools();
+    }else{
+      overlay.classList.add('hidden');
+      if(location.pathname === '/tools/jwt'){
+        history.pushState({}, '', '/');
+      }
     }
   });
 

--- a/templates/jwt_tools.html
+++ b/templates/jwt_tools.html
@@ -1,5 +1,5 @@
 <div id="jwt-tools-overlay" class="notes-overlay hidden">
-  <button type="button" class="btn overlay-close-btn" id="jwt-close-btn"><mark>Close</mark></button>
+  <button type="button" class="btn overlay-close-btn" id="jwt-close-btn">Close</button>
   <textarea id="jwt-tool-input" class="form-input notes-textarea mt-2" rows="6"></textarea>
   <div class="mt-05">
     <input type="text" id="jwt-secret" class="form-input mr-05 w-10em" placeholder="secret" />


### PR DESCRIPTION
## Summary
- fix JWT tools close button
- remove `<mark>` around the close button label

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_685d8cf3fe508332b3b16e866f6381c8