### PR TITLE
Fix Tagify search tag insertion

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -897,8 +897,9 @@
             const exists = t.tagify.value.some(v => v.value === val);
             if(exists){
               t.tagify.removeTags(val);
-            }else{
-              t.tagify.addMixTags([{value: val, color: color}]);
+            } else {
+              const tagData = {value: val, style: `--tag-bg: ${color}`};
+              t.tagify.addTags([tagData], true);
             }
           }else{
             const parts = t.input.value.trim().split(/\s+/).filter(Boolean);


### PR DESCRIPTION
## Summary
- prevent search tags from overwriting previous tags by using `addTags`
- set tag background color using CSS variable so colors are preserved

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e0f5562cc833299d0bd45964ba7ec