### PR TITLE
Persist last search query

### DIFF
--- a/app.py
+++ b/app.py
@@ -383,7 +383,12 @@ def index() -> str:
         from retrorecon.routes.oci import image_view
         return image_view(image_param)
 
-    q = request.args.get('q', '').strip()
+    q_param = request.args.get('q')
+    if q_param is None:
+        q = session.get('search_query', '').strip()
+    else:
+        q = q_param.strip()
+        session['search_query'] = q
     select_all_matching = request.args.get('select_all_matching', 'false').lower() == 'true'
     try:
         page = int(request.args.get('page', 1))

--- a/tests/test_search_persistence.py
+++ b/tests/test_search_persistence.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    with app.app.app_context():
+        app.create_new_db("test")
+    import retrorecon.routes.dynamic as dyn
+    monkeypatch.setattr(dyn, "dynamic_template", lambda *a, **k: "")
+
+
+def test_query_persists_after_delete(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get('/?q=.json')
+        assert resp.status_code == 200
+        with client.session_transaction() as sess:
+            assert sess.get('search_query') == '.json'
+        resp = client.post('/bulk_action', data={'action': 'delete', 'selected_ids': ['1']})
+        assert resp.status_code == 302
+        resp = client.get('/')
+        assert resp.status_code == 200
+        with client.session_transaction() as sess:
+            assert sess.get('search_query') == '.json'


### PR DESCRIPTION
## Summary
- remember last search query in the session so searches survive page redirects
- test search query persistence after deleting URLs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6862be972f208332885cd0f036a4a153