### PR TITLE
Fix Tagify to use plain tag values

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -152,7 +152,7 @@ Parameters:
 - `color` – optional hex color code.
 
 ```
-curl -X POST -d "tag=#foo" -d "color=#ff0000" http://localhost:5000/saved_tags
+curl -X POST -d "tag=foo" -d "color=#ff0000" http://localhost:5000/saved_tags
 ```
 
 ### `POST /delete_saved_tag`
@@ -162,7 +162,7 @@ Parameter:
 - `tag` – query string to delete.
 
 ```
-curl -X POST -d "tag=#foo AND #bar" http://localhost:5000/delete_saved_tag
+curl -X POST -d "tag=foo AND bar" http://localhost:5000/delete_saved_tag
 ```
 
 ### `POST /rename_saved_tag`
@@ -174,7 +174,7 @@ Parameters:
 - `color` – optional hex color code.
 
 ```
-curl -X POST -d "old_tag=#foo" -d "new_tag=#bar" -d "color=#00ff00" \
+curl -X POST -d "old_tag=foo" -d "new_tag=bar" -d "color=#00ff00" \
   http://localhost:5000/rename_saved_tag
 ```
 

--- a/retrorecon/routes/notes.py
+++ b/retrorecon/routes/notes.py
@@ -8,13 +8,11 @@ bp = Blueprint('notes', __name__)
 def saved_tags_route():
     if request.method == 'GET':
         return jsonify({'tags': app.load_saved_tags()})
-    tag = request.form.get('tag', '').strip()
+    tag = request.form.get('tag', '').lstrip('#').strip()
     color = request.form.get('color', '').strip() or saved_tags_mod.DEFAULT_COLOR
     desc = request.form.get('desc', '').strip()
     if not tag:
         return ('', 400)
-    if not tag.startswith('#'):
-        tag = '#' + tag
     if not color.startswith('#'):
         color = '#' + color
     tags = app.load_saved_tags()
@@ -26,11 +24,9 @@ def saved_tags_route():
 
 @bp.route('/delete_saved_tag', methods=['POST'])
 def delete_saved_tag():
-    tag = request.form.get('tag', '').strip()
+    tag = request.form.get('tag', '').lstrip('#').strip()
     if not tag:
         return ('', 400)
-    if not tag.startswith('#'):
-        tag = '#' + tag
     tags = app.load_saved_tags()
     filtered = [t for t in tags if t['name'] != tag]
     if len(filtered) != len(tags):
@@ -39,16 +35,12 @@ def delete_saved_tag():
 
 @bp.route('/rename_saved_tag', methods=['POST'])
 def rename_saved_tag():
-    old_tag = request.form.get('old_tag', '').strip()
-    new_tag = request.form.get('new_tag', '').strip()
+    old_tag = request.form.get('old_tag', '').lstrip('#').strip()
+    new_tag = request.form.get('new_tag', '').lstrip('#').strip()
     color = request.form.get('color', '').strip()
     desc = request.form.get('desc', '').strip()
     if not old_tag or not new_tag:
         return ('', 400)
-    if not old_tag.startswith('#'):
-        old_tag = '#' + old_tag
-    if not new_tag.startswith('#'):
-        new_tag = '#' + new_tag
     if color and not color.startswith('#'):
         color = '#' + color
     tags = app.load_saved_tags()

--- a/retrorecon/saved_tags.py
+++ b/retrorecon/saved_tags.py
@@ -23,16 +23,14 @@ def load_tags(file_path: str) -> List[Dict[str, str]]:
                 result = []
                 for item in data:
                     if isinstance(item, dict):
-                        name = str(item.get("name", "")).strip()
+                        name = str(item.get("name", "")).lstrip("#").strip()
                         color = str(item.get("color", DEFAULT_COLOR)).strip() or DEFAULT_COLOR
                         desc = str(item.get("desc", "")).strip()
                     else:
-                        name = str(item).strip()
+                        name = str(item).lstrip("#").strip()
                         color = DEFAULT_COLOR
                         desc = ""
                     if name:
-                        if not name.startswith("#"):
-                            name = "#" + name
                         if not color.startswith("#"):
                             color = "#" + color
                         result.append({"name": name, "color": color, "desc": desc})

--- a/static/index_page.js
+++ b/static/index_page.js
@@ -67,7 +67,7 @@ async function initTagInputs(){
     });
     const sb = document.getElementById('searchbox');
     if(sb && !sb.tagify){
-      new Tagify(sb, {mode:'mix', pattern:/#\w+/, whitelist:saved});
+      new Tagify(sb, {mode:'mix', pattern:/.+/, whitelist:saved, originalInputValueFormat:v=>v.map(t=>t.value).join(' ')});
     }
   }
 }

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -22,7 +22,7 @@ function initSubdomonster(){
       if(Array.isArray(arr)){
         return arr.map(it => {
           const obj = Array.isArray(it) ? it[0] : it;
-          return obj && obj.value ? '#' + obj.value : '';
+          return obj && obj.value ? obj.value : '';
         }).join(' ').trim();
       }
     }catch{}
