### PR TITLE
Simplify OCI explorer logic

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -610,8 +610,6 @@ Query manifest information for an image.
 curl -G --data-urlencode "image=ubuntu:latest" http://localhost:5000/oci_explorer_api
 ```
 
-Pass `insecure=1` to disable TLS validation or when connecting to self-signed registries.
-
 ### `GET /registry_table`
 Return manifest details as a hierarchical table structure.
 

--- a/retrorecon/routes/oci_explorer.py
+++ b/retrorecon/routes/oci_explorer.py
@@ -27,65 +27,45 @@ def oci_explorer_full_page():
 def oci_explorer_route():
     image = request.args.get('image')
     files_flag = request.args.get('files', 'false').lower() in {'1', 'true', 'yes'}
-    insecure_flag = request.args.get('insecure', 'false').lower() in {'1', 'true', 'yes'}
-    methods_param = request.args.get('methods')
-    if methods_param:
-        methods = [m.strip() for m in methods_param.split(',') if m.strip()]
-    else:
-        methods = [request.args.get('method', 'extension')]
     if not image:
         return jsonify({'error': 'missing_image'}), 400
 
     addr_type = rex.detect_address_type(image)
 
-    async def _gather(insecure: bool):
-        if len(methods) == 1:
-            return await rex.gather_image_info_with_backend(
-                image, methods[0], fetch_files=files_flag, insecure=insecure
-            )
-        return await rex.gather_image_info_multi(
-            image, methods, fetch_files=files_flag, insecure=insecure
+    async def _gather(method: str):
+        return await rex.gather_image_info_with_backend(
+            image, method, fetch_files=files_flag, insecure=True
         )
 
-    async def _digest(insecure: bool) -> str | None:
-        return await rex.get_manifest_digest(image, insecure=insecure)
+    async def _digest() -> str | None:
+        return await rex.get_manifest_digest(image, insecure=True)
 
     try:
-        data = asyncio.run(_gather(insecure_flag))
-        digest = asyncio.run(_digest(insecure_flag))
+        try:
+            data = asyncio.run(_gather('extension'))
+            method_used = 'extension'
+        except Exception:
+            data = asyncio.run(_gather('layerslayer'))
+            method_used = 'layerslayer'
+        digest = asyncio.run(_digest())
     except asyncio.TimeoutError:
         return jsonify({'error': 'timeout'}), 504
-    except ClientConnectorCertificateError:
-        if not insecure_flag:
-            try:
-                data = asyncio.run(_gather(True))
-                digest = asyncio.run(_digest(True))
-                insecure_flag = True
-            except Exception as exc:
-                return jsonify({'error': 'client_error', 'details': str(exc)}), 502
-        else:
-            return jsonify({'error': 'client_error', 'details': 'ssl_error'}), 502
     except ClientError as exc:
         return jsonify({'error': 'client_error', 'details': str(exc)}), 502
     except Exception as exc:
         return jsonify({'error': 'server_error', 'details': str(exc)}), 500
 
     owner, repo, tag = parse_image_ref(image)
-    result = {
+    return jsonify({
         'owner': owner,
         'repo': repo,
         'tag': tag,
         'manifest': digest,
         'addressType': addr_type,
-        'insecure': insecure_flag,
-    }
-    if len(methods) == 1:
-        result['method'] = methods[0]
-        result['platforms'] = data
-    else:
-        result['methods'] = methods
-        result['results'] = data
-    return jsonify(result)
+        'insecure': True,
+        'method': method_used,
+        'platforms': data,
+    })
 
 
 @bp.route('/oci_table', methods=['GET'])

--- a/static/oci_explorer.js
+++ b/static/oci_explorer.js
@@ -3,8 +3,6 @@ function initRegistryExplorer(){
   const overlay = document.getElementById('registry-explorer-overlay');
   if(!overlay) return;
   const imageInput = document.getElementById('registry-image');
-  const methodChecks = overlay.querySelectorAll('input[name="registry-method"]');
-  const insecureCheck = document.getElementById('registry-insecure');
   const fetchBtn = document.getElementById('registry-fetch-btn');
   const closeBtn = document.getElementById('registry-close-btn');
   const tableDiv = document.getElementById('registry-table');
@@ -144,8 +142,7 @@ function initRegistryExplorer(){
     infoDiv.innerHTML = `Owner: <a href="${ownerUrl}" target="_blank">${data.owner}</a> | `+
                         `Image: <a href="${repoUrl}" target="_blank">${data.repo}</a> | `+
                         `Tag: <a href="${repoUrl}" target="_blank">${data.tag}</a> | `+
-                        `Manifest: <a href="${manifestUrl}" target="_blank">${data.manifest}</a>`+
-                        (data.insecure ? ' (insecure)' : '');
+                        `Manifest: <a href="${manifestUrl}" target="_blank">${data.manifest}</a>`;
     let html = '';
     const imgRef = `${data.owner}/${data.repo}:${data.tag}`;
     if(data.results){
@@ -205,16 +202,7 @@ function initRegistryExplorer(){
   fetchBtn.addEventListener('click', async () => {
     const img = imageInput.value.trim();
     if(!img) return;
-    const methods = Array.from(methodChecks).filter(c=>c.checked).map(c=>c.value);
-    let url = '/oci_explorer_api?image=' + encodeURIComponent(img);
-    if(methods.length === 1){
-      url += '&method=' + encodeURIComponent(methods[0]);
-    }else if(methods.length > 1){
-      url += '&methods=' + methods.map(encodeURIComponent).join(',');
-    }
-    if(insecureCheck && insecureCheck.checked){
-      url += '&insecure=1';
-    }
+    const url = '/oci_explorer_api?image=' + encodeURIComponent(img);
     fetchBtn.disabled = true;
     const oldText = fetchBtn.textContent;
     fetchBtn.textContent = 'Fetching...';

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -453,12 +453,6 @@ paths:
   /oci_explorer_api:
     get:
       summary: GET /oci_explorer_api
-      parameters:
-        - in: query
-          name: insecure
-          schema:
-            type: boolean
-          description: Disable TLS verification
       responses:
         '200':
           description: Successful response

--- a/templates/registry_explorer.html
+++ b/templates/registry_explorer.html
@@ -1,9 +1,6 @@
 <div id="registry-explorer-overlay" class="notes-overlay hidden">
   <div class="mb-05">
     <input type="text" id="registry-image" class="form-input mr-05 w-20em" placeholder="ubuntu:latest" />
-    <label class="mr-05"><input type="checkbox" name="registry-method" value="extension" class="form-checkbox" checked /> Extension</label>
-    <label class="mr-05"><input type="checkbox" name="registry-method" value="layerslayer" class="form-checkbox" /> Layerslayer</label>
-    <label class="mr-05"><input type="checkbox" id="registry-insecure" class="form-checkbox" /> Insecure</label>
     <button type="button" class="btn" id="registry-fetch-btn">Fetch</button>
     <button type="button" class="btn" id="registry-close-btn">Close</button>
   </div>


### PR DESCRIPTION
## Summary
- remove method/insecure options from registry explorer UI
- attempt extension first then fallback to layerslayer in the backend
- default to insecure connections
- update docs and OpenAPI spec

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685db65ba9348332a8254c4aeb90b5a5