### PR TITLE
Fix subdomonster domain input dimensions

### DIFF
--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -38,7 +38,7 @@ def register_demo_schemas(registry: SchemaRegistry) -> None:
                                     "attrs": {
                                         "type": "text",
                                         "id": "subdomonster-domain",
-                                        "class": "hidden",
+                                        "class": "form-input mr-05 subdomonster-domain-bar",
                                         "placeholder": "example.com",
                                     },
                                 },

--- a/static/tools.css
+++ b/static/tools.css
@@ -162,5 +162,10 @@
   max-width: 50vw;
 }
 
+.retrorecon-root .subdomonster-domain-bar {
+  width: 226px;
+  height: 31px;
+}
+
 .retrorecon-root #demo-view { flex: 1 1 auto; overflow-y: auto; }
 


### PR DESCRIPTION
## Summary
- display the subdomonster domain field
- add CSS class for the domain field size

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685de36018f08332a793112dd0c081a9