### PR TITLE
Fix domain summary overlay refresh

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -726,3 +726,10 @@ Return aggregate subdomain statistics including the top and loneliest hosts.
 curl http://localhost:5000/domain_summary
 ```
 
+### `GET /domain_summary.json`
+Return the same subdomain summary data as JSON.
+
+```
+curl http://localhost:5000/domain_summary.json
+```
+

--- a/static/domain_summary.js
+++ b/static/domain_summary.js
@@ -1,0 +1,56 @@
+/* File: static/domain_summary.js */
+function initDomainSummary(){
+  const overlay = document.getElementById('domain-summary-overlay');
+  if(!overlay) return;
+  const closeBtn = document.getElementById('domain-summary-close-btn');
+  const totalDomains = document.getElementById('summary-total-domains');
+  const totalHosts = document.getElementById('summary-total-hosts');
+  const topList = document.getElementById('summary-top-list');
+  const lonelyList = document.getElementById('summary-lonely-list');
+
+  async function loadSummary(){
+    try{
+      const resp = await fetch('/domain_summary.json');
+      if(!resp.ok) return;
+      const data = await resp.json();
+      totalDomains.textContent = data.total_domains;
+      totalHosts.textContent = data.total_hosts;
+      topList.innerHTML = '';
+      data.top_subdomains.forEach(([d,c])=>{
+        const li = document.createElement('li');
+        li.textContent = `${d} (${c})`;
+        topList.appendChild(li);
+      });
+      lonelyList.innerHTML = '';
+      data.lonely_subdomains.forEach(([d,c])=>{
+        const li = document.createElement('li');
+        li.textContent = `${d} (${c})`;
+        lonelyList.appendChild(li);
+      });
+    }catch{}
+  }
+
+  closeBtn.addEventListener('click', () => {
+    overlay.classList.add('hidden');
+    document.body.style.overflow = '';
+    if(location.pathname === '/tools/domain_summary'){
+      history.pushState({}, '', '/');
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && !overlay.classList.contains('hidden')){
+      closeBtn.click();
+    }
+  });
+
+  loadSummary();
+  setInterval(loadSummary, 5000);
+  window.loadDomainSummary = loadSummary;
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded', initDomainSummary);
+}else{
+  initDomainSummary();
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -202,7 +202,7 @@
           <div class="menu-header">OSINT</div>
           <div class="menu-row"><a href="#" class="menu-btn" id="subdomonster-link">Subdomonster</a></div>
           <div class="menu-row"><a href="#" class="menu-btn" id="domain-sort-link">Domain Sort</a></div>
-          <div class="menu-row"><a href="/domain_summary" class="menu-btn">Subdomain Info</a></div>
+          <div class="menu-row"><a href="#" class="menu-btn" id="domain-summary-link">Subdomain Info</a></div>
           <form method="POST" action="/fetch_cdx" class="menu-row" id="fetch-cdx-form">
             <input id="domain-input" type="hidden" name="domain" />
             <button type="button" class="menu-btn" id="fetch-cdx-btn">Hindsight (CDX API)</button>
@@ -1449,6 +1449,54 @@
 
       if(location.pathname === '/tools/domain_sort' || openTool === 'domain_sort'){
         showDomainSort(true);
+      }
+
+      const summaryLink = document.getElementById('domain-summary-link');
+      let summaryLoaded = false;
+
+      async function showDomainSummary(skipPush){
+        if(!summaryLoaded){
+          const resp = await fetch('/domain_summary');
+          const html = await resp.text();
+          const root = document.querySelector('.retrorecon-root') || document.body;
+          root.insertAdjacentHTML('beforeend', html);
+          const script = document.createElement('script');
+          script.src = '/static/domain_summary.js';
+          document.body.appendChild(script);
+          summaryLoaded = true;
+        }
+        document.getElementById('domain-summary-overlay').classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+        if(window.loadDomainSummary){ window.loadDomainSummary(); }
+        if(!skipPush){
+          history.pushState({tool:'domain_summary'}, '', '/tools/domain_summary');
+        }
+      }
+
+      function hideDomainSummary(){
+        const ov = document.getElementById('domain-summary-overlay');
+        if(ov) ov.classList.add('hidden');
+        document.body.style.overflow = '';
+      }
+
+      if(summaryLink){
+        summaryLink.addEventListener('click', async (e) => {
+          e.preventDefault();
+          closeMenus();
+          showDomainSummary();
+        });
+      }
+
+      window.addEventListener('popstate', () => {
+        if(location.pathname === '/tools/domain_summary'){
+          showDomainSummary(true);
+        } else {
+          hideDomainSummary();
+        }
+      });
+
+      if(location.pathname === '/tools/domain_summary' || openTool === 'domain_summary'){
+        showDomainSummary(true);
       }
 
       window.addEventListener('popstate', () => {

--- a/templates/subdomain_summary.html
+++ b/templates/subdomain_summary.html
@@ -1,27 +1,18 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Subdomain Summary</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
-</head>
-<body>
-  <div class="retrorecon-root">
-    <h1>Subdomain Summary</h1>
-    <p>Total root domains: {{ total_domains }}</p>
-    <p>Total unique hosts: {{ total_hosts }}</p>
-    <h2>Top 5 Subdomains</h2>
-    <ul>
-    {% for dom, cnt in top_subdomains %}
-      <li>{{ dom }} ({{ cnt }})</li>
-    {% endfor %}
-    </ul>
-    <h2>Lonely Subdomains</h2>
-    <ul>
-    {% for dom, cnt in lonely_subdomains %}
-      <li>{{ dom }} ({{ cnt }})</li>
-    {% endfor %}
-    </ul>
-  </div>
-</body>
-</html>
+<div id="domain-summary-overlay" class="notes-overlay hidden">
+  <button type="button" class="btn overlay-close-btn" id="domain-summary-close-btn">Close</button>
+  <h1>Subdomain Summary</h1>
+  <p>Total root domains: <span id="summary-total-domains">{{ total_domains }}</span></p>
+  <p>Total unique hosts: <span id="summary-total-hosts">{{ total_hosts }}</span></p>
+  <h2>Top 5 Subdomains</h2>
+  <ul id="summary-top-list">
+  {% for dom, cnt in top_subdomains %}
+    <li>{{ dom }} ({{ cnt }})</li>
+  {% endfor %}
+  </ul>
+  <h2>Lonely Subdomains</h2>
+  <ul id="summary-lonely-list">
+  {% for dom, cnt in lonely_subdomains %}
+    <li>{{ dom }} ({{ cnt }})</li>
+  {% endfor %}
+  </ul>
+</div>

--- a/tests/test_domain_summary_api.py
+++ b/tests/test_domain_summary_api.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+from retrorecon import subdomain_utils
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    with app.app.app_context():
+        app.create_new_db("test")
+
+
+def test_domain_summary_json(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        subdomain_utils.insert_records("example.com", ["a.example.com", "b.example.com"], "crtsh")
+        subdomain_utils.insert_records("other.com", ["x.other.com"], "crtsh")
+    with app.app.test_client() as client:
+        resp = client.get("/domain_summary.json")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total_domains"] == 2
+        assert data["total_hosts"] == 3
+        assert any(dom == "a.example.com" for dom, cnt in data["top_subdomains"])


### PR DESCRIPTION
## Summary
- provide live domain summary page with close button
- expose `/domain_summary.json` for AJAX refresh
- hook new overlay and script into the UI
- document the new endpoint
- test JSON output

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e33a87c88332a6b01784f2c10240