### PR TITLE
Fix tag search quoting

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -874,7 +874,11 @@
           if(Array.isArray(arr)){
             return arr.map(it => {
               const obj = Array.isArray(it) ? it[0] : it;
-              return obj && obj.value ? obj.value : '';
+              if(obj && obj.value){
+                const v = obj.value;
+                return /\s/.test(v) ? '"' + v + '"' : v;
+              }
+              return '';
             }).join(' ').trim();
           }
         }catch{}


### PR DESCRIPTION
## Summary
- escape whitespace in tag values when serializing tagify state

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6e9e7a148332becfbc7687482275