### PR TITLE
Fix subdomonster input overflow

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -22,7 +22,13 @@ function initSubdomonster(){
       savedTags = arr.map(t => t.name);
       if(searchInput){
         const tagify = new Tagify(searchInput,{mode:'mix',pattern:/#\w+/,whitelist:savedTags});
-        if(tagify.DOM.scopeParent) tagify.DOM.scopeParent.style.width = '20em';
+        if(tagify.DOM.scopeParent){
+          const sp = tagify.DOM.scopeParent;
+          sp.style.width = '20em';
+          sp.style.maxWidth = '50vw';
+          sp.style.whiteSpace = 'nowrap';
+          sp.style.overflowX = 'auto';
+        }
       }
     });
   const sourceSel = document.getElementById('subdomonster-source');
@@ -322,8 +328,15 @@ function initSubdomonster(){
     html += '</tbody></table>';
     tableDiv.innerHTML = html;
     tableDiv.querySelectorAll('.row-tag-input').forEach(el => {
-      new Tagify(el, { maxTags: 1, whitelist: savedTags,
+      const tg = new Tagify(el, { maxTags: 1, whitelist: savedTags,
         originalInputValueFormat: v => v.map(t => t.value).join(',') });
+      if(tg.DOM.scopeParent){
+        const sp = tg.DOM.scopeParent;
+        sp.style.width = '8em';
+        sp.style.maxWidth = '50vw';
+        sp.style.whiteSpace = 'nowrap';
+        sp.style.overflowX = 'auto';
+      }
     });
     const table = tableDiv.querySelector('table');
     const pageCb = document.getElementById('subdom-page-cb');

--- a/static/tools.css
+++ b/static/tools.css
@@ -141,5 +141,11 @@
   overflow: visible;
 }
 
+.retrorecon-root #subdomonster-overlay .tagify {
+  max-width: 50vw;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
 .retrorecon-root #demo-view { flex: 1 1 auto; overflow-y: auto; }
 


### PR DESCRIPTION
## Summary
- prevent subdomonster tag inputs from wrapping
- ensure subdomonster inputs never exceed half the viewport

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ddc731dcc83328dd3dfdd2df40f49