### PR TITLE
Enhance domain sort tool

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -532,6 +532,14 @@ Serve the recursive domain sort overlay.
 curl http://localhost:5000/domain_sort
 ```
 
+### `POST /domain_sort`
+Generate a collapsible domain tree. Accepts a file upload named `file` and an optional
+`format` field of `html` or `md`. When `format=md`, a Markdown document is returned.
+
+```
+curl -X POST -F "file=@domains.txt" -F "format=md" http://localhost:5000/domain_sort
+```
+
 ### `GET /tools/domain_sort`
 Full-page domain sort overlay that loads on page visit.
 

--- a/docs/template_overview.md
+++ b/docs/template_overview.md
@@ -26,7 +26,7 @@ This document catalogs the HTML templates currently present in the repository an
 | `httpolaroid.html` | Overlay similar to Screenshotter but crawls a URL and packages all assets into a downloadable ZIP. |
 | `subdomonster.html` | Overlay that fetches subdomains from crt.sh or VirusTotal, supports tagging and export with pagination. |
 | `subdomain_summary.html` | Displays counts of root domains and hosts with top and bottom subdomains. |
-| `domain_sort.html` | Accepts a list of domains and renders them as a recursive tree grouped by root domain. |
+| `domain_sort.html` | Upload a domain list and view a collapsible tree grouped by root domain with an optional Markdown export. |
 | `swaggerui.html` | Embeds Swagger UI for browsing the REST API, applying Retrorecon theming. |
 | `text_tools.html` | Overlay for encoding/decoding text using Base64 or URL transforms with copy/save actions. |
 

--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -33,18 +33,38 @@ def _build_tree(domains):
     return tree
 
 
-def _render_tree(tree, root, domains, level=0, printed=None, as_html=False):
+def _render_tree_md(tree, root, domains, level=0, printed=None):
+    """Return a Markdown bullet list of the domain tree."""
     if printed is None:
         printed = set()
     if root in printed:
         return ""
     indent = '  ' * level
-    line = f"{indent}{root}\n" if not as_html else f"{'&nbsp;' * 2 * level}{root}<br/>"
+    line = f"{indent}- {root}\n"
     printed.add(root)
     children = [d for d in domains if d.endswith('.' + root) and d not in printed]
     children = sorted(children, key=lambda d: (len(d.split('.')), d))
     for child in children:
-        line += _render_tree(tree, child, domains, level + 1, printed, as_html)
+        line += _render_tree_md(tree, child, domains, level + 1, printed)
+    return line
+
+
+def _render_tree_html(tree, root, domains, printed=None):
+    """Return nested <li> elements wrapped in <details> for collapsible tree."""
+    if printed is None:
+        printed = set()
+    if root in printed:
+        return ""
+    printed.add(root)
+    children = [d for d in domains if d.endswith('.' + root) and d not in printed]
+    children = sorted(children, key=lambda d: (len(d.split('.')), d))
+    if children:
+        line = f'<li><details class="collapsible" open><summary>{root}</summary><ul>'
+        for child in children:
+            line += _render_tree_html(tree, child, domains, printed)
+        line += '</ul></details></li>'
+    else:
+        line = f'<li>{root}</li>'
     return line
 
 
@@ -298,16 +318,33 @@ def domain_sort_page():
         roots = defaultdict(list)
         for dom in domains:
             roots[_extract_root(dom)].append(dom)
-        as_html = request.form.get('as_html', '0') == '1'
-        output = ''
+        fmt = request.form.get('format', 'html')
+        if fmt not in ('html', 'md'):
+            fmt = 'html'
+        if fmt == 'md':
+            lines = []
+            for root in sorted(roots):
+                lines.append(f"### {root}")
+                tree = _build_tree(roots[root])
+                top_level = [d for d in roots[root] if d == root or (d.endswith('.'+root) and d.count('.') == root.count('.') + 1)]
+                for dom in sorted(top_level, key=lambda d: (len(d.split('.')), d)):
+                    lines.append(_render_tree_md(tree, dom, roots[root]))
+            return Response('\n'.join(lines), mimetype='text/markdown')
+
+        rows = []
         for root in sorted(roots):
-            header = f"{'='*40}\nRoot domain: {root}\n" if not as_html else f"<hr/><b>Root domain: {root}</b><br/>"
-            output += header
+            rows.append(f"<tr><td><a href='#root-{root}'>{root}</a></td><td>{len(roots[root])}</td></tr>")
+        table = (
+            "<table class='domain-sort-summary'><thead><tr><th>Domain</th><th>Subdomains</th></tr></thead>"
+            "<tbody>" + ''.join(rows) + "</tbody></table>"
+        )
+        output = table
+        for root in sorted(roots):
             tree = _build_tree(roots[root])
             top_level = [d for d in roots[root] if d == root or (d.endswith('.'+root) and d.count('.') == root.count('.') + 1)]
-            for dom in sorted(top_level, key=lambda d: (len(d.split('.')), d)):
-                output += _render_tree(tree, dom, roots[root], as_html=as_html)
-        return Response(f"<pre>{output}</pre>", mimetype='text/html')
+            items = ''.join(_render_tree_html(tree, dom, roots[root]) for dom in sorted(top_level, key=lambda d: (len(d.split('.')), d)))
+            output += f"<h3 id='root-{root}'>{root}</h3><ul class='domain-sort-tree'>{items}</ul>"
+        return Response(output, mimetype='text/html')
 
     return dynamic_template('domain_sort.html')
 

--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -4,13 +4,30 @@ function initDomainSort(){
   if(!overlay) return;
   const form = document.getElementById('domain-sort-form');
   const outputDiv = document.getElementById('domain-sort-output');
+  const exportBtn = document.getElementById('domain-sort-export-btn');
   const closeBtn = document.getElementById('domain-sort-close-btn');
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const formData = new FormData(form);
+    formData.set('format', 'html');
     const resp = await fetch('/domain_sort', {method:'POST', body: formData});
     outputDiv.innerHTML = await resp.text();
+  });
+
+  exportBtn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+    formData.set('format', 'md');
+    const resp = await fetch('/domain_sort', {method:'POST', body: formData});
+    const text = await resp.text();
+    const blob = new Blob([text], {type:'text/markdown'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'domain_tree.md';
+    a.click();
+    URL.revokeObjectURL(url);
   });
 
   closeBtn.addEventListener('click', () => {

--- a/static/tools.css
+++ b/static/tools.css
@@ -163,3 +163,41 @@
 
 .retrorecon-root #demo-view { flex: 1 1 auto; overflow-y: auto; }
 
+/* Domain Sort styles */
+.retrorecon-root .domain-sort-form {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5em;
+}
+
+.retrorecon-root .domain-sort-summary {
+  border-collapse: collapse;
+  margin-bottom: 1em;
+}
+/* stylelint-disable-next-line no-descending-specificity */
+.retrorecon-root .domain-sort-summary th,
+.retrorecon-root .domain-sort-summary td {
+  border: 1px solid var(--color-contrast);
+  padding: 0.25em 0.5em;
+}
+
+.retrorecon-root .domain-sort-tree {
+  list-style: none;
+  padding-left: 1em;
+}
+
+.retrorecon-root details.collapsible > summary {
+  cursor: pointer;
+  position: relative;
+  padding-left: 1.2em;
+}
+.retrorecon-root details.collapsible > summary::before {
+  content: '+';
+  position: absolute;
+  left: 0;
+}
+.retrorecon-root details.collapsible[open] > summary::before {
+  content: '-';
+}
+

--- a/templates/domain_sort.html
+++ b/templates/domain_sort.html
@@ -1,12 +1,10 @@
 <div id="domain-sort-overlay" class="notes-overlay hidden">
   <button type="button" class="btn overlay-close-btn" id="domain-sort-close-btn">Close</button>
-  <form id="domain-sort-form" method="post" enctype="multipart/form-data" class="mt-05">
-    <label>Paste domains:<br/>
-      <textarea name="domains" rows="10" cols="60" class="form-input"></textarea>
-    </label><br/>
-    <label>Or upload file: <input type="file" name="file"></label><br/>
-    <label><input type="checkbox" name="as_html" value="1"/> Output as HTML</label><br/>
-    <button type="submit" class="btn mt-05">Generate Tree</button>
+  <form id="domain-sort-form" method="post" enctype="multipart/form-data" class="mt-05 domain-sort-form">
+    <label class="mr-05">Upload file: <input type="file" name="file"></label>
+    <button type="submit" class="btn mr-05">Generate Tree</button>
+    <button type="button" class="btn" id="domain-sort-export-btn">Export to MD</button>
+    <input type="hidden" name="format" value="html" id="domain-sort-format">
   </form>
   <div id="domain-sort-output" class="mt-05"></div>
 </div>

--- a/tests/test_domain_sort_route.py
+++ b/tests/test_domain_sort_route.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def test_domain_sort_markdown(tmp_path):
+    f = tmp_path / "domains.txt"
+    f.write_text("a.example.com\nb.example.com")
+    with app.app.test_client() as client:
+        with open(f, "rb") as fh:
+            resp = client.post('/domain_sort', data={'file': fh, 'format': 'md'})
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert '### example.com' in body
+        assert '- a.example.com' in body
+
+
+def test_domain_sort_html(tmp_path):
+    f = tmp_path / "domains.txt"
+    f.write_text("a.example.com\nb.example.com")
+    with app.app.test_client() as client:
+        with open(f, 'rb') as fh:
+            resp = client.post('/domain_sort', data={'file': fh})
+        assert resp.status_code == 200
+        text = resp.get_data(as_text=True)
+        assert '<table' in text
+        assert 'a.example.com' in text


### PR DESCRIPTION
## Summary
- remove paste flow and default to HTML
- add markdown export option and collapsible UI
- summarize root domain counts in the output
- document the new behaviour and add tests

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862eb9e86a4833280fd78a8d2605adb