### PR TITLE
Add markdown editor overlay

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import requests
 import jwt
 import urllib.parse
+from flask_mdeditor import MDEditor
 from flask import (
     Flask,
     render_template,
@@ -60,6 +61,8 @@ from retrorecon.filters import manifest_links, oci_obj, manifest_table, wb_times
 app = Flask(__name__)
 sys.modules.setdefault('app', sys.modules[__name__])
 app.config.from_object(Config)
+os.makedirs(app.config['MDEDITOR_FILE_UPLOADER'], exist_ok=True)
+MDEditor(app)
 app.add_template_filter(manifest_links, name="manifest_links")
 app.add_template_filter(oci_obj, name="oci_obj")
 app.add_template_filter(manifest_table, name="manifest_table")
@@ -404,6 +407,8 @@ def index() -> str:
         tool = 'subdomonster'
     elif request.path == '/tools/text_tools':
         tool = 'text'
+    elif request.path == '/tools/markdown':
+        tool = 'markdown'
     elif request.path == '/tools/readme':
         tool = 'readme'
     elif request.path == '/tools/about':

--- a/config.py
+++ b/config.py
@@ -46,3 +46,11 @@ class Config:
     VIRUSTOTAL_API = os.environ.get('VIRUSTOTAL_API')
     REGISTRY_USERNAME = os.environ.get('REGISTRY_USERNAME')
     REGISTRY_PASSWORD = os.environ.get('REGISTRY_PASSWORD')
+
+    # Markdown editor settings
+    MDEDITOR_FILE_UPLOADER = os.environ.get(
+        'MDEDITOR_UPLOAD_FOLDER', os.path.join(os.getcwd(), 'uploads')
+    )
+    MDEDITOR_THEME = 'dark'
+    MDEDITOR_PREVIEW_THEME = 'dark'
+    MDEDITOR_EDITOR_THEME = 'pastel-on-dark'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest
 requests
 tldextract
 zstandard
+flask-mdeditor

--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -95,6 +95,17 @@ def jwt_tools_full_page():
     return app.index()
 
 
+@bp.route('/markdown_editor', methods=['GET'])
+def markdown_editor_page():
+    return dynamic_template('markdown_editor.html')
+
+
+@bp.route('/tools/markdown', methods=['GET'])
+def markdown_editor_full_page():
+    """Serve the main dashboard so the overlay can open on load."""
+    return app.index()
+
+
 @bp.route('/tools/jwt_decode', methods=['POST'])
 def jwt_decode_route():
     token = request.form.get('token', '')

--- a/static/markdown_editor.js
+++ b/static/markdown_editor.js
@@ -1,0 +1,52 @@
+function initMarkdownEditor(){
+  const overlay = document.getElementById('markdown-editor-overlay');
+  if(!overlay) return;
+  const textarea = overlay.querySelector('textarea[name="mdeditor"]');
+  const closeBtn = document.getElementById('markdown-editor-close');
+  const openBtn = document.getElementById('md-open-btn');
+  const saveBtn = document.getElementById('md-save-btn');
+  const fileInput = document.getElementById('md-file-input');
+
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    document.body.style.overflow = '';
+  });
+
+  openBtn.addEventListener('click', () => fileInput.click());
+
+  fileInput.addEventListener('change', () => {
+    const f = fileInput.files[0];
+    if(f){
+      f.text().then(t => {
+        if(textarea) textarea.value = t;
+        if(window.editormd && window.editormd.instances && window.editormd.instances['mdeditor']){
+          window.editormd.instances['mdeditor'].setValue(t);
+        }
+      });
+    }
+  });
+
+  saveBtn.addEventListener('click', () => {
+    const text = textarea.value;
+    const blob = new Blob([text], {type:'text/markdown'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'document.md';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(a.href);
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
+}
+
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', initMarkdownEditor);
+} else {
+  initMarkdownEditor();
+}

--- a/static/text_tools.js
+++ b/static/text_tools.js
@@ -7,6 +7,7 @@ function initTextTools(){
   const copyBtn = document.getElementById('text-copy-btn');
   const saveBtn = document.getElementById('text-save-btn');
   const saveNoteBtn = document.getElementById('text-save-note-btn');
+  const mdBtn = document.getElementById('text-mdeditor-btn');
   const notesList = document.getElementById('text-notes-list');
   const b64DecodeBtn = document.getElementById('b64-decode-btn');
   const b64EncodeBtn = document.getElementById('b64-encode-btn');
@@ -132,6 +133,14 @@ function initTextTools(){
       }
     });
   });
