### PR TITLE
Fix subdomonster CDX dropdown

### DIFF
--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -365,8 +365,19 @@ function initSubdomonster(){
         const selected = Array.from(document.querySelectorAll('#subdomonster-table .row-checkbox:checked')).map(c=>c.dataset.sub);
         if(selected.length > 1){
           enqueueCdxImport(selected);
-        }else{
-          enqueueCdxImport([sub]);
+        } else {
+          const form = document.getElementById('fetch-cdx-form');
+          const input = document.getElementById('domain-input');
+          if(form && input){
+            input.value = sub;
+            if(typeof form.requestSubmit === 'function'){
+              form.requestSubmit();
+            }else{
+              form.submit();
+            }
+          }else{
+            enqueueCdxImport([sub]);
+          }
         }
         const row = link.closest('tr');
         const main = row ? row.previousElementSibling : null;


### PR DESCRIPTION
## Summary
- ensure Subdomonster Wayback API menu item submits the existing CDX form while still handling multi-select imports

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d08882408332be436b46a0dca068