### PR TITLE
Add human-readable timestamp filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ from retrorecon import (
     subdomain_utils,
     status as status_mod,
 )
-from retrorecon.filters import manifest_links, oci_obj, manifest_table
+from retrorecon.filters import manifest_links, oci_obj, manifest_table, wb_timestamp
 
 app = Flask(__name__)
 sys.modules.setdefault('app', sys.modules[__name__])
@@ -63,6 +63,7 @@ app.config.from_object(Config)
 app.add_template_filter(manifest_links, name="manifest_links")
 app.add_template_filter(oci_obj, name="oci_obj")
 app.add_template_filter(manifest_table, name="manifest_table")
+app.add_template_filter(wb_timestamp, name="wb_timestamp")
 
 
 @app.route('/favicon.ico', endpoint='core.favicon_ico')

--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import datetime
 from typing import Any, Dict
 
 from markupsafe import Markup, escape
@@ -13,6 +14,17 @@ _SPEC_LINKS = {
     "application/vnd.docker.image.rootfs.diff.tar.gzip": "https://github.com/opencontainers/image-spec/blob/main/layer.md",
     "application/vnd.docker.container.image.v1+json": "https://github.com/opencontainers/image-spec/blob/main/config.md",
 }
+
+
+def wb_timestamp(ts: str | None) -> str:
+    """Return Wayback timestamp ``ts`` formatted as YYYY-MM-DD HH:MM:SS."""
+    if not ts:
+        return ""
+    try:
+        dt = datetime.datetime.strptime(str(ts), "%Y%m%d%H%M%S")
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return str(ts)
 
 
 def _link_media_type(media_type: str) -> str:

--- a/templates/index.html
+++ b/templates/index.html
@@ -311,7 +311,11 @@
                     <input type="checkbox" class="row-checkbox" name="selected_ids" value="{{ url.id }}" onclick="event.stopPropagation()" />
                   </td>
                   <td class="url-result"><div class="cell-content">{{ url.url }}</div></td>
-                  <td class="text-center"><div class="cell-content">{{ url.timestamp or '-' }}</div></td>
+                  <td class="text-center"><div class="cell-content">
+                    {% if url.timestamp %}
+                    <span title="{{ url.timestamp }}">{{ url.timestamp|wb_timestamp }}</span>
+                    {% else %}-{% endif %}
+                  </div></td>
                   <td class="status text-center {% if url.status_code %}status-{{ (url.status_code|string)[:1] }}{% endif %}"><div class="cell-content">{{ url.status_code if url.status_code else '-' }}</div></td>
                   <td class="text-center"><div class="cell-content">{{ url.mime_type or '-' }}</div></td>
                 </tr>

--- a/tests/test_wb_timestamp.py
+++ b/tests/test_wb_timestamp.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from retrorecon.filters import wb_timestamp
+
+
+def test_wb_timestamp_basic():
+    assert wb_timestamp('20240102030405') == '2024-01-02 03:04:05'
+
+
+def test_wb_timestamp_invalid():
+    assert wb_timestamp('badval') == 'badval'
+    assert wb_timestamp(None) == ''


### PR DESCRIPTION
## Summary
- display CDX timestamps in a readable format
- implement `wb_timestamp` Jinja filter and tests

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc54b5ff88332bf3515a3b9fb9c91