### PR TITLE
Fix theme pill button styles

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -948,14 +948,14 @@ body {
 .retrorecon-root .search-history .tag-pill {
   display: inline-flex;
   align-items: center;
-  padding: 1px 3px;
+  padding: 0px 0px;
   font-size: 0.275em;
   font-weight: 600;
-  margin-right: 4px;
-  margin-bottom: 4px;
+  margin-right: 0;
+  margin-bottom: 0px;
   color: var(--fg-color);
   border: 1px solid var(--color-contrast);
-  border-radius: 999px;
+  border-radius: 0;
   background: linear-gradient(135deg, #ff2caf, #6a4cff);
   cursor: pointer;
   transition: opacity 0.2s;

--- a/static/themes/terminal-sans-dark.css
+++ b/static/themes/terminal-sans-dark.css
@@ -2,7 +2,7 @@
 :root {
   --color-base: #222225;
   --color-contrast: #e8e9ed;
-  --color-accent: #62c4ff;
+  --color-accent: #8be9fd;
   --font-main: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   --bg-color: var(--color-base);
   --bg-rgb: 34 34 37;

--- a/static/themes/theme-neon.css
+++ b/static/themes/theme-neon.css
@@ -13,12 +13,12 @@
   --bg-rgb: 0 0 0;
   --panel-opacity: 0.92;
   --fg-color: var(--font-main);
-  --accent-color: var(--font-accent);
+  --accent-color: var(--color-accent);
 
   /* Generic variable names for dynamic theming */
   --color-bg: var(--bg-color);
   --color-text: var(--fg-color);
-  --color-accent: var(--font-accent);
+  --color-accent: #8be9fd;
   --color-border: var(--border-color);
   --font-family-base: var(--font-main);
 }
@@ -194,14 +194,14 @@ body.bg-hidden {
 .retrorecon-root .search-history .tag-pill {
   display: inline-flex;
   align-items: center;
-  padding: 1px 3px;
+  padding: 0px 0px;
   font-size: 0.275em;
   font-weight: 600;
-  margin-right: 4px;
-  margin-bottom: 4px;
+  margin-right: 0;
+  margin-bottom: 0px;
   color: var(--fg-color);
   border: 1px solid var(--color-contrast);
-  border-radius: 999px;
+  border-radius: 0;
   background: linear-gradient(135deg, #ff2caf, #6a4cff);
   cursor: pointer;
   transition: opacity 0.2s;


### PR DESCRIPTION
## Summary
- update default `.search-history` pill buttons
- fix neon theme pill button layout
- standardize accent color across themes

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6862e5a9f02483329f70187df2cf0331