### PR TITLE
Add human-readable timestamp display

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ from retrorecon import (
     subdomain_utils,
     status as status_mod,
 )
-from retrorecon.filters import manifest_links, oci_obj, manifest_table
+from retrorecon.filters import manifest_links, oci_obj, manifest_table, human_ts
 
 app = Flask(__name__)
 sys.modules.setdefault('app', sys.modules[__name__])
@@ -63,6 +63,7 @@ app.config.from_object(Config)
 app.add_template_filter(manifest_links, name="manifest_links")
 app.add_template_filter(oci_obj, name="oci_obj")
 app.add_template_filter(manifest_table, name="manifest_table")
+app.add_template_filter(human_ts, name="human_ts")
 
 
 @app.route('/favicon.ico', endpoint='core.favicon_ico')

--- a/retrorecon/filters.py
+++ b/retrorecon/filters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import datetime
 from typing import Any, Dict
 
 from markupsafe import Markup, escape
@@ -13,6 +14,18 @@ _SPEC_LINKS = {
     "application/vnd.docker.image.rootfs.diff.tar.gzip": "https://github.com/opencontainers/image-spec/blob/main/layer.md",
     "application/vnd.docker.container.image.v1+json": "https://github.com/opencontainers/image-spec/blob/main/config.md",
 }
+
+
+def human_ts(value: Any) -> str:
+    """Return timestamp string *value* in YYYY-MM-DD HH:MM:SS form."""
+    s = str(value or "").strip()
+    if not s or not s.isdigit():
+        return s
+    try:
+        dt = datetime.datetime.strptime(s[:14], "%Y%m%d%H%M%S")
+    except ValueError:
+        return s
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _link_media_type(media_type: str) -> str:

--- a/templates/index.html
+++ b/templates/index.html
@@ -311,7 +311,7 @@
                     <input type="checkbox" class="row-checkbox" name="selected_ids" value="{{ url.id }}" onclick="event.stopPropagation()" />
                   </td>
                   <td class="url-result"><div class="cell-content">{{ url.url }}</div></td>
-                  <td class="text-center"><div class="cell-content">{{ url.timestamp or '-' }}</div></td>
+                  <td class="text-center"><div class="cell-content">{{ url.timestamp|human_ts if url.timestamp else '-' }}</div></td>
                   <td class="status text-center {% if url.status_code %}status-{{ (url.status_code|string)[:1] }}{% endif %}"><div class="cell-content">{{ url.status_code if url.status_code else '-' }}</div></td>
                   <td class="text-center"><div class="cell-content">{{ url.mime_type or '-' }}</div></td>
                 </tr>

--- a/tests/test_human_ts.py
+++ b/tests/test_human_ts.py
@@ -1,0 +1,11 @@
+import app
+from retrorecon.filters import human_ts
+
+
+def test_human_ts_valid():
+    assert human_ts('20240102123456') == '2024-01-02 12:34:56'
+
+
+def test_human_ts_invalid():
+    assert human_ts('') == ''
+    assert human_ts('abcdef') == 'abcdef'


### PR DESCRIPTION
## Summary
- implement `human_ts` Jinja filter
- register the filter with Flask
- render timestamps using the filter
- add unit tests for `human_ts`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc5d9c70c8332ae3acfc48f9d4fc7