### PR TITLE
Fix JWT close button event

### DIFF
--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -181,11 +181,13 @@ function initJWTTools(){
     }
   });
 
-  saveBtn.addEventListener('click', () => {
-    const blob=new Blob([input.value],{type:'text/plain'});
-    const url=URL.createObjectURL(blob);
-    const a=document.createElement('a');a.href=url;a.download='jwt.txt';document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);
-  });
+  if(saveBtn){
+    saveBtn.addEventListener('click', () => {
+      const blob=new Blob([input.value],{type:'text/plain'});
+      const url=URL.createObjectURL(blob);
+      const a=document.createElement('a');a.href=url;a.download='jwt.txt';document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);
+    });
+  }
 
   clearBtn.addEventListener('click', () => {
     input.value = '';


### PR DESCRIPTION
## Summary
- avoid crash if jwt-save-btn is missing

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d90bcb5f08332a61f4767fc5780a1