### PR TITLE
Enhancement for domain sort page

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -63,13 +63,15 @@ def _render_tree_html(tree, root, domains, printed=None):
     printed.add(root)
     children = [d for d in domains if d.endswith('.' + root) and d not in printed]
     children = sorted(children, key=lambda d: (len(d.split('.')), d))
+    count = subdomain_utils.count_urls_for_host(root)
+    label = f"{root} ({count})" if count else root
     if children:
-        line = f'<li><details class="collapsible" open><summary>{root}</summary><ul>'
+        line = f'<li><details class="collapsible" open><summary>{label}</summary><ul>'
         for child in children:
             line += _render_tree_html(tree, child, domains, printed)
         line += '</ul></details></li>'
     else:
-        line = f'<li>{root}</li>'
+        line = f'<li>{label}</li>'
     return line
 
 
@@ -77,15 +79,17 @@ def _render_domain_sort_output(roots: dict) -> str:
     """Return the full HTML output for the domain sort table and tree."""
     rows = []
     for root in sorted(roots):
+        url_count = subdomain_utils.count_urls_for_root(root)
         rows.append(
             "<tr>"
             f"<td><a href='#' class='domain-sort-toggle' data-target='root-{root}'>"
             f"{root}</a></td>"
             f"<td>{len(roots[root])}</td>"
+            f"<td>{url_count}</td>"
             "</tr>"
         )
     table = (
-        "<table class='domain-sort-summary'><thead><tr><th>Domain</th><th>Subdomains</th></tr></thead>"
+        "<table class='domain-sort-summary'><thead><tr><th>Domain</th><th>Subdomains</th><th>URLs</th></tr></thead>"
         "<tbody>" + ''.join(rows) + "</tbody></table>"
     )
     output = table

--- a/retrorecon/subdomain_utils.py
+++ b/retrorecon/subdomain_utils.py
@@ -369,3 +369,23 @@ def list_url_hosts() -> List[str]:
         if host and host not in hosts:
             hosts.append(_clean(host))
     return hosts
+
+
+def count_urls_for_host(host: str) -> int:
+    """Return how many URL records are associated with ``host``."""
+    row = query_db(
+        "SELECT COUNT(*) AS cnt FROM urls WHERE domain = ?",
+        [_clean(host)],
+        one=True,
+    )
+    return row["cnt"] if row else 0
+
+
+def count_urls_for_root(root: str) -> int:
+    """Return total URL records for ``root`` and all its subdomains."""
+    row = query_db(
+        "SELECT COUNT(*) AS cnt FROM urls WHERE domain = ? OR domain LIKE ?",
+        [_clean(root), f"%.{_clean(root)}"],
+        one=True,
+    )
+    return row["cnt"] if row else 0

--- a/tests/test_domain_sort_route.py
+++ b/tests/test_domain_sort_route.py
@@ -109,3 +109,15 @@ def test_domain_sort_includes_url_hosts(monkeypatch, tmp_path):
         resp = client.get('/domain_sort')
         text = resp.get_data(as_text=True)
         assert 'foo.example.com' in text
+
+def test_domain_sort_url_counts(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.app_context():
+        app.execute_db(
+            "INSERT INTO urls (url, domain) VALUES (?, ?)",
+            ["https://bar.example.com/index.html", "bar.example.com"]
+        )
+    with app.app.test_client() as client:
+        resp = client.get('/domain_sort')
+        text = resp.get_data(as_text=True)
+        assert 'bar.example.com (1)' in text


### PR DESCRIPTION
## Summary
- count URLs per subdomain and root domain
- display URL counts in domain sort tree and table
- test coverage for new counts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641ec3aa908332a056b55ea4f7ec62