### PR TITLE
Fix domain sort form action

### DIFF
--- a/templates/domain_sort.html
+++ b/templates/domain_sort.html
@@ -1,6 +1,6 @@
 <div id="domain-sort-overlay" class="notes-overlay hidden">
   <button type="button" class="btn overlay-close-btn" id="domain-sort-close-btn">Close</button>
-  <form id="domain-sort-form" method="post" enctype="multipart/form-data" class="mt-05 domain-sort-form">
+  <form id="domain-sort-form" action="/domain_sort" method="post" enctype="multipart/form-data" class="mt-05 domain-sort-form">
     <label class="mr-05">Upload file: <input type="file" name="file"></label>
     <button type="submit" class="btn mr-05">Generate Tree</button>
     <button type="button" class="btn" id="domain-sort-export-btn">Export to MD</button>

--- a/tests/test_domain_sort_route.py
+++ b/tests/test_domain_sort_route.py
@@ -58,7 +58,12 @@ def test_domain_sort_toggle_attribute(tmp_path, monkeypatch):
         with open(f, 'rb') as fh:
             resp = client.post('/domain_sort', data={'file': fh})
         text = resp.get_data(as_text=True)
-        assert 'class=\'domain-sort-toggle\'' in text
+    assert 'class=\'domain-sort-toggle\'' in text
+
+
+def test_domain_sort_form_action():
+    html = (Path(__file__).resolve().parents[1] / 'templates' / 'domain_sort.html').read_text()
+    assert 'action="/domain_sort"' in html
 
 
 def test_domain_sort_aggregates_all(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure domain sort form posts to `/domain_sort` without JS
- test form action points to the correct endpoint

## Testing
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863058260d483328d4aaa11874937e9