### PR TITLE
Fix legacy saved tag deletion

### DIFF
--- a/retrorecon/saved_tags.py
+++ b/retrorecon/saved_tags.py
@@ -6,21 +6,45 @@ from typing import List
 _TAGS_LOCK = threading.Lock()
 
 def load_tags(file_path: str) -> List[str]:
-    """Return saved search tags from ``file_path``."""
+    """Return saved search tags from ``file_path``.
+
+    Handles legacy data which stored dictionaries with a ``name`` field.
+    """
     with _TAGS_LOCK:
         if not os.path.exists(file_path):
             return []
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, "r") as f:
                 data = json.load(f)
-            if isinstance(data, list):
-                return [str(t) for t in data]
         except Exception:
-            pass
-        return []
+            return []
+
+        result: List[str] = []
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    name = str(item.get("name", "")).strip()
+                else:
+                    name = str(item).strip()
+                if not name:
+                    continue
+                if not name.startswith("#"):
+                    name = "#" + name.lstrip("#")
+                if name not in result:
+                    result.append(name)
+        return result
 
 def save_tags(file_path: str, tags: List[str]) -> None:
     """Persist ``tags`` to ``file_path``."""
     with _TAGS_LOCK:
-        with open(file_path, 'w') as f:
-            json.dump(tags, f)
+        clean: List[str] = []
+        for tag in tags:
+            name = str(tag).strip()
+            if not name:
+                continue
+            if not name.startswith("#"):
+                name = "#" + name.lstrip("#")
+            if name not in clean:
+                clean.append(name)
+        with open(file_path, "w") as f:
+            json.dump(clean, f)

--- a/tests/test_saved_tags.py
+++ b/tests/test_saved_tags.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import json
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import app
@@ -33,3 +34,20 @@ def test_saved_tag_crud(tmp_path, monkeypatch):
         assert resp.status_code == 204
         resp = client.get('/saved_tags')
         assert resp.get_json() == {"tags": []}
+
+
+def test_load_legacy_tags(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    legacy = [
+        {"name": ".js", "color": "#181ed8"},
+        {"name": ".zip", "color": "#edb10c"}
+    ]
+    with open(tmp_path / "tags.json", "w") as f:
+        json.dump(legacy, f)
+    with app.app.test_client() as client:
+        resp = client.get('/saved_tags')
+        assert resp.get_json() == {"tags": ["#.js", "#.zip"]}
+        resp = client.post('/delete_saved_tag', data={'tag': '.js'})
+        assert resp.status_code == 204
+        resp = client.get('/saved_tags')
+        assert resp.get_json() == {"tags": ["#.zip"]}


### PR DESCRIPTION
## Summary
- handle legacy saved tag objects when loading tags
- ensure saved tag list deduplicates and normalizes
- add regression test for legacy tag handling

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a8034680833291d0bd6aaef43475