### PR TITLE
Fix column handle init timing

### DIFF
--- a/static/httpolaroid.js
+++ b/static/httpolaroid.js
@@ -154,7 +154,7 @@ function initHttpolaroid(){
     }
   });
 
-  loadRows();
+  window.loadHttpolaroidRows = loadRows;
 }
 
 if(document.readyState==='loading'){

--- a/static/jwt_tools.js
+++ b/static/jwt_tools.js
@@ -215,7 +215,7 @@ function initJWTTools(){
     });
   }
 
-  loadJar();
+  window.loadJwtJar = loadJar;
 }
 
 if(document.readyState==='loading'){

--- a/static/screenshotter.js
+++ b/static/screenshotter.js
@@ -139,7 +139,7 @@ function initScreenshotter(){
     });
   }
 
-  loadShots();
+  window.loadScreenshotRows = loadShots;
 }
 
 if(document.readyState==='loading'){

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -506,10 +506,12 @@ function initSubdomonster(){
     }
   });
 
-  if(tableData.length){
-    render();
-    updateSelectionStatus();
-  }
+  window.renderSubdomonster = () => {
+    if(tableData.length){
+      render();
+      updateSelectionStatus();
+    }
+  };
   window.startSubdomonsterStatus = startStatusPolling;
   window.stopSubdomonsterStatus = stopStatusPolling;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1135,12 +1135,18 @@
           const html = await resp.text();
           const root = document.querySelector('.retrorecon-root') || document.body;
           root.insertAdjacentHTML('beforeend', html);
-          const script = document.createElement('script');
-          script.src = '/static/jwt_tools.js';
-          document.body.appendChild(script);
+          await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = '/static/jwt_tools.js';
+            script.onload = resolve;
+            script.onerror = reject;
+            document.body.appendChild(script);
+          });
           jwtToolsLoaded = true;
         }
-        document.getElementById('jwt-tools-overlay').classList.remove('hidden');
+        const ov = document.getElementById('jwt-tools-overlay');
+        ov.classList.remove('hidden');
+        if(window.loadJwtJar){ window.loadJwtJar(); }
         if(!skipPush){
           history.pushState({tool:'jwt'}, '', '/tools/jwt');
         }
@@ -1179,12 +1185,18 @@
           const html = await resp.text();
           const root = document.querySelector('.retrorecon-root') || document.body;
           root.insertAdjacentHTML('beforeend', html);
-          const script = document.createElement('script');
-          script.src = '/static/screenshotter.js';
-          document.body.appendChild(script);
+          await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = '/static/screenshotter.js';
+            script.onload = resolve;
+            script.onerror = reject;
+            document.body.appendChild(script);
+          });
           screenshotLoaded = true;
         }
-        document.getElementById('screenshot-overlay').classList.remove('hidden');
+        const ov = document.getElementById('screenshot-overlay');
+        ov.classList.remove('hidden');
+        if(window.loadScreenshotRows){ window.loadScreenshotRows(); }
         if(!skipPush){
           history.pushState({tool:'screenshot'}, '', '/tools/screenshotter');
         }
@@ -1211,12 +1223,18 @@
           const html = await resp.text();
           const root = document.querySelector('.retrorecon-root') || document.body;
           root.insertAdjacentHTML('beforeend', html);
-          const script = document.createElement('script');
-          script.src = '/static/httpolaroid.js';
-          document.body.appendChild(script);
+          await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = '/static/httpolaroid.js';
+            script.onload = resolve;
+            script.onerror = reject;
+            document.body.appendChild(script);
+          });
           httpolaroidLoaded = true;
         }
-        document.getElementById('httpolaroid-overlay').classList.remove('hidden');
+        const ov = document.getElementById('httpolaroid-overlay');
+        ov.classList.remove('hidden');
+        if(window.loadHttpolaroidRows){ window.loadHttpolaroidRows(); }
         if(!skipPush){
           history.pushState({tool:'httpolaroid'}, '', '/tools/httpolaroid');
         }
@@ -1302,6 +1320,7 @@
         const ov = document.getElementById('subdomonster-overlay');
         ov.classList.remove('hidden');
         document.body.style.overflow = 'hidden';
+        if(window.renderSubdomonster){ window.renderSubdomonster(); }
         if(window.startSubdomonsterStatus){
           window.startSubdomonsterStatus();
         }


### PR DESCRIPTION
## Summary
- expose functions to load overlay tables when shown
- wait for JS to load before displaying overlays
- call loaders after overlays become visible

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec55a8a6883328fdc3d0df58445a0