### PR TITLE
Implement GitHub-like tag admin sidebar

### DIFF
--- a/retrorecon/routes/notes.py
+++ b/retrorecon/routes/notes.py
@@ -10,6 +10,7 @@ def saved_tags_route():
         return jsonify({'tags': app.load_saved_tags()})
     tag = request.form.get('tag', '').strip()
     color = request.form.get('color', '').strip() or saved_tags_mod.DEFAULT_COLOR
+    desc = request.form.get('desc', '').strip()
     if not tag:
         return ('', 400)
     if not tag.startswith('#'):
@@ -19,7 +20,7 @@ def saved_tags_route():
     tags = app.load_saved_tags()
     names = [t['name'] for t in tags]
     if tag not in names:
-        tags.append({'name': tag, 'color': color})
+        tags.append({'name': tag, 'color': color, 'desc': desc})
         app.save_saved_tags(tags)
     return ('', 204)
 
@@ -41,6 +42,7 @@ def rename_saved_tag():
     old_tag = request.form.get('old_tag', '').strip()
     new_tag = request.form.get('new_tag', '').strip()
     color = request.form.get('color', '').strip()
+    desc = request.form.get('desc', '').strip()
     if not old_tag or not new_tag:
         return ('', 400)
     if not old_tag.startswith('#'):
@@ -56,12 +58,15 @@ def rename_saved_tag():
             t['name'] = new_tag
             if color:
                 t['color'] = color
+            if desc:
+                t['desc'] = desc
             updated = True
     if updated:
-        names = [t['name'] for t in tags]
-        if len(set(names)) != len(names):
-            tags = [dict(name=n, color=c) for n,c in {(t['name'], t['color']) for t in tags}]
-        app.save_saved_tags(tags)
+        unique = {}
+        for t in tags:
+            if t['name'] not in unique:
+                unique[t['name']] = t
+        app.save_saved_tags(list(unique.values()))
     return ('', 204)
 
 @bp.route('/notes/<int:url_id>', methods=['GET'])

--- a/retrorecon/saved_tags.py
+++ b/retrorecon/saved_tags.py
@@ -11,7 +11,7 @@ def load_tags(file_path: str) -> List[Dict[str, str]]:
     """Return saved tag data from ``file_path``.
 
     The file may contain either a list of strings (legacy format) or a list of
-    objects with ``name`` and ``color`` fields.
+    objects with ``name``, ``color`` and optional ``desc`` fields.
     """
     with _TAGS_LOCK:
         if not os.path.exists(file_path):
@@ -25,15 +25,17 @@ def load_tags(file_path: str) -> List[Dict[str, str]]:
                     if isinstance(item, dict):
                         name = str(item.get("name", "")).strip()
                         color = str(item.get("color", DEFAULT_COLOR)).strip() or DEFAULT_COLOR
+                        desc = str(item.get("desc", "")).strip()
                     else:
                         name = str(item).strip()
                         color = DEFAULT_COLOR
+                        desc = ""
                     if name:
                         if not name.startswith("#"):
                             name = "#" + name
                         if not color.startswith("#"):
                             color = "#" + color
-                        result.append({"name": name, "color": color})
+                        result.append({"name": name, "color": color, "desc": desc})
                 return result
         except Exception:
             pass
@@ -43,4 +45,4 @@ def save_tags(file_path: str, tags: List[Dict[str, str]]) -> None:
     """Persist ``tags`` to ``file_path``."""
     with _TAGS_LOCK:
         with open(file_path, 'w') as f:
-            json.dump(tags, f)
+            json.dump(tags, f, indent=2)

