### PR TITLE
Fix boolean search NOT logic

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -23,7 +23,8 @@ curl http://localhost:5000/
 
 Optional query parameter `q` accepts plain text or expressions using the
 `url:`, `timestamp:`, `http:` and `mime:` operators combined with Boolean
-keywords (`AND`, `OR`, `NOT`).
+keywords (`AND`, `OR`, `NOT`). If a term has no prefix it is matched only
+against the URL field.
 
 Example:
 

--- a/retrorecon/search_utils.py
+++ b/retrorecon/search_utils.py
@@ -152,11 +152,10 @@ def parse_search_expression(tokens: List[str], pos: int = 0) -> Tuple[str, List[
             return "mime_type LIKE ?", [f"%{val}%"]
         if lower.startswith('tag:'):
             return "has_tag(tags, ?)", [tok[4:]]
-        return (
-            "(" "url LIKE ? OR tags LIKE ? OR CAST(timestamp AS TEXT) LIKE ? OR "
-            "CAST(status_code AS TEXT) LIKE ? OR mime_type LIKE ?" ")",
-            [f"%{tok}%"] * 5,
-        )
+        # If no prefix is provided, restrict the search to the URL field. This
+        # avoids NOT clauses excluding rows due to matches in unrelated columns
+        # like tags or MIME type.
+        return "url LIKE ?", [f"%{tok}%"]
 
     def parse_primary(p: int) -> Tuple[str, List[str], int]:
         if p >= len(tokens):

--- a/tests/test_boolean_search.py
+++ b/tests/test_boolean_search.py
@@ -1,0 +1,28 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from retrorecon.search_utils import build_search_sql
+
+
+def test_and_not_url_only():
+    conn = sqlite3.connect(':memory:')
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE urls (id INTEGER PRIMARY KEY, url TEXT, timestamp TEXT, status_code INTEGER, mime_type TEXT, tags TEXT)"
+    )
+    # url contains 'config', tags contain '.js'
+    conn.execute(
+        "INSERT INTO urls (url, timestamp, status_code, mime_type, tags) VALUES ('https://demo.com/config', '20210101', 200, 'text/html', 'script.js')"
+    )
+    # url has '.js'
+    conn.execute(
+        "INSERT INTO urls (url, timestamp, status_code, mime_type, tags) VALUES ('https://demo.com/config.js', '20210101', 200, 'application/javascript', '')"
+    )
+
+    sql, params = build_search_sql('config AND NOT .js')
+    rows = conn.execute(f'SELECT url FROM urls WHERE {sql}', params).fetchall()
+    assert [r['url'] for r in rows] == ['https://demo.com/config']
+


### PR DESCRIPTION
## Summary
- limit default search fields to URL only
- document that unspecified terms match URLs
- test NOT logic using a SQLite in-memory table

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c17d786c833288b2899b97ac99b7