### PR TITLE
Fix CDX import wildcard

### DIFF
--- a/app.py
+++ b/app.py
@@ -550,7 +550,7 @@ def fetch_cdx() -> Response:
 
     cdx_api = (
         'http://web.archive.org/cdx/search/cdx'
-        '?url={domain}/*&output=json&fl=original,timestamp,statuscode,mimetype'
+        '?url=*.{domain}/*&output=json&fl=original,timestamp,statuscode,mimetype'
         '&collapse=urlkey&limit=1000'
     ).format(domain=domain)
 

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -33,7 +33,7 @@ curl -G --data-urlencode "q=url:example.com AND http:200" http://localhost:5000/
 ```
 
 ### `POST /fetch_cdx`
-Fetch Wayback Machine CDX records for a domain and insert any new URLs into the loaded database.
+Fetch Wayback Machine CDX records for a domain and insert any new URLs into the loaded database. The backend automatically queries `url=*.DOMAIN/*` so all subdomains are included.
 
 Parameters:
 - `domain` – domain name to query.

--- a/docs/new_user_guide.md
+++ b/docs/new_user_guide.md
@@ -6,7 +6,7 @@ This short guide walks through the typical workflow of exploring archived URLs.
    ```bash
    curl -X POST http://localhost:5000/fetch_cdx -d "domain=example.com"
    ```
-   This pulls Wayback Machine records into the local SQLite database.
+   This pulls Wayback Machine records for `example.com` **and all of its subdomains** into the local SQLite database. The server automatically queries `url=*.example.com/*`.
 
 2. **Browse results**
    Visit `http://localhost:5000/` in your browser. Use the search box to filter


### PR DESCRIPTION
## Summary
- fetch CDX data using `*.domain/*` so subdomains are included
- clarify docs about automatic wildcard behavior

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861fed7db8c8332947f2c8b4ecde23d