### PR TITLE
Fix domain sort root extraction offline

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -10,11 +10,15 @@ from retrorecon import domain_sort
 from collections import defaultdict
 import tldextract
 
+# Use a local suffix list to avoid network requests when extracting domains
+_EXTRACTOR = tldextract.TLDExtract(suffix_list_urls=None)
+
 bp = Blueprint('domains', __name__)
 
 
 def _extract_root(domain: str) -> str:
-    ext = tldextract.extract(domain)
+    """Return the registered domain using a local suffix cache."""
+    ext = _EXTRACTOR(domain)
     if ext.domain and ext.suffix:
         return f"{ext.domain}.{ext.suffix}"
     return domain


### PR DESCRIPTION
## Summary
- avoid network requests when extracting root domains from `/domain_sort`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686300b900a48332953a4d028d7d644b