### PR TITLE
Fix screen flicker when selecting tags

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -875,6 +875,10 @@
         current = term;
       }
       box.value = current;
+      if(typeof tagsOverlay !== 'undefined' && !tagsOverlay.classList.contains('hidden')){
+        tagsOverlay.classList.add('hidden');
+        tagsOverlay.classList.remove('show');
+      }
       document.getElementById('search-form').submit();
     }
 


### PR DESCRIPTION
## Summary
- close the tags overlay before submitting a quick tag search

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ee1527108332acb859be3b20d8bb