### PR TITLE
Fix markdown editor layout issues

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1449,3 +1449,13 @@ body.bg-hidden {
 .retrorecon-root .md-file-item:hover {
   text-decoration: underline;
 }
+
+.retrorecon-root #markdown-editor-form,
+.retrorecon-root #markdown-editor-form .wmd-wrapper,
+.retrorecon-root #markdown-editor-form .editormd {
+  height: 100%;
+}
+
+.retrorecon-root #markdown-editor-close {
+  right: 1em;
+}

--- a/static/markdown_editor.js
+++ b/static/markdown_editor.js
@@ -30,6 +30,20 @@ function initMarkdownEditor(){
       });
     });
   }
+  window.loadMdFiles = loadFiles;
+
+  function refreshEditor(){
+    if(window.editormd && window.editormd.instances && window.editormd.instances['mdeditor']){
+      const inst = window.editormd.instances['mdeditor'];
+      const body = overlay.querySelector('.md-editor-body');
+      if(body){
+        inst.resize('100%', body.clientHeight || 700);
+      } else {
+        inst.resize('100%', 700);
+      }
+    }
+  }
+  window.refreshMdEditor = refreshEditor;
 
   closeBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');

--- a/templates/index.html
+++ b/templates/index.html
@@ -1189,6 +1189,8 @@
         }
         ov.classList.remove('hidden');
         document.body.style.overflow = 'hidden';
+        if(window.loadMdFiles) window.loadMdFiles();
+        if(window.refreshMdEditor) window.refreshMdEditor();
         if(!skipPush){
           history.pushState({tool:'markdown'}, '', '/tools/markdown');
         }


### PR DESCRIPTION
## Summary
- resize Markdown editor after overlay opens and expose helper functions
- ensure Markdown form uses full overlay height and adjust close button
- refresh file list and editor size whenever the overlay is displayed

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e17d06608332a377d14c8aa8f61c