+
+  if(mdBtn){
+    mdBtn.addEventListener('click', () => {
+      if(typeof showMarkdownEditor === 'function'){
+        showMarkdownEditor(false, input.value);
+      }
+    });
+  }
 
   closeBtn.addEventListener('click', () => {
     if(typeof hideTextTools === 'function'){

--- a/templates/index.html
+++ b/templates/index.html
@@ -213,6 +213,7 @@
           <div class="menu-header">Utilities</div>
           <div class="menu-row"><a href="#" class="menu-btn" id="text-tools-link">Text Tools</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="jwt-tools-link">JWT Tools</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="markdown-editor-link">Markdown Editor</a></div>
           <form method="POST" action="/tools/webpack-zip" class="menu-row" id="webpack-form">
             <input type="hidden" name="map_url" id="webpack-url-input" />
             <button type="button" class="menu-btn" id="webpack-btn">Webpack Exploder</button>
@@ -1158,6 +1159,64 @@
 
       if(location.pathname === '/tools/jwt' || openTool === 'jwt'){
         showJwtTools(true);
+      }
+
+      const markdownLink = document.getElementById('markdown-editor-link');
+      let markdownLoaded = false;
+
+      async function showMarkdownEditor(skipPush, preset){
+        if(!markdownLoaded){
+          const resp = await fetch('/markdown_editor');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          await new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = '/static/markdown_editor.js';
+            script.onload = resolve;
+            script.onerror = reject;
+            document.body.appendChild(script);
+          });
+          markdownLoaded = true;
+        }
+        const ov = document.getElementById('markdown-editor-overlay');
+        const ta = ov.querySelector('textarea[name="mdeditor"]');
+        if(preset && ta){
+          ta.value = preset;
+          if(window.editormd && window.editormd.instances && window.editormd.instances['mdeditor']){
+            window.editormd.instances['mdeditor'].setValue(preset);
+          }
+        }
+        ov.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+        if(!skipPush){
+          history.pushState({tool:'markdown'}, '', '/tools/markdown');
+        }
+      }
+
+      function hideMarkdownEditor(){
+        const ov = document.getElementById('markdown-editor-overlay');
+        if(ov) ov.classList.add('hidden');
+        document.body.style.overflow = '';
+      }
+
+      if(markdownLink){
+        markdownLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          showMarkdownEditor();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/markdown'){
+          showMarkdownEditor(true);
+        } else {
+          hideMarkdownEditor();
+        }
+      });
+
+      if(location.pathname === '/tools/markdown' || openTool === 'markdown'){
+        showMarkdownEditor(true);
       }
 
       const screenshotLink = document.getElementById('screenshot-link');

--- a/templates/markdown_editor.html
+++ b/templates/markdown_editor.html
@@ -1,0 +1,14 @@
+<div id="markdown-editor-overlay" class="notes-overlay hidden">
+  <div class="d-flex flex-between mb-05">
+    <span class="font-bold">Markdown Editor</span>
+    <button type="button" class="btn overlay-close-btn" id="markdown-editor-close">Close</button>
+  </div>
+  <form id="markdown-editor-form">
+    {{ mdeditor.load(name='mdeditor') }}
+  </form>
+  <div class="mt-05">
+    <button type="button" class="btn" id="md-open-btn">Load File</button>
+    <input type="file" id="md-file-input" accept=".md,text/markdown" class="d-none" />
+    <button type="button" class="btn" id="md-save-btn">Save As</button>
+  </div>
+</div>

--- a/templates/text_tools.html
+++ b/templates/text_tools.html
@@ -9,6 +9,7 @@
     <button type="button" class="btn" id="text-copy-btn"><span class="emoji-badge" aria-hidden="true">📋</span>Copy</button>
     <button type="button" class="btn" id="text-save-btn"><span class="emoji-badge" aria-hidden="true">💾</span>Save As</button>
     <button type="button" class="btn" id="text-save-note-btn"><span class="emoji-badge" aria-hidden="true">📝</span>Save Note</button>
+    <button type="button" class="btn" id="text-mdeditor-btn">Markdown Editor</button>
   </div>
   <div id="text-notes-list" class="notes-list mt-05"></div>
 </div>


### PR DESCRIPTION
## Summary
- add flask-mdeditor dependency and config
- initialize markdown editor in app
- create Markdown editor overlay and JS
- hook overlay into Tools menu and Text Tools
- add routes and open-tool handling

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862ce3eeb588332a95d5c25df8c3c18