### PR TITLE
Fix Subdomonster JS syntax and remove broken save control

### DIFF
--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -35,35 +35,6 @@ def register_demo_schemas(registry: SchemaRegistry) -> None:
                             "children": [
                                 {
                                     "tag": "button",
-                                    "attrs": {"type": "button", "class": "btn mr-05", "id": "subdom-export-btn"},
-                                    "text": "\U0001f4be",
-                                },
-                                {
-                                    "tag": "form",
-                                    "attrs": {
-                                        "id": "subdom-export-form",
-                                        "class": "hidden",
-                                        "action": "/export_subdomains",
-                                        "method": "GET",
-                                        "target": "_blank",
-                                    },
-                                    "children": [
-                                        {
-                                            "tag": "input",
-                                            "attrs": {"type": "hidden", "name": "domain", "id": "subdom-export-domain"},
-                                        },
-                                        {
-                                            "tag": "input",
-                                            "attrs": {"type": "hidden", "name": "format", "id": "subdom-export-format"},
-                                        },
-                                        {
-                                            "tag": "input",
-                                            "attrs": {"type": "hidden", "name": "q", "id": "subdom-export-q"},
-                                        },
-                                    ],
-                                },
-                                {
-                                    "tag": "button",
                                     "attrs": {"type": "button", "class": "btn overlay-close-btn", "id": "subdomonster-close-btn"},
                                     "text": "Close",
                                 },

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -7,11 +7,6 @@ function initSubdomonster(){
   const paginationDiv = document.getElementById('subdomonster-pagination');
   const closeBtn = document.getElementById('subdomonster-close-btn');
   const statusSpan = document.getElementById('subdomonster-status');
-  const exportBtn = document.getElementById('subdom-export-btn');
-  const exportForm = document.getElementById('subdom-export-form');
-  const exportDomainInp = document.getElementById('subdom-export-domain');
-  const exportFormatInp = document.getElementById('subdom-export-format');
-  const exportQInp = document.getElementById('subdom-export-q');
   // Tagify removed
   let currentPage = 1;
   let tableData = [];
@@ -251,7 +246,10 @@ function initSubdomonster(){
     html += '</tbody></table>';
     tableDiv.innerHTML = html;
     tableDiv.querySelectorAll('.row-tag-input').forEach(el => {
-        originalInputValueFormat: v => v.map(t => t.value).join(',') });
+      new Tagify(el, {
+        maxTags: 1,
+        originalInputValueFormat: v => v.map(t => t.value).join(',')
+      });
     });
     const table = tableDiv.querySelector('table');
     const pageCb = document.getElementById('subdom-page-cb');
@@ -410,18 +408,6 @@ function initSubdomonster(){
 
 
 
-  if(exportBtn && exportForm){
-    exportBtn.addEventListener('click', () => {
-      const fmt = prompt('Format (md,csv,json)', 'json');
-      if(!fmt) return;
-      const domain = domainInput ? domainInput.value.trim() : '';
-      if(!domain) return;
-      if(exportDomainInp) exportDomainInp.value = domain;
-      if(exportFormatInp) exportFormatInp.value = fmt;
-      if(exportQInp) exportQInp.value = '';
-      exportForm.submit();
-    });
-  }
 
 
 


### PR DESCRIPTION
## Summary
- fix Tagify initialization in `subdomonster.js`
- remove unused export button and form from subdomonster overlay

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860ae411bb88332916d95516e9a8dfa