### PR TITLE
Fix Text Tools button styles

### DIFF
--- a/static/tools.css
+++ b/static/tools.css
@@ -55,6 +55,7 @@
 }
 .retrorecon-root .emoji-badge {
   margin-right: 0.25em;
+  vertical-align: middle;
 }
 
 /* JWT Tools overlay */

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -1,5 +1,5 @@
 <div id="text-tools-overlay" class="notes-overlay hidden">
-  <button type="button" class="btn overlay-close-btn" id="text-tools-close-btn"><mark>Close</mark></button>
+  <button type="button" class="btn overlay-close-btn" id="text-tools-close-btn">Close</button>
   <textarea id="text-tool-input" class="form-input notes-textarea" rows="6"></textarea>
   <div class="mt-05">
     <button type="button" class="btn" id="b64-decode-btn"><span class="emoji-badge" aria-hidden="true">🔓</span>Base64 Decode</button>


### PR DESCRIPTION
## Summary
- style Text Tools close button like other overlays
- align emoji icons in button labels

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d99b9784c8332bcf4f92d9f32f0c8