--- a/static/base.css
+++ b/static/base.css
@@ -1240,9 +1240,9 @@ body.bg-hidden {
 .retrorecon-root .tags-overlay {
   position: fixed;
   top: var(--navbar-height);
-  left: 0;
   right: 0;
   bottom: 0;
+  width: 20em;
   background: rgba(var(--bg-rgb) / 0.95);
   color: var(--fg-color);
   z-index: 1000;
@@ -1250,8 +1250,13 @@ body.bg-hidden {
   padding: 1em;
   display: flex;
   flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.25s ease-in-out;
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+.retrorecon-root .tags-overlay.show {
+  transform: translateX(0);
 }
 
 .retrorecon-root .dropdown-shade {
@@ -1268,7 +1273,25 @@ body.bg-hidden {
   display: none;
 }
 .retrorecon-root .tags-overlay.hidden {
-  display: none;
+  transform: translateX(100%);
+}
+.retrorecon-root .tag-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.retrorecon-root .tag-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4em;
+}
+.retrorecon-root .tag-item .saved-tag {
+  flex-shrink: 0;
+}
+.retrorecon-root #tag-editor {
+  border-top: 1px solid var(--fg-color);
+  padding-top: 0.5em;
 }
 .retrorecon-root .notes-textarea {
   width: 100%;

--- a/templates/index.html
+++ b/templates/index.html
@@ -390,12 +390,20 @@
     <div id="notes-list" class="notes-list mt-05"></div>
   </div>
 
-  <div id="tags-overlay" class="notes-overlay hidden">
-    <input type="text" id="tag-manager-input" class="form-input tag-input" placeholder="New tag..." />
-    <input type="color" id="tag-color-input" value="#cccccc" class="ml-05" />
-    <div class="mt-05">
-      <button type="button" class="btn" id="tag-add-btn">Add</button>
+  <div id="tags-overlay" class="tags-overlay hidden">
+    <div class="tag-toolbar">
+      <input type="text" id="tag-search-input" class="form-input tag-input" placeholder="Search tags..." />
+      <button type="button" class="btn" id="tag-new-btn">New</button>
       <button type="button" class="btn" id="tag-close-btn">Close</button>
+    </div>
+    <div id="tag-editor" class="mt-05 hidden">
+      <input type="text" id="tag-name-input" class="form-input tag-input" placeholder="Tag name" />
+      <input type="color" id="tag-color-input" value="#cccccc" class="ml-05" />
+      <input type="text" id="tag-desc-input" class="form-input tag-input mt-05" placeholder="Description" />
+      <div class="mt-05">
+        <button type="button" class="btn" id="tag-save-btn">Save</button>
+        <button type="button" class="btn" id="tag-cancel-btn">Cancel</button>
+      </div>
     </div>
     <div id="tags-list" class="notes-list mt-05"></div>
   </div>
@@ -410,11 +418,18 @@
     const noteCloseBtn = document.getElementById('note-close-btn');
     const deleteAllBtn = document.getElementById('delete-all-notes-btn');
     const tagsOverlay = document.getElementById('tags-overlay');
-    const tagInput = document.getElementById('tag-manager-input');
+    const tagSearchInput = document.getElementById('tag-search-input');
+    const tagNameInput = document.getElementById('tag-name-input');
+    const tagDescInput = document.getElementById('tag-desc-input');
     const tagColorInput = document.getElementById('tag-color-input');
+    const tagEditor = document.getElementById('tag-editor');
     const tagsList = document.getElementById('tags-list');
-    const tagAddBtn = document.getElementById('tag-add-btn');
+    const tagSaveBtn = document.getElementById('tag-save-btn');
+    const tagCancelBtn = document.getElementById('tag-cancel-btn');
+    const tagNewBtn = document.getElementById('tag-new-btn');
     const tagCloseBtn = document.getElementById('tag-close-btn');
+    let editingTag = null;
+    let allTags = [];
     let currentUrlId = null;
     let editingId = null;
 
@@ -489,9 +504,10 @@
 
     function renderTags(list){
       tagsList.innerHTML = '';
+      list.sort((a,b)=>a.name.localeCompare(b.name));
       list.forEach(t => {
         const div = document.createElement('div');
-        div.className = 'note-item';
+        div.className = 'tag-item';
         const span = document.createElement('span');
         span.className = 'saved-tag';
         span.textContent = t.name;
@@ -499,6 +515,18 @@
         div.appendChild(span);
         const actions = document.createElement('div');
         actions.className = 'notes-actions';
+        const edit = document.createElement('a');
+        edit.href = '#';
+        edit.className = 'notes-link';
+        edit.textContent = 'Edit';
+        edit.addEventListener('click', e => {
+          e.preventDefault();
+          editingTag = t;
+          tagNameInput.value = t.name;
+          tagColorInput.value = t.color || '#cccccc';
+          tagDescInput.value = t.desc || '';
+          tagEditor.classList.remove('hidden');
+        });
         const del = document.createElement('a');
         del.href = '#';
         del.className = 'notes-link ml-05';
@@ -509,6 +537,7 @@
             fetch('/delete_saved_tag', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:t.name})}).then(loadTags);
           }
         });
+        actions.appendChild(edit);
         actions.appendChild(del);
         div.appendChild(actions);
         tagsList.appendChild(div);
@@ -518,27 +547,52 @@
 
     function loadTags(){
       fetch('/saved_tags').then(r=>r.json()).then(d=>{
-        const tags = Array.isArray(d.tags) ? d.tags : [];
-        renderTags(tags);
+        allTags = Array.isArray(d.tags) ? d.tags : [];
+        applySearch();
       });
     }
 
