### PR TITLE
Fix wildcard CDX imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -541,7 +541,7 @@ def fetch_cdx() -> Response:
     if not domain:
         flash("No domain provided for CDX fetch.", "error")
         return redirect(url_for('index'))
-    if not re.match(r'^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
+    if not re.match(r'^(?:\*\.)?(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$', domain):
         flash("Invalid domain value.", "error")
         return redirect(url_for('index'))
     if not _db_loaded():

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -36,11 +36,12 @@ curl -G --data-urlencode "q=url:example.com AND http:200" http://localhost:5000/
 Fetch Wayback Machine CDX records for a domain and insert any new URLs into the loaded database.
 
 Parameters:
-- `domain` – domain name to query.
+- `domain` – domain name to query. Prefix with `*.` to include subdomains.
 
 Example:
 ```
 curl -X POST -d "domain=example.com" http://localhost:5000/fetch_cdx
+curl -X POST -d "domain=*.example.com" http://localhost:5000/fetch_cdx
 ```
 
 ### `POST /import_file` (`/import_json`)

--- a/docs/new_user_guide.md
+++ b/docs/new_user_guide.md
@@ -5,6 +5,8 @@ This short guide walks through the typical workflow of exploring archived URLs.
 1. **Fetch CDX data**
    ```bash
    curl -X POST http://localhost:5000/fetch_cdx -d "domain=example.com"
+   # wildcard subdomains are also supported
+   curl -X POST http://localhost:5000/fetch_cdx -d "domain=*.example.com"
    ```
    This pulls Wayback Machine records into the local SQLite database.
 

--- a/tests/test_fetch_cdx_wildcard.py
+++ b/tests/test_fetch_cdx_wildcard.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    with app.app.app_context():
+        app.create_new_db("test")
+
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_fetch_cdx_accepts_wildcard(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+
+    sample = [["original", "timestamp"], ["http://foo.example.com/", "202001"]]
+    monkeypatch.setattr(app.requests, "get", lambda url, timeout=20: FakeResp(sample))
+
+    with app.app.test_client() as client:
+        resp = client.post("/fetch_cdx", data={"domain": "*.example.com", "ajax": "1"})
+        assert resp.status_code == 200
+        assert resp.get_json()["inserted"] == 1
+
+    with app.app.app_context():
+        row = app.query_db("SELECT url FROM urls", one=True)
+        assert row["url"] == "http://foo.example.com/"


### PR DESCRIPTION
## Summary
- support `*.domain.com` patterns when importing CDX data
- document wildcard usage in the user guide and API routes
- add regression test for wildcard CDX imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f6eb51408332990ef5f3ca319dc2