### PR TITLE
Fix search query serialization

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -15,17 +15,31 @@ function initSubdomonster(){
   const exportQInp = document.getElementById('subdom-export-q');
   const searchInput = document.getElementById('subdomonster-search');
   function cleanTagString(str){
-    if(!str) return '';
-    const nozw = str.replace(/\u200b/g, '');
-    return nozw.replace(/\[\[(.*?)\]\]/g, (m, p) => {
-      try {
+    console.debug('cleanTagString input', str);
+    if(!str){ console.debug('cleanTagString result', ''); return ''; }
+    if(Array.isArray(str)){
+      const res = str.map(o => (o && o.value) ? o.value : '').join(' ').trim();
+      console.debug('cleanTagString result', res); return res;
+    }
+    const raw = String(str).replace(/\u200b/g, '');
+    try{
+      const arr = JSON.parse(raw);
+      if(Array.isArray(arr)){
+        const res = arr.map(o => (o && o.value) ? o.value : '').join(' ').trim();
+        console.debug('cleanTagString result', res); return res;
+      }
+    }catch{}
+    const res = raw.replace(/\[\[(.*?)\]\]/g, (m,p) => {
+      try{
         let obj = JSON.parse(p);
         if(Array.isArray(obj)) obj = obj[0];
         return obj && obj.value ? obj.value : '';
-      } catch {
+      }catch{
         return p;
       }
     }).trim();
+    console.debug('cleanTagString result', res);
+    return res;
   }
   let savedTags = [];
   fetch('/saved_tags')

--- a/templates/index.html
+++ b/templates/index.html
@@ -867,17 +867,31 @@
     let savedTagColors = {};
 
       function cleanTagString(str){
-        if(!str) return '';
-        const nozw = str.replace(/\u200b/g, '');
-        return nozw.replace(/\[\[(.*?)\]\]/g, (m, p) => {
-          try {
+        console.debug('cleanTagString input', str);
+        if(!str) { console.debug('cleanTagString result', ''); return ''; }
+        if(Array.isArray(str)){
+          const res = str.map(o => (o && o.value) ? o.value : '').join(' ').trim();
+          console.debug('cleanTagString result', res); return res;
+        }
+        const raw = String(str).replace(/\u200b/g, '');
+        try{
+          const arr = JSON.parse(raw);
+          if(Array.isArray(arr)){
+            const res = arr.map(o => (o && o.value) ? o.value : '').join(' ').trim();
+            console.debug('cleanTagString result', res); return res;
+          }
+        }catch{}
+        const res = raw.replace(/\[\[(.*?)\]\]/g, (m,p) => {
+          try{
             let obj = JSON.parse(p);
             if(Array.isArray(obj)) obj = obj[0];
             return obj && obj.value ? obj.value : '';
-          } catch {
+          }catch{
             return p;
           }
         }).trim();
+        console.debug('cleanTagString result', res);
+        return res;
       }
     async function initSearchTags(){
       let saved = [];


### PR DESCRIPTION
## Summary
- robustify `cleanTagString` so tagify mix strings always return space separated tags
- log inputs and outputs for debugging

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68601e7d47548332818bca35fb9c21ee