### PR TITLE
Add test for subdomonster checkbox column

### DIFF
--- a/tests/test_subdomonster_table.py
+++ b/tests/test_subdomonster_table.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_subdomonster_js_has_checkbox_column():
+    js = Path('static/subdomonster.js').read_text()
+    assert '<col class="w-1-6em checkbox-col"' in js
+    assert '<th class="w-1-6em checkbox-col no-resize text-center"' in js
+    assert 'subdomonster-col-widths' in js


### PR DESCRIPTION
## Summary
- add regression test that ensures the Subdomonster checkbox column is marked with `no-resize`

## Testing
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f66141e0883328cb758d0673ee6b8