### PR TITLE
Fix Save Tag script

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -312,6 +312,7 @@ body {
   border: 1px solid var(--color-contrast);
   background: var(--bg-color);
   color: var(--fg-color);
+  white-space: nowrap;
   cursor: pointer;
   transition: opacity 0.2s;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
   <link rel="stylesheet" href="{{ url_for('static', filename='tools.css') }}" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
   {% if current_theme %}
   {% if current_theme == 'terminal-sans-dark.css' %}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@latest" />
@@ -1591,7 +1592,6 @@
   if(urlTable) makeResizable(urlTable, 'url-col-widths');
   </script>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
 <script src="{{ url_for('static', filename='index_page.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Tagify earlier so inline script can access it
- keep Save Tag button text on one line

## Testing
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685dc91b85bc8332805d80dd582f293d