### PR TITLE
Fix table column width persistence

### DIFF
--- a/static/col_resize.js
+++ b/static/col_resize.js
@@ -1,0 +1,47 @@
+function makeResizableTable(table, key){
+  if(!table) return;
+  table.style.tableLayout = 'fixed';
+  const ths = table.querySelectorAll('th');
+  const cols = table.querySelectorAll('col');
+  let widths = {};
+  try {
+    widths = JSON.parse(localStorage.getItem(key) || '{}');
+  } catch {}
+  if(Object.keys(widths).length !== ths.length){
+    widths = {};
+  }
+  ths.forEach((th, idx) => {
+    const id = idx;
+    if(widths[id]){
+      th.style.width = widths[id];
+      if(cols[id]) cols[id].style.width = widths[id];
+    }
+    const initial = th.style.width || th.offsetWidth + 'px';
+    th.style.width = initial;
+    if(cols[id]) cols[id].style.width = initial;
+    if(th.classList.contains('no-resize')) return;
+    const res = document.createElement('div');
+    res.className = 'col-resizer';
+    th.appendChild(res);
+    let startX = 0;
+    let startWidth = 0;
+    res.addEventListener('mousedown', e => {
+      startX = e.pageX;
+      startWidth = th.offsetWidth;
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', stop);
+      e.preventDefault();
+    });
+    function onMove(ev){
+      const w = Math.max(30, startWidth + (ev.pageX - startX));
+      th.style.width = w + 'px';
+      if(cols[id]) cols[id].style.width = w + 'px';
+      widths[id] = w + 'px';
+    }
+    function stop(){
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', stop);
+      try{ localStorage.setItem(key, JSON.stringify(widths)); }catch{}
+    }
+  });
+}

