### PR TITLE
Fix table column resizing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1671,10 +1671,12 @@
     });
 
     // Column resizing
-    const urlTable = document.querySelector('.url-table');
-    if(urlTable && typeof makeResizableTable === 'function'){
-      makeResizableTable(urlTable, 'url-col-widths');
-    }
+    document.addEventListener('DOMContentLoaded', function(){
+      const urlTable = document.querySelector('.url-table');
+      if(urlTable && typeof makeResizableTable === 'function'){
+        makeResizableTable(urlTable, 'url-col-widths');
+      }
+    });
   </script>
 </div>
 <script src="{{ url_for('static', filename='col_resize.js') }}"></script>


### PR DESCRIPTION
## Summary
- ensure the column resizer is initialized after the script loads

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e3344be48833287e028a824766412