### PR TITLE
Add search tag manager overlay

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -163,6 +163,17 @@ Parameter:
 curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/delete_saved_tag
 ```
 
+### `POST /rename_saved_tag`
+Rename an existing saved tag.
+
+Parameters:
+- `old_tag` – current tag name.
+- `new_tag` – new tag value.
+
+```
+curl -X POST -d "old_tag=#foo" -d "new_tag=#bar" http://localhost:5000/rename_saved_tag
+```
+
 ### `POST /tools/webpack-zip`
 Download sources referenced in a Webpack `.js.map` file as a ZIP archive.
 

--- a/retrorecon/routes/notes.py
+++ b/retrorecon/routes/notes.py
@@ -31,6 +31,24 @@ def delete_saved_tag():
         app.save_saved_tags(tags)
     return ('', 204)
 
+@bp.route('/rename_saved_tag', methods=['POST'])
+def rename_saved_tag():
+    old_tag = request.form.get('old_tag', '').strip()
+    new_tag = request.form.get('new_tag', '').strip()
+    if not old_tag or not new_tag:
+        return ('', 400)
+    if not old_tag.startswith('#'):
+        old_tag = '#' + old_tag
+    if not new_tag.startswith('#'):
+        new_tag = '#' + new_tag
+    tags = app.load_saved_tags()
+    if old_tag in tags:
+        tags.remove(old_tag)
+    if new_tag not in tags:
+        tags.append(new_tag)
+    app.save_saved_tags(tags)
+    return ('', 204)
+
 @bp.route('/notes/<int:url_id>', methods=['GET'])
 def notes_get(url_id: int):
     if not app._db_loaded():

--- a/static/base.css
+++ b/static/base.css
@@ -1222,6 +1222,22 @@ body.bg-hidden {
   overflow-y: auto;
   overscroll-behavior: contain;
 }
+.retrorecon-root .tags-overlay {
+  position: fixed;
+  top: var(--navbar-height);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(var(--bg-rgb) / 0.95);
+  color: var(--fg-color);
+  z-index: 1000;
+  box-sizing: border-box;
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
 
 .retrorecon-root .dropdown-shade {
   position: fixed;
@@ -1234,6 +1250,9 @@ body.bg-hidden {
   display: block;
 }
 .retrorecon-root .notes-overlay.hidden {
+  display: none;
+}
+.retrorecon-root .tags-overlay.hidden {
   display: none;
 }
 .retrorecon-root .notes-textarea {

--- a/templates/index.html
+++ b/templates/index.html
@@ -260,6 +260,7 @@
         <div class="search-buttons">
           <button type="submit" class="btn">Search</button>
           <button type="button" id="save-tag-btn" class="btn">Save Tag</button>
+          <button type="button" id="manage-tags-btn" class="btn">Tags…</button>
           <button type="button" class="btn" onclick="document.getElementById('searchbox').value=''; document.getElementById('search-form').submit();">Clear</button>
         </div>
       </div>
@@ -384,6 +385,15 @@
     <div id="notes-list" class="notes-list mt-05"></div>
   </div>
 
+  <div id="tags-overlay" class="notes-overlay hidden">
+    <input type="text" id="tag-manager-input" class="form-input tag-input" placeholder="New tag..." />
+    <div class="mt-05">
+      <button type="button" class="btn" id="tag-add-btn">Add</button>
+      <button type="button" class="btn" id="tag-close-btn">Close</button>
+    </div>
+    <div id="tags-list" class="notes-list mt-05"></div>
+  </div>
+
   <script>
     const totalResultsCount = {{ total_count }};
 
@@ -393,6 +403,11 @@
     const noteSaveBtn = document.getElementById('note-save-btn');
     const noteCloseBtn = document.getElementById('note-close-btn');
     const deleteAllBtn = document.getElementById('delete-all-notes-btn');
+    const tagsOverlay = document.getElementById('tags-overlay');
+    const tagInput = document.getElementById('tag-manager-input');
+    const tagsList = document.getElementById('tags-list');
+    const tagAddBtn = document.getElementById('tag-add-btn');
+    const tagCloseBtn = document.getElementById('tag-close-btn');
     let currentUrlId = null;
     let editingId = null;
 
@@ -462,6 +477,62 @@
     deleteAllBtn.addEventListener('click', () => {
       if(confirm('Delete all notes?')){
         fetch('/delete_note', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({url_id: currentUrlId, all:'1'})}).then(loadNotes);
+      }
+    });
+
+    function renderTags(list){
+      tagsList.innerHTML = '';
+      list.forEach(t => {
+        const div = document.createElement('div');
+        div.className = 'note-item';
+        const span = document.createElement('span');
+        span.textContent = t;
+        div.appendChild(span);
+        const actions = document.createElement('div');
+        actions.className = 'notes-actions';
+        const del = document.createElement('a');
+        del.href = '#';
+        del.className = 'notes-link ml-05';
+        del.textContent = 'Delete';
+        del.addEventListener('click', e => {
+          e.preventDefault();
+          if(confirm('Delete tag?')){
+            fetch('/delete_saved_tag', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:t})}).then(loadTags);
+          }
+        });
+        actions.appendChild(del);
+        div.appendChild(actions);
+        tagsList.appendChild(div);
+      });
+      if(searchTagify) searchTagify.settings.whitelist = list;
+    }
+
+    function loadTags(){
+      fetch('/saved_tags').then(r=>r.json()).then(d=>{
+        const tags = Array.isArray(d.tags) ? d.tags : [];
+        renderTags(tags);
+      });
+    }
+
+    function openTags(){
+      tagInput.value = '';
+      loadTags();
+      tagsOverlay.classList.remove('hidden');
+    }
+
+    tagAddBtn.addEventListener('click', () => {
+      let val = tagInput.value.trim();
+      if(!val) return;
+      if(!val.startsWith('#')) val = '#' + val;
+      fetch('/saved_tags', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:val})})
+        .then(() => { tagInput.value=''; loadTags(); });
+    });
+
+    tagCloseBtn.addEventListener('click', () => { tagsOverlay.classList.add('hidden'); });
+    document.getElementById('manage-tags-btn').addEventListener('click', openTags);
+    document.addEventListener('keydown', e => {
+      if(e.key === 'Escape' && !tagsOverlay.classList.contains('hidden')){
+        tagCloseBtn.click();
       }
     });
 

--- a/tests/test_saved_tags.py
+++ b/tests/test_saved_tags.py
@@ -29,7 +29,12 @@ def test_saved_tag_crud(tmp_path, monkeypatch):
         resp = client.get('/saved_tags')
         assert resp.get_json() == {"tags": ["#foo"]}
 
-        resp = client.post('/delete_saved_tag', data={'tag': 'foo'})
+        resp = client.post('/rename_saved_tag', data={'old_tag': 'foo', 'new_tag': 'bar'})
+        assert resp.status_code == 204
+        resp = client.get('/saved_tags')
+        assert resp.get_json() == {"tags": ["#bar"]}
+
+        resp = client.post('/delete_saved_tag', data={'tag': 'bar'})
         assert resp.status_code == 204
         resp = client.get('/saved_tags')
         assert resp.get_json() == {"tags": []}


### PR DESCRIPTION
## Summary
- let users manage saved search tags via new overlay
- support renaming tags on the backend
- document `/rename_saved_tag` API route
- test new behavior

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc5e57500833294e05750a21c8457