### PR TITLE
Add text notes table to Text Tools

### DIFF
--- a/static/text_tools.js
+++ b/static/text_tools.js
@@ -7,10 +7,55 @@ function initTextTools(){
   const copyBtn = document.getElementById('text-copy-btn');
   const saveBtn = document.getElementById('text-save-btn');
   const saveNoteBtn = document.getElementById('text-save-note-btn');
+  const notesList = document.getElementById('text-notes-list');
   const b64DecodeBtn = document.getElementById('b64-decode-btn');
   const b64EncodeBtn = document.getElementById('b64-encode-btn');
   const urlDecodeBtn = document.getElementById('url-decode-btn');
   const urlEncodeBtn = document.getElementById('url-encode-btn');
+
+  let editingId = null;
+
+  function renderNotes(data){
+    if(!notesList) return;
+    notesList.innerHTML = '';
+    data.forEach(n => {
+      const div = document.createElement('div');
+      div.className = 'note-item';
+      const text = document.createElement('span');
+      text.textContent = n.content;
+      div.appendChild(text);
+      const actions = document.createElement('div');
+      actions.className = 'notes-actions';
+      const load = document.createElement('a');
+      load.href = '#';
+      load.className = 'notes-link';
+      load.textContent = 'Load';
+      load.addEventListener('click', e => {
+        e.preventDefault();
+        input.value = n.content;
+        editingId = n.id;
+      });
+      const del = document.createElement('a');
+      del.href = '#';
+      del.className = 'notes-link ml-05';
+      del.textContent = 'Delete';
+      del.addEventListener('click', e => {
+        e.preventDefault();
+        if(confirm('Delete note?')){
+          fetch('/delete_text_note', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({note_id:n.id})}).then(loadNotes);
+        }
+      });
+      actions.appendChild(load);
+      actions.appendChild(del);
+      div.appendChild(actions);
+      notesList.appendChild(div);
+    });
+  }
+
+  function loadNotes(){
+    if(!notesList) return;
+    fetch('/text_notes').then(r=>r.json()).then(renderNotes);
+  }
 
   const initParams = new URLSearchParams(location.search);
   const presetText = initParams.get('text');
@@ -70,14 +115,18 @@ function initTextTools(){
   saveNoteBtn.addEventListener('click', () => {
     const content = input.value.trim();
     if(!content) return;
+    const params = new URLSearchParams({content});
+    if(editingId) params.set('note_id', editingId);
     fetch('/text_notes', {
       method: 'POST',
       headers: {'Content-Type':'application/x-www-form-urlencoded'},
-      body: new URLSearchParams({content})
+      body: params
     }).then(r => {
       if(r.ok){
         saveNoteBtn.textContent = 'Saved!';
         setTimeout(() => { saveNoteBtn.textContent = 'Save Note'; }, 1000);
+        editingId = null;
+        loadNotes();
       } else {
         r.text().then(t => alert(t));
       }
@@ -97,6 +146,9 @@ function initTextTools(){
       closeBtn.click();
     }
   });
+
+  loadNotes();
+  window.loadTextNotes = loadNotes;
 }
 
 if(document.readyState === 'loading'){

--- a/templates/index.html
+++ b/templates/index.html
@@ -895,6 +895,7 @@
           textToolsLoaded = true;
         }
         document.getElementById('text-tools-overlay').classList.remove('hidden');
+        if(window.loadTextNotes) window.loadTextNotes();
         document.body.style.overflow = 'hidden';
         if(!skipPush){
           history.pushState({tool:'text'}, '', '/tools/text_tools');

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -10,4 +10,5 @@
     <button type="button" class="btn" id="text-save-btn"><span class="emoji-badge" aria-hidden="true">💾</span>Save As</button>
     <button type="button" class="btn" id="text-save-note-btn"><span class="emoji-badge" aria-hidden="true">📝</span>Save Note</button>
   </div>
+  <div id="text-notes-list" class="notes-list mt-05"></div>
 </div>


### PR DESCRIPTION
## Summary
- load saved notes whenever Text Tools opens
- show a list of notes and allow loading/deleting them

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685dc43112188332990a2b808e29c2ff