### PR TITLE
Enhance domain_sort upload feedback

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1460,3 +1460,8 @@ body.bg-hidden {
 .retrorecon-root #markdown-editor-close {
   right: 1em;
 }
+
+.retrorecon-root .domain-sort-status {
+  font-style: italic;
+  color: var(--fg-color);
+}

--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -6,6 +6,7 @@ function initDomainSort(){
   const outputDiv = document.getElementById('domain-sort-output');
   const exportBtn = document.getElementById('domain-sort-export-btn');
   const closeBtn = document.getElementById('domain-sort-close-btn');
+  const statusDiv = document.getElementById('domain-sort-status');
 
   outputDiv.addEventListener('click', (e) => {
     if(e.target.classList.contains('domain-sort-toggle')){
@@ -16,18 +17,25 @@ function initDomainSort(){
     }
   });
 
+  function setStatus(msg){
+    if(statusDiv) statusDiv.textContent = msg;
+  }
+
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const formData = new FormData(form);
     formData.set('format', 'html');
+    setStatus('Processing...');
     const resp = await fetch('/domain_sort', {method:'POST', body: formData});
     outputDiv.innerHTML = await resp.text();
+    setStatus(resp.ok ? 'List imported successfully.' : 'Upload failed.');
   });
 
   exportBtn.addEventListener('click', async (e) => {
     e.preventDefault();
     const formData = new FormData(form);
     formData.set('format', 'md');
+    setStatus('Processing...');
     const resp = await fetch('/domain_sort', {method:'POST', body: formData});
     const text = await resp.text();
     const blob = new Blob([text], {type:'text/markdown'});
@@ -37,6 +45,7 @@ function initDomainSort(){
     a.download = 'domain_tree.md';
     a.click();
     URL.revokeObjectURL(url);
+    setStatus(resp.ok ? 'Markdown exported.' : 'Export failed.');
   });
 
   closeBtn.addEventListener('click', () => {

--- a/templates/domain_sort.html
+++ b/templates/domain_sort.html
@@ -6,5 +6,6 @@
     <button type="button" class="btn" id="domain-sort-export-btn">Export to MD</button>
     <input type="hidden" name="format" value="html" id="domain-sort-format">
   </form>
+  <div id="domain-sort-status" class="domain-sort-status mt-05"></div>
   <div id="domain-sort-output" class="mt-05">{{ initial_output|safe }}</div>
 </div>


### PR DESCRIPTION
## Summary
- show an empty status area on the Domain Sort overlay
- indicate processing and success when uploading a file

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_68630f335c9083328c1bf4e062d402a8