### PR TITLE
Add domain sort overlay

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -504,6 +504,20 @@ Full-page subdomain overlay with the same bulk-selection features.
 curl http://localhost:5000/tools/subdomonster
 ```
 
+### `GET /domain_sort`
+Serve the recursive domain sort overlay.
+
+```
+curl http://localhost:5000/domain_sort
+```
+
+### `GET /tools/domain_sort`
+Full-page domain sort overlay that loads on page visit.
+
+```
+curl http://localhost:5000/tools/domain_sort
+```
+
 ### `GET /subdomains`
 List subdomains from the database.
 

--- a/docs/menu_mapping.md
+++ b/docs/menu_mapping.md
@@ -28,6 +28,7 @@ This table lists each HTML template in the project alongside the dynamic pattern
 | screenshotter.html | screenshotter_page |
 | httpolaroid.html | static_html |
 | subdomonster.html | subdomonster_page |
+| domain_sort.html | static_html |
 | subdomain_summary.html | static_html |
 | swaggerui.html | static_html |
 | text_tools.html | static_html |

--- a/docs/template_overview.md
+++ b/docs/template_overview.md
@@ -26,6 +26,7 @@ This document catalogs the HTML templates currently present in the repository an
 | `httpolaroid.html` | Overlay similar to Screenshotter but crawls a URL and packages all assets into a downloadable ZIP. |
 | `subdomonster.html` | Overlay that fetches subdomains from crt.sh or VirusTotal, supports tagging and export with pagination. |
 | `subdomain_summary.html` | Displays counts of root domains and hosts with top and bottom subdomains. |
+| `domain_sort.html` | Accepts a list of domains and renders them as a recursive tree grouped by root domain. |
 | `swaggerui.html` | Embeds Swagger UI for browsing the REST API, applying Retrorecon theming. |
 | `text_tools.html` | Overlay for encoding/decoding text using Base64 or URL transforms with copy/save actions. |
 

--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -1,0 +1,31 @@
+/* File: static/domain_sort.js */
+function initDomainSort(){
+  const overlay = document.getElementById('domain-sort-overlay');
+  if(!overlay) return;
+  const form = document.getElementById('domain-sort-form');
+  const outputDiv = document.getElementById('domain-sort-output');
+  const closeBtn = document.getElementById('domain-sort-close-btn');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+    const resp = await fetch('/domain_sort', {method:'POST', body: formData});
+    outputDiv.innerHTML = await resp.text();
+  });
+
+  closeBtn.addEventListener('click', () => {
+    history.back();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
+}
+
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', initDomainSort);
+}else{
+  initDomainSort();
+}

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -368,6 +368,18 @@ paths:
       responses:
         '200':
           description: Successful response
+  /domain_sort:
+    get:
+      summary: GET /domain_sort
+      responses:
+        '200':
+          description: Successful response
+  /tools/domain_sort:
+    get:
+      summary: GET /tools/domain_sort
+      responses:
+        '200':
+          description: Successful response
   /subdomains:
     get:
       summary: GET /subdomains

--- a/templates/domain_sort.html
+++ b/templates/domain_sort.html
@@ -1,0 +1,12 @@
+<div id="domain-sort-overlay" class="notes-overlay hidden">
+  <button type="button" class="btn overlay-close-btn" id="domain-sort-close-btn">Close</button>
+  <form id="domain-sort-form" method="post" enctype="multipart/form-data" class="mt-05">
+    <label>Paste domains:<br/>
+      <textarea name="domains" rows="10" cols="60" class="form-input"></textarea>
+    </label><br/>
+    <label>Or upload file: <input type="file" name="file"></label><br/>
+    <label><input type="checkbox" name="as_html" value="1"/> Output as HTML</label><br/>
+    <button type="submit" class="btn mt-05">Generate Tree</button>
+  </form>
+  <div id="domain-sort-output" class="mt-05"></div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -201,6 +201,7 @@
       <div class="dropdown-content" id="tools-menu">
           <div class="menu-header">OSINT</div>
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="domain-sort-link">Domain Sort</a></div>
           <div class="menu-row"><a href="/domain_summary" class="menu-btn">Subdomain Info</a></div>
           <form method="POST" action="/fetch_cdx" class="menu-row" id="fetch-cdx-form">
             <input id="domain-input" type="hidden" name="domain" />
@@ -1401,6 +1402,53 @@
 
       if(location.pathname === '/tools/subdomonster' || openTool === 'subdomonster'){
         showSubdomonster(true);
+      }
+
+      const sortLink = document.getElementById('domain-sort-link');
+      let sortLoaded = false;
+
+      async function showDomainSort(skipPush){
+        if(!sortLoaded){
+          const resp = await fetch('/domain_sort');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/domain_sort.js';
+          document.body.appendChild(script);
+          sortLoaded = true;
+        }
+        document.getElementById('domain-sort-overlay').classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+        if(!skipPush){
+          history.pushState({tool:'domain_sort'}, '', '/tools/domain_sort');
+        }
+      }
+
+      function hideDomainSort(){
+        const ov = document.getElementById('domain-sort-overlay');
+        if(ov) ov.classList.add('hidden');
+        document.body.style.overflow = '';
+      }
+
+      if(sortLink){
+        sortLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          closeMenus();
+          showDomainSort();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/domain_sort'){
+          showDomainSort(true);
+        } else {
+          hideDomainSort();
+        }
+      });
+
+      if(location.pathname === '/tools/domain_sort' || openTool === 'domain_sort'){
+        showDomainSort(true);
       }
 
       window.addEventListener('popstate', () => {


### PR DESCRIPTION
## Summary
- implement recursive domain sort endpoint
- add domain sort overlay and JS
- expose the new tool in the UI and docs

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ded6b88c8332b8536fc293a06611