### PR TITLE
Fix domain sort persistence

### DIFF
--- a/templates/domain_sort.html
+++ b/templates/domain_sort.html
@@ -6,5 +6,5 @@
     <button type="button" class="btn" id="domain-sort-export-btn">Export to MD</button>
     <input type="hidden" name="format" value="html" id="domain-sort-format">
   </form>
-  <div id="domain-sort-output" class="mt-05"></div>
+  <div id="domain-sort-output" class="mt-05">{{ initial_output|safe }}</div>
 </div>


### PR DESCRIPTION
## Summary
- persist domain sort results across requests
- preload past imports on GET `/domain_sort`
- update HTML template to accept pre-rendered output
- test persistence of GET results

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_68630910e94883328cbe8ae3a8dd9e42