--- a/static/httpolaroid.js
+++ b/static/httpolaroid.js
@@ -35,45 +35,9 @@ function initHttpolaroid(){
   }
 
   function makeResizable(table, key){
-    table.style.tableLayout = 'fixed';
-    const ths = table.querySelectorAll('th');
-    const cols = table.querySelectorAll('col');
-    let widths = {};
-    try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
-    ths.forEach((th, idx) => {
-      const id = idx;
-      if(widths[id]){
-        th.style.width = widths[id];
-        if(cols[id]) cols[id].style.width = widths[id];
-      }
-      const initial = th.style.width || th.offsetWidth + 'px';
-      th.style.width = initial;
-      if(cols[id]) cols[id].style.width = initial;
-      if(th.classList.contains('no-resize')) return;
-      const res = document.createElement('div');
-      res.className = 'col-resizer';
-      th.appendChild(res);
-      let startX = 0;
-      let startWidth = 0;
-      res.addEventListener('mousedown', e => {
-        startX = e.pageX;
-        startWidth = th.offsetWidth;
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', stop);
-        e.preventDefault();
-      });
-      function onMove(e){
-        const w = Math.max(30, startWidth + (e.pageX - startX));
-        th.style.width = w + 'px';
-        if(cols[id]) cols[id].style.width = w + 'px';
-        widths[id] = w + 'px';
-      }
-      function stop(){
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', stop);
-        localStorage.setItem(key, JSON.stringify(widths));
-      }
-    });
+    if(typeof makeResizableTable === 'function'){
+      makeResizableTable(table, key);
+    }
   }
 
   function render(){

--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -20,45 +20,9 @@ function initJWTTools(){
   let sortDir = 'desc';
 
   function makeResizable(table, key){
-    table.style.tableLayout = 'fixed';
-    const ths = table.querySelectorAll('th');
-    const cols = table.querySelectorAll('col');
-    let widths = {};
-    try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
-    ths.forEach((th, idx) => {
-      const id = idx;
-      if(widths[id]){
-        th.style.width = widths[id];
-        if(cols[id]) cols[id].style.width = widths[id];
-      }
-      const initial = th.style.width || th.offsetWidth + 'px';
-      th.style.width = initial;
-      if(cols[id]) cols[id].style.width = initial;
-      if(th.classList.contains('no-resize')) return;
-      const res = document.createElement('div');
-      res.className = 'col-resizer';
-      th.appendChild(res);
-      let startX = 0;
-      let startWidth = 0;
-      res.addEventListener('mousedown', e => {
-        startX = e.pageX;
-        startWidth = th.offsetWidth;
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', stop);
-        e.preventDefault();
-      });
-      function onMove(e){
-        const w = Math.max(30, startWidth + (e.pageX - startX));
-        th.style.width = w + 'px';
-        if(cols[id]) cols[id].style.width = w + 'px';
-        widths[id] = w + 'px';
-      }
-      function stop(){
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', stop);
-        localStorage.setItem(key, JSON.stringify(widths));
-      }
-    });
+    if(typeof makeResizableTable === 'function'){
+      makeResizableTable(table, key);
+    }
   }
 
   function renderJar(){

--- a/static/layerpeek.js
+++ b/static/layerpeek.js
@@ -44,45 +44,9 @@ function initLayerpeek(){
   }
 
   function makeResizable(table, key){
-    table.style.tableLayout = 'fixed';
-    const ths = table.querySelectorAll('th');
-    const cols = table.querySelectorAll('col');
-    let widths = {};
-    try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
-    ths.forEach((th, idx) => {
-      const id = idx;
-      if(widths[id]){
-        th.style.width = widths[id];
-        if(cols[id]) cols[id].style.width = widths[id];
-      }
-      const initial = th.style.width || th.offsetWidth + 'px';
-      th.style.width = initial;
-      if(cols[id]) cols[id].style.width = initial;
-      if(th.classList.contains('no-resize')) return;
-      const res = document.createElement('div');
-      res.className = 'col-resizer';
-      th.appendChild(res);
-      let startX = 0;
-      let startWidth = 0;
-      res.addEventListener('mousedown', e => {
-        startX = e.pageX;
-        startWidth = th.offsetWidth;
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', stop);
-        e.preventDefault();
-      });
-      function onMove(e){
-        const w = Math.max(30, startWidth + (e.pageX - startX));
-        th.style.width = w + 'px';
-        if(cols[id]) cols[id].style.width = w + 'px';
-        widths[id] = w + 'px';
-      }
-      function stop(){
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', stop);
-        localStorage.setItem(key, JSON.stringify(widths));
-      }
-    });
+    if(typeof makeResizableTable === 'function'){
+      makeResizableTable(table, key);
+    }
   }
 
   function render(data){

--- a/static/oci_explorer.js
+++ b/static/oci_explorer.js
@@ -32,45 +32,9 @@ function initRegistryExplorer(){
   }
 
   function makeResizable(table, key){
-    table.style.tableLayout = 'fixed';
-    const ths = table.querySelectorAll('th');
-    const cols = table.querySelectorAll('col');
-    let widths = {};
-    try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
-    ths.forEach((th, idx) => {
-      const id = idx;
-      if(widths[id]){
-        th.style.width = widths[id];
-        if(cols[id]) cols[id].style.width = widths[id];
-      }
-      const initial = th.style.width || th.offsetWidth + 'px';
-      th.style.width = initial;
-      if(cols[id]) cols[id].style.width = initial;
-      if(th.classList.contains('no-resize')) return;
-      const res = document.createElement('div');
-      res.className = 'col-resizer';
-      th.appendChild(res);
-      let startX = 0;
-      let startWidth = 0;
-      res.addEventListener('mousedown', e => {
-        startX = e.pageX;
-        startWidth = th.offsetWidth;
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', stop);
-        e.preventDefault();
-      });
-      function onMove(e){
-        const w = Math.max(30, startWidth + (e.pageX - startX));
-        th.style.width = w + 'px';
-        if(cols[id]) cols[id].style.width = w + 'px';
-        widths[id] = w + 'px';
-      }
-      function stop(){
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', stop);
-        localStorage.setItem(key, JSON.stringify(widths));
-      }
-    });
+    if(typeof makeResizableTable === 'function'){
+      makeResizableTable(table, key);
+    }
   }
 
   function attachSort(table){

--- a/static/screenshotter.js
+++ b/static/screenshotter.js
@@ -24,45 +24,9 @@ function initScreenshotter(){
   if(presetUrl) urlInput.value = presetUrl;
 
   function makeResizable(table, key){
-    table.style.tableLayout = 'fixed';
-    const ths = table.querySelectorAll('th');
-    const cols = table.querySelectorAll('col');
-    let widths = {};
-    try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
-    ths.forEach((th, idx) => {
-      const id = idx;
-      if(widths[id]){
-        th.style.width = widths[id];
-        if(cols[id]) cols[id].style.width = widths[id];
-      }
-      const initial = th.style.width || th.offsetWidth + 'px';
-      th.style.width = initial;
-      if(cols[id]) cols[id].style.width = initial;
-      if(th.classList.contains('no-resize')) return;
-      const res = document.createElement('div');
-      res.className = 'col-resizer';
-      th.appendChild(res);
-      let startX = 0;
-      let startWidth = 0;
-      res.addEventListener('mousedown', e => {
-        startX = e.pageX;
-        startWidth = th.offsetWidth;
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', stop);
-        e.preventDefault();
-      });
-      function onMove(e){
-        const w = Math.max(30, startWidth + (e.pageX - startX));
-        th.style.width = w + 'px';
-        if(cols[id]) cols[id].style.width = w + 'px';
-        widths[id] = w + 'px';
-      }
-      function stop(){
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', stop);
-        localStorage.setItem(key, JSON.stringify(widths));
-      }
-    });
+    if(typeof makeResizableTable === 'function'){
+      makeResizableTable(table, key);
+    }
   }
 
   function render(){

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -161,53 +161,9 @@ function initSubdomonster(){
   }
 
   function makeResizable(table, key){
-    table.style.tableLayout = 'fixed';
-    const ths = table.querySelectorAll('th');
-    const cols = table.querySelectorAll('col');
-    let widths = {};
-    try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
-    if(Object.keys(widths).length !== ths.length){
-      widths = {};
-      localStorage.removeItem(key);
+    if(typeof makeResizableTable === 'function'){
+      makeResizableTable(table, key);
     }
-    ths.forEach((th, idx) => {
-      const id = idx;
-      let w = widths[id];
-      if(!w){
-        const ow = th.offsetWidth;
-        if(ow > 0){
-          w = ow + 'px';
-        }
-      }
-      if(w){
-        th.style.width = w;
-        if(cols[id]) cols[id].style.width = w;
-      }
-      if(th.classList.contains('no-resize')) return;
-      const res = document.createElement('div');
-      res.className = 'col-resizer';
-      th.appendChild(res);
-      let startX = 0;
-      let startWidth = 0;
-      res.addEventListener('mousedown', e => {
-        startX = e.pageX;
-        startWidth = th.offsetWidth;
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', stop);
-        e.preventDefault();
-      });
-      function onMove(e){
-        const w = Math.max(30, startWidth + (e.pageX - startX));
-        th.style.width = w + 'px';
-        if(cols[id]) cols[id].style.width = w + 'px';
-        widths[id] = w + 'px';
-      }
-      function stop(){
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', stop);
-        localStorage.setItem(key, JSON.stringify(widths));
-      }
-    });
   }
 
   function renderPagination(totalPages, totalCount){

--- a/templates/index.html
+++ b/templates/index.html
@@ -1634,56 +1634,13 @@
     });
 
     // Column resizing
-    function makeResizable(table, key){
-      table.style.tableLayout = 'fixed';
-      const ths = table.querySelectorAll('th');
-      const cols = table.querySelectorAll('col');
-      let widths = {};
-      try{ widths = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
-      if(Object.keys(widths).length !== ths.length){
-        widths = {};
-        localStorage.removeItem(key);
-      }
-      ths.forEach((th, idx) => {
-        const id = idx;
-        if(widths[id]){
-          th.style.width = widths[id];
-          if(cols[id]) cols[id].style.width = widths[id];
-        }
-        const initial = th.style.width || th.offsetWidth + 'px';
-        th.style.width = initial;
-        if(cols[id]) cols[id].style.width = initial;
-        if(th.classList.contains('no-resize')) return;
-        const res = document.createElement('div');
-        res.className = 'col-resizer';
-        th.appendChild(res);
-        let startX = 0;
-        let startWidth = 0;
-        res.addEventListener('mousedown', e => {
-          startX = e.pageX;
-          startWidth = th.offsetWidth;
-          document.addEventListener('mousemove', onMove);
-          document.addEventListener('mouseup', stop);
-          e.preventDefault();
-        });
-        function onMove(e){
-          const w = Math.max(30, startWidth + (e.pageX - startX));
-          th.style.width = w + 'px';
-          if(cols[id]) cols[id].style.width = w + 'px';
-          widths[id] = w + 'px';
-        }
-        function stop(){
-          document.removeEventListener('mousemove', onMove);
-          document.removeEventListener('mouseup', stop);
-          localStorage.setItem(key, JSON.stringify(widths));
-        }
-      });
-    }
-
     const urlTable = document.querySelector('.url-table');
-  if(urlTable) makeResizable(urlTable, 'url-col-widths');
+    if(urlTable && typeof makeResizableTable === 'function'){
+      makeResizableTable(urlTable, 'url-col-widths');
+    }
   </script>
 </div>
+<script src="{{ url_for('static', filename='col_resize.js') }}"></script>
 <script src="{{ url_for('static', filename='index_page.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize column resizing logic in `col_resize.js`
- load the new script on index page
- have table scripts call the shared `makeResizableTable`

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dfa3bd3fc8332934516eae23ac936