@@ -34,9 +34,9 @@ function initSubdomonster(){
     .then(d => {
       const arr = Array.isArray(d.tags) ? d.tags : [];
       savedTags = arr.map(t => t.name);
-      if(searchInput){
-        window.subdomSearchTagify = new Tagify(searchInput,{mode:'mix',pattern:/#\w+/,whitelist:savedTags,
-          originalInputValueFormat:v=>v.map(t=>'#'+t.value).join(' ')});
+        if(searchInput){
+        window.subdomSearchTagify = new Tagify(searchInput,{mode:'mix',pattern:/.+/,whitelist:savedTags,
+          originalInputValueFormat:v=>v.map(t=>t.value).join(' ')});
       }
     });
   const sourceSel = document.getElementById('subdomonster-source');

--- a/templates/index.html
+++ b/templates/index.html
@@ -584,7 +584,7 @@
       const name = tagNameInput.value.trim();
       if(!name) return;
       const params = new URLSearchParams({color: tagColorInput.value, desc: tagDescInput.value});
-      if(!name.startsWith('#')) params.set(editingTag ? 'new_tag' : 'tag', '#' + name); else params.set(editingTag ? 'new_tag' : 'tag', name);
+      params.set(editingTag ? 'new_tag' : 'tag', name);
       if(editingTag){
         params.set('old_tag', editingTag.name);
         fetch('/rename_saved_tag', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:params}).then(()=>{tagEditor.classList.add('hidden'); loadTags();});
@@ -866,20 +866,20 @@
     let searchTagify;
     let savedTagColors = {};
 
-    function cleanTagString(str){
-      if(!str) return '';
-      const nozw = str.replace(/\u200b/g, '');
-      try{
-        const arr = JSON.parse(nozw);
-        if(Array.isArray(arr)){
-          return arr.map(it => {
-            const obj = Array.isArray(it) ? it[0] : it;
-            return obj && obj.value ? '#' + obj.value : '';
-          }).join(' ').trim();
-        }
-      }catch{}
-      return nozw;
-    }
+      function cleanTagString(str){
+        if(!str) return '';
+        const nozw = str.replace(/\u200b/g, '');
+        try{
+          const arr = JSON.parse(nozw);
+          if(Array.isArray(arr)){
+            return arr.map(it => {
+              const obj = Array.isArray(it) ? it[0] : it;
+              return obj && obj.value ? obj.value : '';
+            }).join(' ').trim();
+          }
+        }catch{}
+        return nozw;
+      }
     async function initSearchTags(){
       let saved = [];
       try {
@@ -894,8 +894,8 @@
       } catch(e){}
       const input = document.getElementById('searchbox');
       if(input && window.Tagify){
-        searchTagify = new Tagify(input, {mode:'mix', pattern:/#\w+/, whitelist:saved,
-          originalInputValueFormat:v=>v.map(t=>'#'+t.value).join(' ')});
+        searchTagify = new Tagify(input, {mode:'mix', pattern:/.+/, whitelist:saved,
+          originalInputValueFormat:v=>v.map(t=>t.value).join(' ')});
         const trap = (e) => {
           if(e.key === 'Enter'){
             e.preventDefault();
@@ -905,7 +905,7 @@
         };
         searchTagify.DOM.input.addEventListener('keydown', trap);
         searchTagify.on('add', e => {
-          const val = '#' + e.detail.data.value;
+          const val = e.detail.data.value;
           const color = savedTagColors[val];
           if(color) e.detail.tag.style.setProperty('--tag-bg', color);
         });
@@ -913,8 +913,7 @@
     }
 
     function toggleSearchTag(tag){
-      if(!tag.startsWith('#')) tag = '#' + tag;
-      const val = tag.slice(1);
+      const val = tag;
       const color = savedTagColors[tag] || '#ccc';
       const targets = [
         {input: document.getElementById('searchbox'), tagify: searchTagify},
@@ -932,7 +931,7 @@
               parts.push(tag);
             }
             t.tagify.removeAllTags();
-            const tags = parts.map(p => ({value:p.slice(1), style:`--tag-bg: ${savedTagColors[p] || '#ccc'}`}));
+            const tags = parts.map(p => ({value:p, style:`--tag-bg: ${savedTagColors[p] || '#ccc'}`}));
             t.tagify.addTags(tags, true);
             const inp = t.tagify.DOM.input;
             if(inp) inp.focus();
@@ -955,9 +954,6 @@
       let val = searchTagify ? searchTagify.getMixedTagsAsString() : document.getElementById('searchbox').value.trim();
       val = cleanTagString(val);
       if(!val) return;
-      if(!val.startsWith('#')){
-        val = '#' + val;
-      }
       fetch('/saved_tags', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:new URLSearchParams({tag:val})})
         .then(() => { if(searchTagify && !searchTagify.settings.whitelist.includes(val)) searchTagify.settings.whitelist.push(val); });
     }

--- a/tests/test_saved_tags.py
+++ b/tests/test_saved_tags.py
@@ -23,16 +23,16 @@ def test_saved_tag_crud(tmp_path, monkeypatch):
         assert (tmp_path / "tags.json").exists()
 
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": [{"name": "#foo", "color": "#123456", "desc": "d"}]}
+        assert resp.get_json() == {"tags": [{"name": "foo", "color": "#123456", "desc": "d"}]}
 
         client.post('/saved_tags', data={'tag': 'foo', 'color': '#123456', 'desc': 'd'})  # duplicate
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": [{"name": "#foo", "color": "#123456", "desc": "d"}]}
+        assert resp.get_json() == {"tags": [{"name": "foo", "color": "#123456", "desc": "d"}]}
 
         resp = client.post('/rename_saved_tag', data={'old_tag': 'foo', 'new_tag': 'bar', 'color': '#654321', 'desc': 'e'})
         assert resp.status_code == 204
         resp = client.get('/saved_tags')
-        assert resp.get_json() == {"tags": [{"name": "#bar", "color": "#654321", "desc": "e"}]}
+        assert resp.get_json() == {"tags": [{"name": "bar", "color": "#654321", "desc": "e"}]}
 
         resp = client.post('/delete_saved_tag', data={'tag': 'bar'})
         assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- strip leading `#` from saved tags everywhere
- adjust Tagify configs to accept free text
- update saved tags CRUD logic and documentation
- adapt unit tests for new tag format

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6c3819fc8332be5a5f41a9039ac2