### PR TITLE
Fix domain sort toggle

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -364,7 +364,13 @@ def domain_sort_page():
 
         rows = []
         for root in sorted(roots):
-            rows.append(f"<tr><td><a href='#root-{root}'>{root}</a></td><td>{len(roots[root])}</td></tr>")
+            rows.append(
+                "<tr>"
+                f"<td><a href='#' class='domain-sort-toggle' data-target='root-{root}'>" 
+                f"{root}</a></td>"
+                f"<td>{len(roots[root])}</td>"
+                "</tr>"
+            )
         table = (
             "<table class='domain-sort-summary'><thead><tr><th>Domain</th><th>Subdomains</th></tr></thead>"
             "<tbody>" + ''.join(rows) + "</tbody></table>"

--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -7,6 +7,15 @@ function initDomainSort(){
   const exportBtn = document.getElementById('domain-sort-export-btn');
   const closeBtn = document.getElementById('domain-sort-close-btn');
 
+  outputDiv.addEventListener('click', (e) => {
+    if(e.target.classList.contains('domain-sort-toggle')){
+      e.preventDefault();
+      const id = e.target.dataset.target;
+      const el = document.getElementById(id);
+      if(el){ el.open = !el.open; }
+    }
+  });
+
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const formData = new FormData(form);

--- a/tests/test_domain_sort_route.py
+++ b/tests/test_domain_sort_route.py
@@ -50,6 +50,17 @@ def test_domain_sort_html(tmp_path, monkeypatch):
         assert subs == ['a.example.com', 'b.example.com']
 
 
+def test_domain_sort_toggle_attribute(tmp_path, monkeypatch):
+    setup_tmp(monkeypatch, tmp_path)
+    f = tmp_path / "domains.txt"
+    f.write_text("a.example.com")
+    with app.app.test_client() as client:
+        with open(f, 'rb') as fh:
+            resp = client.post('/domain_sort', data={'file': fh})
+        text = resp.get_data(as_text=True)
+        assert 'class=\'domain-sort-toggle\'' in text
+
+
 def test_domain_sort_aggregates_all(tmp_path, monkeypatch):
     setup_tmp(monkeypatch, tmp_path)
     f1 = tmp_path / "one.txt"


### PR DESCRIPTION
## Summary
- add clickable toggles to the summary table
- support toggling domain groups in `domain_sort.js`
- test for the new toggle link

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862fd96c0fc83328da76a9260f42e9a