### PR TITLE
Fix dropdown container closing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -378,6 +378,7 @@
       </a>
     </div>
   </div>
+</div>
 
   <div id="notes-overlay" class="notes-overlay hidden">
     <textarea id="note-input" class="form-input notes-textarea" rows="6" placeholder="Add a note..."></textarea>


### PR DESCRIPTION
## Summary
- fix missing closing tag for `layout-d` div

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686075caec38833290c782d492f171f7