-    function openTags(){
-      tagInput.value = '';
-      loadTags();
-      tagsOverlay.classList.remove('hidden');
+    function applySearch(){
+      const term = tagSearchInput.value.trim().toLowerCase();
+      const filtered = term ? allTags.filter(t => t.name.toLowerCase().includes(term)) : allTags;
+      renderTags(filtered);
     }
 
-    tagAddBtn.addEventListener('click', () => {
-      let val = tagInput.value.trim();
-      if(!val) return;
-      if(!val.startsWith('#')) val = '#' + val;
-      const params = new URLSearchParams({tag:val, color: tagColorInput.value});
-      fetch('/saved_tags', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:params})
-        .then(() => { tagInput.value=''; loadTags(); });
+    function openTags(){
+      tagEditor.classList.add('hidden');
+      tagSearchInput.value = '';
+      editingTag = null;
+      loadTags();
+      tagsOverlay.classList.remove('hidden');
+      tagsOverlay.classList.add('show');
+    }
+
+    tagSearchInput.addEventListener('input', applySearch);
+
+    tagNewBtn.addEventListener('click', () => {
+      editingTag = null;
+      tagNameInput.value = '';
+      tagColorInput.value = '#cccccc';
+      tagDescInput.value = '';
+      tagEditor.classList.remove('hidden');
     });
 
-    tagCloseBtn.addEventListener('click', () => { tagsOverlay.classList.add('hidden'); });
+    tagSaveBtn.addEventListener('click', () => {
+      const name = tagNameInput.value.trim();
+      if(!name) return;
+      const params = new URLSearchParams({color: tagColorInput.value, desc: tagDescInput.value});
+      if(!name.startsWith('#')) params.set(editingTag ? 'new_tag' : 'tag', '#' + name); else params.set(editingTag ? 'new_tag' : 'tag', name);
+      if(editingTag){
+        params.set('old_tag', editingTag.name);
+        fetch('/rename_saved_tag', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:params}).then(()=>{tagEditor.classList.add('hidden'); loadTags();});
+      }else{
+        fetch('/saved_tags', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:params}).then(()=>{tagEditor.classList.add('hidden'); loadTags();});
+      }
+    });
+
+    tagCancelBtn.addEventListener('click', () => { tagEditor.classList.add('hidden'); });
+
+    tagCloseBtn.addEventListener('click', () => { tagsOverlay.classList.add('hidden'); tagsOverlay.classList.remove('show'); });
     document.getElementById('manage-tags-btn').addEventListener('click', openTags);
     document.addEventListener('keydown', e => {
       if(e.key === 'Escape' && !tagsOverlay.classList.contains('hidden')){

--- a/tests/test_saved_tags.py
+++ b/tests/test_saved_tags.py
@@ -18,21 +18,21 @@ def test_saved_tag_crud(tmp_path, monkeypatch):
         resp = client.get('/saved_tags')
         assert resp.get_json() == {"tags": []}
 
-        resp = client.post('/saved_tags', data={'tag': 'foo', 'color': '#123456'})
+        resp = client.post('/saved_tags', data={'tag': 'foo', 'color': '#123456', 'desc': 'd'})
         assert resp.status_code == 204
         assert (tmp_path / "tags.json").exists()
 
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": [{"name": "#foo", "color": "#123456"}]}
+        assert resp.get_json() == {"tags": [{"name": "#foo", "color": "#123456", "desc": "d"}]}
 
-        client.post('/saved_tags', data={'tag': 'foo', 'color': '#123456'})  # duplicate
+        client.post('/saved_tags', data={'tag': 'foo', 'color': '#123456', 'desc': 'd'})  # duplicate
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": [{"name": "#foo", "color": "#123456"}]}
+        assert resp.get_json() == {"tags": [{"name": "#foo", "color": "#123456", "desc": "d"}]}
 
-        resp = client.post('/rename_saved_tag', data={'old_tag': 'foo', 'new_tag': 'bar', 'color': '#654321'})
+        resp = client.post('/rename_saved_tag', data={'old_tag': 'foo', 'new_tag': 'bar', 'color': '#654321', 'desc': 'e'})
         assert resp.status_code == 204
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": [{"name": "#bar", "color": "#654321"}]}
+        assert resp.get_json() == {"tags": [{"name": "#bar", "color": "#654321", "desc": "e"}]}
 
         resp = client.post('/delete_saved_tag', data={'tag': 'bar'})
         assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- support descriptions when saving tags
- add routes to handle tag descriptions
- rework tag overlay as a sidebar with search & edit capabilities
- adjust styles for new tags sidebar
- update tests

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd9454890833287e817b0b8a8ac13