### PR TITLE
Remove stray background path

### DIFF
--- a/app.py
+++ b/app.py
@@ -495,7 +495,7 @@ def index() -> str:
     default_theme = 'nostalgia.css' if 'nostalgia.css' in AVAILABLE_THEMES else (AVAILABLE_THEMES[0] if AVAILABLE_THEMES else '')
     current_theme = session.get('theme', default_theme)
 
-    default_background = 'background.jpg' if 'background.jpg' in AVAILABLE_BACKGROUNDS else (AVAILABLE_BACKGROUNDS[0] if AVAILABLE_BACKGROUNDS else '')
+    default_background = AVAILABLE_BACKGROUNDS[0] if AVAILABLE_BACKGROUNDS else ''
     current_background = session.get('background', default_background)
 
     panel_opacity = float(session.get('panel_opacity', 0.75))

--- a/static/base.css
+++ b/static/base.css
@@ -195,8 +195,7 @@ body {
 /* --- Updated CSS to emulate Fandom Map Room style --- */
 
 .retrorecon-root {
-  background: var(--bg-color) url("/static/img/background.jpg") no-repeat center center fixed;
-  background-size: cover;
+  background: var(--bg-color);
   display: flex;
   flex-direction: column;
   position: relative;


### PR DESCRIPTION
## Summary
- remove old `background.jpg` path from CSS and default background logic
- keep default backgrounds using the first wallpaper if available

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860b5b9b588833289c691b196d4c597