### PR TITLE
Integrate CDX URL hosts into domain tools

### DIFF
--- a/retrorecon/subdomain_utils.py
+++ b/retrorecon/subdomain_utils.py
@@ -355,3 +355,17 @@ def scrape_from_urls(target_root: Optional[str] = None) -> int:
             count += insert_records(_clean(root), [_clean(host)], "scrape", cdx=True)
         offset += limit
     return count
+
+
+def list_url_hosts() -> List[str]:
+    """Return distinct hostnames from the ``urls`` table."""
+    rows = query_db("SELECT url, domain FROM urls")
+    hosts: List[str] = []
+    for r in rows:
+        host = (r["domain"] or "").lower().strip()
+        if not host:
+            host = urllib.parse.urlsplit(r["url"]).hostname or ""
+            host = host.lower().strip()
+        if host and host not in hosts:
+            hosts.append(_clean(host))
+    return hosts

--- a/tests/test_domain_sort_route.py
+++ b/tests/test_domain_sort_route.py
@@ -97,3 +97,15 @@ def test_domain_sort_get_persists(tmp_path, monkeypatch):
         resp = client.get('/domain_sort')
         body = resp.get_data(as_text=True)
         assert 'a.example.com' in body
+
+def test_domain_sort_includes_url_hosts(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.execute_db(
+            "INSERT INTO urls (url, domain) VALUES (?, ?)",
+            ["https://foo.example.com/a", "foo.example.com"]
+        )
+    with app.app.test_client() as client:
+        resp = client.get('/domain_sort')
+        text = resp.get_data(as_text=True)
+        assert 'foo.example.com' in text


### PR DESCRIPTION
## Summary
- include hostnames from `urls` table when summarizing domains
- merge CDX hosts into Domain Sort output
- expose helper `list_url_hosts`
- test new behaviour for summary and sort routes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_68641bd64fac83328353260b78b3fae8