### PR TITLE
Enhance Markdown editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ RetroRecon digs through the internet’s attic to find forgotten, buried, or qui
 | Dynamic Rendering API         | Programmatically render pages from schemas with managed assets             |
 | OCI Registry Table Explorer   | Browse container images as tables with direct download links |
 | HTTPolaroid Snapshots         | Capture a single URL with full headers, screenshot and assets into a zip |
+| Markdown Editor               | Edit and preview project docs with a resizable editor |
 | Subdomain Info Summary        | View aggregate counts of root domains and hosts |
 
 ---

--- a/config.py
+++ b/config.py
@@ -54,3 +54,6 @@ class Config:
     MDEDITOR_THEME = 'dark'
     MDEDITOR_PREVIEW_THEME = 'dark'
     MDEDITOR_EDITOR_THEME = 'pastel-on-dark'
+    MDEDITOR_WIDTH = '100%'
+    MDEDITOR_HEIGHT = 700
+    MARKDOWN_STORAGE = os.path.join(os.getcwd(), 'docs')

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -216,6 +216,27 @@ Serve the JWT Tools overlay used for decoding and encoding JWTs.
 curl http://localhost:5000/jwt_tools
 ```
 
+### `GET /markdown_editor`
+Serve the Markdown Editor overlay with the file list sidebar.
+
+```
+curl http://localhost:5000/markdown_editor
+```
+
+### `GET /markdown_files`
+Return a JSON array of Markdown filenames located under the configured docs directory.
+
+```
+curl http://localhost:5000/markdown_files
+```
+
+### `GET /markdown_file/<name>`
+Return the raw contents of `<name>` from the docs directory.
+
+```
+curl http://localhost:5000/markdown_file/api_routes.md
+```
+
 ### `POST /tools/jwt_decode`
 Decode a JWT sent in the `token` field. Returns JSON containing the header,
 payload and additional fields:

--- a/retrorecon/markdown_utils.py
+++ b/retrorecon/markdown_utils.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+from typing import List
+
+
+def list_markdown_files(directory: Path) -> List[str]:
+    """Return sorted Markdown filenames under *directory*."""
+    if not directory.exists():
+        return []
+    return sorted(f.name for f in directory.glob('*.md') if f.is_file())
+
+
+def read_markdown_file(directory: Path, name: str) -> str:
+    """Return the text of *name* from *directory* or raise ``FileNotFoundError``."""
+    # Prevent directory traversal
+    if '/' in name or '\\' in name or not name.endswith('.md'):
+        raise FileNotFoundError(name)
+    path = directory / name
+    if not path.is_file():
+        raise FileNotFoundError(name)
+    return path.read_text(encoding='utf-8')

--- a/retrorecon/routes/tools.py
+++ b/retrorecon/routes/tools.py
@@ -106,6 +106,31 @@ def markdown_editor_full_page():
     return app.index()
 
 
+@bp.route('/markdown_files', methods=['GET'])
+def markdown_files():
+    """Return a list of Markdown files from the configured directory."""
+    from pathlib import Path
+    from retrorecon.markdown_utils import list_markdown_files
+
+    directory = Path(current_app.config['MARKDOWN_STORAGE'])
+    files = list_markdown_files(directory)
+    return jsonify(files)
+
+
+@bp.route('/markdown_file/<path:name>', methods=['GET'])
+def markdown_file(name: str):
+    """Return the contents of a Markdown file."""
+    from pathlib import Path
+    from retrorecon.markdown_utils import read_markdown_file
+
+    directory = Path(current_app.config['MARKDOWN_STORAGE'])
+    try:
+        text = read_markdown_file(directory, name)
+    except FileNotFoundError:
+        return ('', 404)
+    return Response(text, mimetype='text/markdown')
+
+
 @bp.route('/tools/jwt_decode', methods=['POST'])
 def jwt_decode_route():
     token = request.form.get('token', '')

--- a/static/base.css
+++ b/static/base.css
@@ -1423,3 +1423,29 @@ body.bg-hidden {
   from { top: 100%; }
   to { top: -100%; }
 }
+
+.retrorecon-root #markdown-editor-overlay {
+  overflow: hidden;
+}
+
+.retrorecon-root .md-editor-body {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.retrorecon-root .md-file-list {
+  width: 14em;
+  overflow-y: auto;
+  border-right: 1px solid var(--fg-color);
+  padding-right: 0.5em;
+}
+
+.retrorecon-root .md-file-item {
+  cursor: pointer;
+  margin-bottom: 0.25em;
+}
+
+.retrorecon-root .md-file-item:hover {
+  text-decoration: underline;
+}

--- a/static/markdown_editor.js
+++ b/static/markdown_editor.js
@@ -6,6 +6,30 @@ function initMarkdownEditor(){
   const openBtn = document.getElementById('md-open-btn');
   const saveBtn = document.getElementById('md-save-btn');
   const fileInput = document.getElementById('md-file-input');
+  const fileList = document.getElementById('md-file-list');
+
+  function loadFiles(){
+    if(!fileList) return;
+    fetch('/markdown_files').then(r=>r.json()).then(files => {
+      fileList.innerHTML = '';
+      files.forEach(name => {
+        const item = document.createElement('div');
+        item.className = 'md-file-item';
+        item.textContent = name;
+        item.addEventListener('click', () => {
+          fetch('/markdown_file/' + encodeURIComponent(name))
+            .then(r=>r.text())
+            .then(t => {
+              if(textarea) textarea.value = t;
+              if(window.editormd && window.editormd.instances && window.editormd.instances['mdeditor']){
+                window.editormd.instances['mdeditor'].setValue(t);
+              }
+            });
+        });
+        fileList.appendChild(item);
+      });
+    });
+  }
 
   closeBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');
@@ -43,6 +67,8 @@ function initMarkdownEditor(){
       closeBtn.click();
     }
   });
+
+  loadFiles();
 }
 
 if(document.readyState === 'loading'){

--- a/templates/markdown_editor.html
+++ b/templates/markdown_editor.html
@@ -1,11 +1,12 @@
 <div id="markdown-editor-overlay" class="notes-overlay hidden">
-  <div class="d-flex flex-between mb-05">
-    <span class="font-bold">Markdown Editor</span>
-    <button type="button" class="btn overlay-close-btn" id="markdown-editor-close">Close</button>
+  <button type="button" class="btn overlay-close-btn" id="markdown-editor-close">Close</button>
+  <div class="font-bold mb-05">Markdown Editor</div>
+  <div class="md-editor-body d-flex flex-1">
+    <div id="md-file-list" class="md-file-list mr-05"></div>
+    <form id="markdown-editor-form" class="flex-1">
+      {{ mdeditor.load(name='mdeditor') }}
+    </form>
   </div>
-  <form id="markdown-editor-form">
-    {{ mdeditor.load(name='mdeditor') }}
-  </form>
   <div class="mt-05">
     <button type="button" class="btn" id="md-open-btn">Load File</button>
     <input type="file" id="md-file-input" accept=".md,text/markdown" class="d-none" />

--- a/tests/test_markdown_files.py
+++ b/tests/test_markdown_files.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "one.md").write_text("hello")
+    monkeypatch.setitem(app.app.config, "MARKDOWN_STORAGE", str(docs))
+
+
+def test_markdown_file_routes(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get("/markdown_files")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "one.md" in data
+        resp = client.get("/markdown_file/one.md")
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == "hello"


### PR DESCRIPTION
## Summary
- expand markdown editor and show saved docs list
- support listing and serving markdown files
- document new routes and update feature table
- add config and utilities for docs path
- test markdown file endpoints

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d4b1169883328dc6261aacacee5a