### PR TITLE
Fix subdomonster overlay layout

### DIFF
--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -34,48 +34,6 @@ def register_demo_schemas(registry: SchemaRegistry) -> None:
                             "attrs": {"class": "mb-05 search-input-row"},
                             "children": [
                                 {
-                                    "tag": "input",
-                                    "attrs": {
-                                        "type": "text",
-                                        "id": "subdomonster-domain",
-                                        "class": "form-input mr-05 subdomonster-domain-bar",
-                                        "placeholder": "example.com",
-                                    },
-                                },
-                                {
-                                    "tag": "button",
-                                    "attrs": {"type": "button", "class": "btn mr-05", "id": "subdom-add-domain-btn"},
-                                    "text": "+",
-                                },
-                                {
-                                    "tag": "select",
-                                    "attrs": {"id": "subdomonster-source", "class": "form-select mr-05 w-6em"},
-                                    "children": [
-                                        {"tag": "option", "attrs": {"value": "crtsh", "selected": True}, "text": "crt.sh"},
-                                        {"tag": "option", "attrs": {"value": "virustotal"}, "text": "VirusTotal"},
-                                        {"tag": "option", "attrs": {"value": "local"}, "text": "Local"},
-                                    ],
-                                },
-                                {
-                                    "tag": "input",
-                                    "attrs": {
-                                        "type": "text",
-                                        "id": "subdomonster-api-key",
-                                        "class": "form-input mr-05 hidden",
-                                        "placeholder": "API key",
-                                        "value": app.app.config.get("VIRUSTOTAL_API", ""),
-                                    },
-                                },
-                                {
-                                    "tag": "input",
-                                    "attrs": {
-                                        "type": "text",
-                                        "id": "subdomonster-search",
-                                        "class": "form-input mr-05 subdom-search",
-                                        "placeholder": "search",
-                                    },
-                                },
-                                {
                                     "tag": "button",
                                     "attrs": {"type": "button", "class": "btn mr-05", "id": "subdom-export-btn"},
                                     "text": "\U0001f4be",

--- a/static/base.css
+++ b/static/base.css
@@ -1404,6 +1404,10 @@ body.bg-hidden {
   right: 0.5em;
   float: none;
 }
+.retrorecon-root #subdomonster-close-btn {
+  top: 1em;
+  right: 1em;
+}
 
 .retrorecon-root .help-overlay {
   max-width: 95%;

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -3,7 +3,6 @@ function initSubdomonster(){
   const overlay = document.getElementById('subdomonster-overlay');
   if(!overlay) return;
   const domainInput = document.getElementById('subdomonster-domain');
-  const addBtn = document.getElementById('subdom-add-domain-btn');
   const tableDiv = document.getElementById('subdomonster-table');
   const paginationDiv = document.getElementById('subdomonster-pagination');
   const closeBtn = document.getElementById('subdomonster-close-btn');
@@ -13,7 +12,6 @@ function initSubdomonster(){
   const exportDomainInp = document.getElementById('subdom-export-domain');
   const exportFormatInp = document.getElementById('subdom-export-format');
   const exportQInp = document.getElementById('subdom-export-q');
-  const searchInput = document.getElementById('subdomonster-search');
   function cleanTagString(str){
     if(!str) return '';
     const nozw = str.replace(/\u200b/g, '');
@@ -33,13 +31,7 @@ function initSubdomonster(){
     .then(d => {
       const arr = Array.isArray(d.tags) ? d.tags : [];
       savedTags = arr.map(t => t.name);
-        if(searchInput){
-        window.subdomSearchTagify = new Tagify(searchInput,{mode:'mix',pattern:/.+/,whitelist:savedTags,
-          originalInputValueFormat:v=>v.map(t=>t.value).join(' ')});
-      }
     });
-  const sourceSel = document.getElementById('subdomonster-source');
-  const apiInput = document.getElementById('subdomonster-api-key');
   let currentPage = 1;
   let tableData = [];
   const init = document.getElementById('subdomonster-init');
@@ -108,7 +100,6 @@ function initSubdomonster(){
       await new Promise(r=>setTimeout(r,1000));
     }
     cdxProcessing = false;
-    if(addBtn) addBtn.click();
   }
 
   function enqueueCdxImport(list){
@@ -148,31 +139,6 @@ function initSubdomonster(){
   }
 
 
-  async function fetchSearch(){
-    const term = cleanTagString(searchInput.value.trim());
-    const domain = domainInput.value.trim();
-    const params = new URLSearchParams();
-    if(term) params.append('q', term);
-    if(domain) params.append('domain', domain);
-    const resp = await fetch('/subdomains?' + params.toString());
-    if(resp.ok){
-      const data = await resp.json();
-      tableData = Array.isArray(data.results) ? data.results : data;
-    } else {
-      tableData = [];
-    }
-  }
-
-  if(searchInput){
-    searchInput.addEventListener('input', async () => {
-      searchText = cleanTagString(searchInput.value.trim()).toLowerCase();
-      currentPage = 1;
-      selectedSubs.clear();
-      await fetchSearch();
-      render();
-      updateSelectionStatus();
-    });
-  }
 
   function makeResizable(table, key){
     if(typeof makeResizableTable === 'function'){
@@ -232,14 +198,6 @@ function initSubdomonster(){
     });
   }
 
-  if(sourceSel){
-    sourceSel.addEventListener('change', () => {
-      const val = sourceSel.value;
-      apiInput.classList.toggle('hidden', val !== 'virustotal');
-    });
-    // initialize visibility
-    apiInput.classList.toggle('hidden', sourceSel.value !== 'virustotal');
-  }
 
   function render(){
     const widths = window.getColWidths ? window.getColWidths('subdomonster-col-widths', 5) : {};
@@ -267,7 +225,7 @@ function initSubdomonster(){
       `<col${widths[3]?` style=\"width:${widths[3]}\"`:''}/>`+
       `<col${widths[4]?` style=\"width:${widths[4]}\"`:''}/>`+
       '</colgroup><thead><tr>'+
-      `<th class="w-1-6em checkbox-col no-resize text-center"${widths[0]?` style=\"width:${widths[0]}\"`:''}><input type="checkbox" onclick="document.querySelectorAll(\'#subdomonster-table .row-checkbox\').forEach(c=>c.checked=this.checked);selectAll=false;" /></th>`+
+      `<th class="w-1-6em checkbox-col text-center"${widths[0]?` style=\"width:${widths[0]}\"`:''}><input type="checkbox" onclick="document.querySelectorAll(\'#subdomonster-table .row-checkbox\').forEach(c=>c.checked=this.checked);selectAll=false;" /></th>`+
       `<th class="sortable" data-field="subdomain"${widths[1]?` style=\"width:${widths[1]}\"`:''}>Subdomain</th>`+
       `<th class="sortable" data-field="domain"${widths[2]?` style=\"width:${widths[2]}\"`:''}>Domain</th>`+
       `<th class="sortable" data-field="source"${widths[3]?` style=\"width:${widths[3]}\"`:''}>Source</th>`+
@@ -470,46 +428,17 @@ function initSubdomonster(){
     renderPagination(totalPages, sorted.length);
   }
 
-  addBtn.addEventListener('click', async () => {
-    const input = prompt('Domain to fetch', domainInput.value.trim());
-    const domain = (input || '').trim();
-    if(!domain) return;
-    domainInput.value = domain;
-    const source = sourceSel ? sourceSel.value : 'crtsh';
-    const params = new URLSearchParams();
-    if(domain) params.append('domain', domain);
-    params.append('source', source);
-    if(source === 'virustotal'){
-      const api_key = apiInput.value.trim();
-      params.append('api_key', api_key);
-      if(!domain) return;
-    } else if(source !== 'local' && !domain){
-      return;
-    }
-    showStatus('Fetching...');
-    const resp = await fetch('/subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
-    if(resp.ok){
-      const data = await resp.json();
-      tableData = Array.isArray(data) ? data : [];
-      currentPage = 1;
-      selectedSubs.clear();
-      render();
-      updateSelectionStatus();
-    } else {
-      alert(await resp.text());
-    }
-  });
 
 
   if(exportBtn && exportForm){
     exportBtn.addEventListener('click', () => {
       const fmt = prompt('Format (md,csv,json)', 'json');
       if(!fmt) return;
-      const domain = domainInput.value.trim();
+      const domain = domainInput ? domainInput.value.trim() : '';
       if(!domain) return;
       if(exportDomainInp) exportDomainInp.value = domain;
       if(exportFormatInp) exportFormatInp.value = fmt;
-      if(exportQInp) exportQInp.value = searchInput ? searchInput.value.trim() : '';
+      if(exportQInp) exportQInp.value = '';
       exportForm.submit();
     });
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -915,8 +915,7 @@
       const val = tag;
       const color = savedTagColors[tag] || '#ccc';
       const targets = [
-        {input: document.getElementById('searchbox'), tagify: searchTagify},
-        {input: document.getElementById('subdomonster-search'), tagify: window.subdomSearchTagify}
+        {input: document.getElementById('searchbox'), tagify: searchTagify}
       ];
       for(const t of targets){
         if(t.input && !t.input.closest('.hidden')){

--- a/tests/test_subdomonster_table.py
+++ b/tests/test_subdomonster_table.py
@@ -7,6 +7,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 def test_subdomonster_js_has_checkbox_column():
     js = Path('static/subdomonster.js').read_text()
     assert '<col class="w-1-6em checkbox-col"' in js
-    assert '<th class="w-1-6em checkbox-col no-resize text-center"' in js
+    assert '<th class="w-1-6em checkbox-col text-center"' in js
     assert 'subdomonster-col-widths' in js
-    assert 'checkbox-col no-resize' in js
+    assert 'checkbox-col text-center' in js
+    assert 'subdomonster-search' not in js
+    assert 'subdomonster-api-key' not in js


### PR DESCRIPTION
## Summary
- strip unused domain controls from subdomonster overlay
- reposition subdomonster close button
- allow resizing of the first column
- remove leftover search and API key inputs
- update tests

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68602355badc8332ac9eb9f2842aea51