### PR TITLE
Add subdomain editing via UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -374,6 +374,15 @@ def delete_subdomain(root_domain: str, subdomain: str) -> None:
     subdomain_utils.delete_record(root_domain, subdomain)
 
 
+def update_subdomain(
+    old_root_domain: str, old_subdomain: str, new_root_domain: str, new_subdomain: str
+) -> None:
+    """Rename a subdomain entry in the database."""
+    subdomain_utils.update_record(
+        old_root_domain, old_subdomain, new_root_domain, new_subdomain
+    )
+
+
 @app.route('/', methods=['GET'])
 def index() -> str:
     """Render the main search page or serve registry explorer views."""

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -594,6 +594,15 @@ Delete a subdomain entry.
 curl -X POST -d "domain=example.com" -d "subdomain=dev" http://localhost:5000/delete_subdomain
 ```
 
+### `POST /update_subdomain`
+Rename a subdomain entry.
+
+```
+curl -X POST -d "domain=example.com" -d "subdomain=old" \
+     -d "new_domain=example.net" -d "new_subdomain=new" \
+     http://localhost:5000/update_subdomain
+```
+
 
 ### `POST /load_saved_db`
 Switch to a database file stored under `db/`.

--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -237,6 +237,21 @@ def delete_subdomain_route():
     return ('', 204)
 
 
+@bp.route('/update_subdomain', methods=['POST'])
+def update_subdomain_route():
+    """Rename a subdomain entry."""
+    if not app._db_loaded():
+        return ('', 400)
+    domain = request.form.get('domain', '').strip().lower()
+    subdomain = request.form.get('subdomain', '').strip().lower()
+    new_domain = request.form.get('new_domain', '').strip().lower()
+    new_subdomain = request.form.get('new_subdomain', '').strip().lower()
+    if not domain or not subdomain or not new_domain or not new_subdomain:
+        return ('', 400)
+    app.update_subdomain(domain, subdomain, new_domain, new_subdomain)
+    return ('', 204)
+
+
 @bp.route('/subdomain_action', methods=['POST'])
 def subdomain_action():
     """Bulk modify or delete subdomains."""

--- a/retrorecon/subdomain_utils.py
+++ b/retrorecon/subdomain_utils.py
@@ -114,6 +114,17 @@ def delete_record(root_domain: str, subdomain: str) -> None:
     )
 
 
+def update_record(
+    root_domain: str, subdomain: str, new_root: str, new_sub: str
+) -> None:
+    """Rename ``subdomain`` and/or ``root_domain`` in the DB."""
+    execute_db(
+        "UPDATE domains SET root_domain = ?, subdomain = ?"
+        " WHERE root_domain = ? AND subdomain = ?",
+        [_clean(new_root), _clean(new_sub), _clean(root_domain), _clean(subdomain)],
+    )
+
+
 def add_tag(root_domain: str, subdomain: str, tag: str) -> None:
     rows = query_db(
         "SELECT id, tags FROM domains WHERE root_domain = ? AND subdomain = ?",

--- a/static/base.css
+++ b/static/base.css
@@ -1392,7 +1392,7 @@ body.bg-hidden {
 }
 .retrorecon-root #subdomonster-close-btn {
   top: 1em;
-  right: 1em;
+  right: calc(1em + 10px);
 }
 
 .retrorecon-root .help-overlay {

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -415,6 +415,12 @@ paths:
       responses:
         '200':
           description: Successful response
+  /update_subdomain:
+    post:
+      summary: POST /update_subdomain
+      responses:
+        '200':
+          description: Successful response
   /subdomain_action:
     post:
       summary: POST /subdomain_action

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -234,6 +234,7 @@ function initSubdomonster(){
               `</div>`+
             `</div>`+
             `<button type="button" class="btn explode-btn copy-btn" data-sub="${encoded}" title="Copy">📋 Copy</button>`+
+            `<button type="button" class="btn edit-btn" title="Edit">✏️ Edit</button>`+
             `<button type="button" class="btn delete-btn" title="Delete">🗑️ Delete</button>`+
             `<button type="button" class="btn ml-05 notes-btn" data-sub="${encoded}">📝 Notes</button>`+
             `<input type="text" class="form-input ml-05 row-tag-input tag-input" placeholder="Tag" size="8" />`+
@@ -303,6 +304,36 @@ function initSubdomonster(){
           document.body.removeChild(t);
           btn.textContent = 'Copied!';
           setTimeout(() => { btn.textContent = '📋 Copy'; }, 1000);
+        }
+      });
+    });
+
+    table.querySelectorAll('.edit-btn').forEach(btn => {
+      btn.addEventListener('click', async ev => {
+        ev.stopPropagation();
+        const tr = btn.closest('tr');
+        if(!tr) return;
+        const sub = tr.dataset.sub;
+        const domain = tr.dataset.domain;
+        const newSub = prompt('Subdomain', sub);
+        if(!newSub) return;
+        const newDom = prompt('Root domain', domain);
+        if(!newDom) return;
+        const params = new URLSearchParams({domain, subdomain: sub, new_domain: newDom, new_subdomain: newSub});
+        const resp = await fetch('/update_subdomain', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:params});
+        if(resp.ok){
+          const item = tableData.find(r => r.subdomain === sub && r.domain === domain);
+          if(item){
+            item.subdomain = newSub;
+            item.domain = newDom;
+          }
+          if(selectedSubs.has(sub)){
+            selectedSubs.delete(sub);
+            selectedSubs.add(newSub);
+          }
+          render();
+        } else {
+          alert('Update failed');
         }
       });
     });

--- a/tests/test_update_subdomain.py
+++ b/tests/test_update_subdomain.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+from retrorecon import subdomain_utils
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    with app.app.app_context():
+        app.create_new_db("test")
+
+
+def test_update_subdomain(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        subdomain_utils.insert_records("example.com", ["a.example.com"], "crtsh")
+    with app.app.test_client() as client:
+        resp = client.post(
+            "/update_subdomain",
+            data={
+                "domain": "example.com",
+                "subdomain": "a.example.com",
+                "new_domain": "example.net",
+                "new_subdomain": "b.example.net",
+            },
+        )
+        assert resp.status_code == 204
+    with app.app.app_context():
+        rows = subdomain_utils.list_subdomains("example.net")
+        assert any(r["subdomain"] == "b.example.net" for r in rows)


### PR DESCRIPTION
## Summary
- allow renaming subdomain records via new `/update_subdomain` endpoint
- adjust subdomonster close button position
- add Edit button in subdomain table
- document new API route
- expand OpenAPI spec
- test updating a subdomain

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e6f79fac8332af5a0fa27a0dd2ee