### PR TITLE
Fix tag input height

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -716,6 +716,15 @@ body {
   background: var(--bg-color);
   color: var(--fg-color);
 }
+/* Reduce height of Tagify inputs to avoid tall rows */
+.retrorecon-root .tagify {
+  font-size: 12px !important;
+  min-height: 1.6em;
+}
+.retrorecon-root .tagify__input {
+  padding: 0 4px;
+  line-height: 1.2em;
+}
 /* Bulk action buttons use the generic .btn style */
 .retrorecon-root .bulk-action-btn {
   font-size: 1em;


### PR DESCRIPTION
## Summary
- shrink the Tagify input box height so rows aren't too tall

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685dbe9d1594833281de9a4870d9edb6