### PR TITLE
Fix search tag encoding

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -14,6 +14,20 @@ function initSubdomonster(){
   const exportFormatInp = document.getElementById('subdom-export-format');
   const exportQInp = document.getElementById('subdom-export-q');
   const searchInput = document.getElementById('subdomonster-search');
+  function cleanTagString(str){
+    if(!str) return '';
+    const nozw = str.replace(/\u200b/g, '');
+    try{
+      const arr = JSON.parse(nozw);
+      if(Array.isArray(arr)){
+        return arr.map(it => {
+          const obj = Array.isArray(it) ? it[0] : it;
+          return obj && obj.value ? '#' + obj.value : '';
+        }).join(' ').trim();
+      }
+    }catch{}
+    return nozw;
+  }
   let savedTags = [];
   fetch('/saved_tags')
     .then(r => r.ok ? r.json() : {tags: []})
@@ -21,7 +35,8 @@ function initSubdomonster(){
       const arr = Array.isArray(d.tags) ? d.tags : [];
       savedTags = arr.map(t => t.name);
       if(searchInput){
-        window.subdomSearchTagify = new Tagify(searchInput,{mode:'mix',pattern:/#\w+/,whitelist:savedTags});
+        window.subdomSearchTagify = new Tagify(searchInput,{mode:'mix',pattern:/#\w+/,whitelist:savedTags,
+          originalInputValueFormat:v=>v.map(t=>'#'+t.value).join(' ')});
       }
     });
   const sourceSel = document.getElementById('subdomonster-source');
@@ -135,7 +150,7 @@ function initSubdomonster(){
 
 
   async function fetchSearch(){
-    const term = searchInput.value.trim();
+    const term = cleanTagString(searchInput.value.trim());
     const domain = domainInput.value.trim();
     const params = new URLSearchParams();
     if(term) params.append('q', term);
@@ -151,7 +166,7 @@ function initSubdomonster(){
 
   if(searchInput){
     searchInput.addEventListener('input', async () => {
-      searchText = searchInput.value.trim().toLowerCase();
+      searchText = cleanTagString(searchInput.value.trim()).toLowerCase();
       currentPage = 1;
       selectedSubs.clear();
       await fetchSearch();

--- a/templates/index.html
+++ b/templates/index.html
@@ -865,6 +865,21 @@
 
     let searchTagify;
     let savedTagColors = {};
+
+    function cleanTagString(str){
+      if(!str) return '';
+      const nozw = str.replace(/\u200b/g, '');
+      try{
+        const arr = JSON.parse(nozw);
+        if(Array.isArray(arr)){
+          return arr.map(it => {
+            const obj = Array.isArray(it) ? it[0] : it;
+            return obj && obj.value ? '#' + obj.value : '';
+          }).join(' ').trim();
+        }
+      }catch{}
+      return nozw;
+    }
     async function initSearchTags(){
       let saved = [];
       try {
@@ -879,11 +894,12 @@
       } catch(e){}
       const input = document.getElementById('searchbox');
       if(input && window.Tagify){
-        searchTagify = new Tagify(input, {mode:'mix', pattern:/#\w+/, whitelist:saved});
+        searchTagify = new Tagify(input, {mode:'mix', pattern:/#\w+/, whitelist:saved,
+          originalInputValueFormat:v=>v.map(t=>'#'+t.value).join(' ')});
         const trap = (e) => {
           if(e.key === 'Enter'){
             e.preventDefault();
-            if(searchTagify) input.value = searchTagify.getMixedTagsAsString();
+            if(searchTagify) input.value = cleanTagString(searchTagify.getMixedTagsAsString());
             searchForm.submit();
           }
         };
@@ -913,6 +929,12 @@
             } else {
               const tagData = {value: val, style: `--tag-bg: ${color}`};
               t.tagify.addTags([tagData], true);
+              const inp = t.tagify.DOM.input;
+              if(inp){
+                inp.focus();
+                const len = inp.value.length;
+                if(inp.setSelectionRange) inp.setSelectionRange(len,len);
+              }
             }
           }else{
             const parts = t.input.value.trim().split(/\s+/).filter(Boolean);
@@ -930,7 +952,8 @@
     }
 
     function saveTag(){
-      let val = document.getElementById('searchbox').value.trim();
+      let val = searchTagify ? searchTagify.getMixedTagsAsString() : document.getElementById('searchbox').value.trim();
+      val = cleanTagString(val);
       if(!val) return;
       if(!val.startsWith('#')){
         val = '#' + val;
@@ -945,12 +968,14 @@
     const clearBtn = document.getElementById('clear-search-btn');
     if (searchInput && searchForm) {
       searchForm.addEventListener('submit', () => {
-        if(searchTagify) searchInput.value = searchTagify.getMixedTagsAsString();
+        if(searchTagify) searchInput.value = cleanTagString(searchTagify.getMixedTagsAsString());
+        else searchInput.value = cleanTagString(searchInput.value);
       });
       searchInput.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
           e.preventDefault();
-          if(searchTagify) searchInput.value = searchTagify.getMixedTagsAsString();
+          if(searchTagify) searchInput.value = cleanTagString(searchTagify.getMixedTagsAsString());
+          else searchInput.value = cleanTagString(searchInput.value);
           searchForm.submit();
         }
       });


### PR DESCRIPTION
## Summary
- strip Tagify metadata before submitting search queries
- preserve searchbox tags and colors when toggling
- normalize tag strings across Subdomonster

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f637f218883328b7e2b1847ac8e82