### PR TITLE
Fix Tagify search clobbering bug

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -20,13 +20,10 @@ function initSubdomonster(){
     try{
       const arr = JSON.parse(nozw);
       if(Array.isArray(arr)){
-        return arr.map(it => {
-          const obj = Array.isArray(it) ? it[0] : it;
-          return obj && obj.value ? obj.value : '';
-        }).join(' ').trim();
+        return arr.map(it => (Array.isArray(it) ? it[0] : it).value || '').join(' ').trim();
       }
     }catch{}
-    return nozw;
+    return nozw.trim();
   }
   let savedTags = [];
   fetch('/saved_tags')

--- a/templates/index.html
+++ b/templates/index.html
@@ -872,17 +872,10 @@
         try{
           const arr = JSON.parse(nozw);
           if(Array.isArray(arr)){
-            return arr.map(it => {
-              const obj = Array.isArray(it) ? it[0] : it;
-              if(obj && obj.value){
-                const v = obj.value;
-                return /\s/.test(v) ? '"' + v + '"' : v;
-              }
-              return '';
-            }).join(' ').trim();
+            return arr.map(it => (Array.isArray(it) ? it[0] : it).value || '').join(' ').trim();
           }
         }catch{}
-        return nozw;
+        return nozw.trim();
       }
     async function initSearchTags(){
       let saved = [];
@@ -936,7 +929,11 @@
             }
             t.tagify.removeAllTags();
             const tags = parts.map(p => ({value:p, style:`--tag-bg: ${savedTagColors[p] || '#ccc'}`}));
-            t.tagify.addTags(tags, true);
+            if(t.tagify.addMixTags){
+              t.tagify.addMixTags(tags);
+            } else {
+              t.tagify.addTags(tags, true);
+            }
             const inp = t.tagify.DOM.input;
             if(inp) inp.focus();
           }else{


### PR DESCRIPTION
## Summary
- adjust `cleanTagString` helper for robust tag parsing
- use `addMixTags` when updating search bar to preserve order

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860179fa24083329392094feb669a18