### PR TITLE
Fix subdomonster CDX dropdown

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -362,6 +362,13 @@ function initSubdomonster(){
       link.addEventListener('click', (ev) => {
         ev.preventDefault();
         const sub = decodeURIComponent(link.dataset.sub);
+        const form = document.getElementById('fetch-cdx-form');
+        const input = document.getElementById('domain-input');
+        if(form && input){
+          input.value = sub;
+          form.submit();
+          return;
+        }
         const selected = Array.from(document.querySelectorAll('#subdomonster-table .row-checkbox:checked')).map(c=>c.dataset.sub);
         if(selected.length > 1){
           enqueueCdxImport(selected);


### PR DESCRIPTION
## Summary
- ensure Subdomonster Wayback API menu item submits the existing CDX form

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d08882408332be436b46a0dca068