### PR TITLE
Fix text tools input spacing

### DIFF
--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -1,6 +1,6 @@
 <div id="text-tools-overlay" class="notes-overlay hidden">
   <button type="button" class="btn overlay-close-btn" id="text-tools-close-btn">Close</button>
-  <textarea id="text-tool-input" class="form-input notes-textarea" rows="6"></textarea>
+  <textarea id="text-tool-input" class="form-input notes-textarea mt-2" rows="6"></textarea>
   <div class="mt-05">
     <button type="button" class="btn" id="b64-decode-btn"><span class="emoji-badge" aria-hidden="true">🔓</span>Base64 Decode</button>
     <button type="button" class="btn" id="b64-encode-btn"><span class="emoji-badge" aria-hidden="true">🔒</span>Base64 Encode</button>


### PR DESCRIPTION
## Summary
- shift text input down in Text Tools overlay

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da5ecf13883329603a4e4d3ddd475