### PR TITLE
Enable closing overlays via ESC key

### DIFF
--- a/static/dag_explorer.js
+++ b/static/dag_explorer.js
@@ -300,6 +300,11 @@ function initDagExplorer(){
     overlay.classList.add('hidden');
     if(location.pathname === '/tools/dag_explorer'){ history.pushState({}, '', '/'); }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 }
 
 if(document.readyState==='loading'){

--- a/static/demo.js
+++ b/static/demo.js
@@ -46,6 +46,11 @@ function initDemo(){
       history.pushState({}, '', '/');
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 }
 if(document.readyState==='loading'){
   document.addEventListener('DOMContentLoaded', initDemo);

--- a/static/help_about.js
+++ b/static/help_about.js
@@ -8,6 +8,11 @@ function initHelpAbout(){
       history.pushState({}, '', '/');
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 }
 if(document.readyState==='loading'){
   document.addEventListener('DOMContentLoaded', initHelpAbout);

--- a/static/help_readme.js
+++ b/static/help_readme.js
@@ -9,6 +9,11 @@ function initHelpReadme(){
       history.pushState({}, '', '/');
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
   backBtn.addEventListener('click', () => {
     overlay.scrollTo({top:0, behavior:'smooth'});
   });

--- a/static/httpolaroid.js
+++ b/static/httpolaroid.js
@@ -184,6 +184,11 @@ function initHttpolaroid(){
       history.pushState({}, '', '/');
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 
   loadRows();
 }

--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -205,6 +205,11 @@ function initJWTTools(){
         }
       }
     });
+    document.addEventListener('keydown', (e) => {
+      if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+        closeBtn.click();
+      }
+    });
   }
 
   function getSelected(){

--- a/static/layerpeek.js
+++ b/static/layerpeek.js
@@ -162,6 +162,11 @@ function initLayerpeek(){
       history.pushState({}, '', '/');
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 }
 
 if(document.readyState==='loading'){

--- a/static/oci_explorer.js
+++ b/static/oci_explorer.js
@@ -224,6 +224,11 @@ function initRegistryExplorer(){
       history.pushState({}, '', '/');
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 }
 
 if(document.readyState==='loading'){

--- a/static/screenshotter.js
+++ b/static/screenshotter.js
@@ -161,6 +161,11 @@ function initScreenshotter(){
       history.pushState({}, '', '/');
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 
   if(toggleBtn){
     toggleBtn.addEventListener('click', () => {

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -514,6 +514,11 @@ function initSubdomonster(){
   closeBtn.addEventListener('click', () => {
     history.back();
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 
   if(tableData.length){
     render();

--- a/static/text_tools.js
+++ b/static/text_tools.js
@@ -92,6 +92,11 @@ function initTextTools(){
       document.body.style.overflow = '';
     }
   });
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
 }
 
 if(document.readyState === 'loading'){

--- a/templates/index.html
+++ b/templates/index.html
@@ -454,6 +454,11 @@
     });
 
     noteCloseBtn.addEventListener('click', () => { notesOverlay.classList.add('hidden'); });
+    document.addEventListener('keydown', (e) => {
+      if(e.key === 'Escape' && !notesOverlay.classList.contains('hidden')){
+        noteCloseBtn.click();
+      }
+    });
 
     deleteAllBtn.addEventListener('click', () => {
       if(confirm('Delete all notes?')){


### PR DESCRIPTION
## Summary
- allow pressing ESC to close tool overlays the same as the close button
- add the behaviour for notes overlay on the main page

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbb92a3c48332a42fbc4adf24c1aa