### PR TITLE
Implement universal status indicator

### DIFF
--- a/docs/status_state_machine.md
+++ b/docs/status_state_machine.md
@@ -13,6 +13,9 @@ Status events are retrieved via the `/status` API and shown in the UI.
 - `layerpeek_fetch_manifest` – retrieving image manifest information.
 - `layerpeek_fetch_layers` – downloading layer details.
 - `layerpeek_done` – layerpeek inspection complete.
+- `screenshot_start` – screenshot capture initiated.
+- `screenshot_done` – screenshot capture finished.
+- `screenshot_error` – screenshot capture failed.
 
 The client polls `/status` frequently when new messages are being emitted and
 gradually backs off to a slower pace when idle, up to 30 seconds between

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -42,7 +42,9 @@ function initSubdomonster(){
   }
 
   function showStatus(msg){
-    if(statusSpan){
+    if(window.showStatus){
+      window.showStatus(msg);
+    } else if(statusSpan){
       statusSpan.textContent = msg;
       setTimeout(() => { if(statusSpan.textContent === msg) statusSpan.textContent = ''; }, 4000);
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -835,6 +835,7 @@
       if(statusClear) clearTimeout(statusClear);
       statusClear = setTimeout(() => { text.textContent = 'idle'; }, 3000);
     }
+    window.showStatus = showStatus;
 
     function pollStatus(){
       fetch('/status')
@@ -1243,6 +1244,7 @@
         const ov = document.getElementById('screenshot-overlay');
         ov.classList.remove('hidden');
         if(window.loadScreenshotRows){ window.loadScreenshotRows(); }
+        if(window.startScreenshotStatus){ window.startScreenshotStatus(); }
         if(!skipPush){
           history.pushState({tool:'screenshot'}, '', '/tools/screenshotter');
         }
@@ -1251,6 +1253,7 @@
       function hideScreenshot(){
         const ov = document.getElementById('screenshot-overlay');
         if(ov) ov.classList.add('hidden');
+        if(window.stopScreenshotStatus){ window.stopScreenshotStatus(); }
       }
 
       if(screenshotLink){


### PR DESCRIPTION
## Summary
- expose global `showStatus` function on main page
- forward Subdomonster messages to the global status display
- poll `/status` for screenshot operations and update the UI
- emit screenshot status codes from the backend
- document new status codes

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631ef5e6048332a0d040fb2f09b531