### PR TITLE
Fix OCI Tools menu close button placement

### DIFF
--- a/templates/registry_explorer.html
+++ b/templates/registry_explorer.html
@@ -1,11 +1,11 @@
 <div id="registry-explorer-overlay" class="notes-overlay hidden">
+  <button type="button" class="btn overlay-close-btn" id="registry-close-btn">Close</button>
   <div class="mb-05">
     <input type="text" id="registry-image" class="form-input mr-05 w-20em" placeholder="ubuntu:latest" />
     <label class="mr-05"><input type="checkbox" name="registry-method" value="extension" class="form-checkbox" checked /> Extension</label>
     <label class="mr-05"><input type="checkbox" name="registry-method" value="layerslayer" class="form-checkbox" /> Layerslayer</label>
     <label class="mr-05"><input type="checkbox" id="registry-insecure" class="form-checkbox" /> Insecure</label>
     <button type="button" class="btn" id="registry-fetch-btn">Fetch</button>
-    <button type="button" class="btn" id="registry-close-btn">Close</button>
   </div>
   <div class="mb-05">
     <button type="button" class="btn btn--small" id="registry-add-bookmark-btn">Add Bookmark</button>


### PR DESCRIPTION
## Summary
- move the OCI registry explorer close button to the top-right corner
- keep other form controls unchanged

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db644eb408332a2b7ae201c615e5a