### PR TITLE
Add subdomain import UI

### DIFF
--- a/retrorecon/dynamic_schemas.py
+++ b/retrorecon/dynamic_schemas.py
@@ -44,6 +44,44 @@ def register_demo_schemas(registry: SchemaRegistry) -> None:
                                 },
                             ],
                         },
+                        {
+                            "tag": "div",
+                            "attrs": {"class": "mb-05"},
+                            "children": [
+                                {
+                                    "tag": "input",
+                                    "attrs": {
+                                        "type": "text",
+                                        "id": "subdomonster-domain",
+                                        "class": "form-input mr-05 subdomonster-domain-bar",
+                                        "placeholder": "example.com",
+                                    },
+                                },
+                                {
+                                    "tag": "select",
+                                    "attrs": {"id": "subdom-source", "class": "form-select mr-05"},
+                                    "children": [
+                                        {"tag": "option", "attrs": {"value": "crtsh"}, "text": "crt.sh"},
+                                        {"tag": "option", "attrs": {"value": "virustotal"}, "text": "VirusTotal"},
+                                        {"tag": "option", "attrs": {"value": "local"}, "text": "Local"},
+                                    ],
+                                },
+                                {
+                                    "tag": "input",
+                                    "attrs": {
+                                        "type": "text",
+                                        "id": "subdom-api",
+                                        "class": "form-input mr-05 w-10em",
+                                        "placeholder": "API key",
+                                    },
+                                },
+                                {
+                                    "tag": "button",
+                                    "attrs": {"type": "button", "class": "btn", "id": "subdom-fetch-btn"},
+                                    "text": "Import",
+                                },
+                            ],
+                        },
                         {"tag": "div", "attrs": {"id": "subdomonster-table", "class": "mt-05"}},
                         {"tag": "div", "attrs": {"id": "subdomonster-pagination", "class": "mt-05"}},
                         {"html_field": "init_script"},

--- a/static/subdomonster.js
+++ b/static/subdomonster.js
@@ -3,6 +3,9 @@ function initSubdomonster(){
   const overlay = document.getElementById('subdomonster-overlay');
   if(!overlay) return;
   const domainInput = document.getElementById('subdomonster-domain');
+  const sourceSel = document.getElementById('subdom-source');
+  const apiInput = document.getElementById('subdom-api');
+  const fetchBtn = document.getElementById('subdom-fetch-btn');
   const tableDiv = document.getElementById('subdomonster-table');
   const paginationDiv = document.getElementById('subdomonster-pagination');
   const closeBtn = document.getElementById('subdomonster-close-btn');
@@ -114,6 +117,30 @@ function initSubdomonster(){
       clearTimeout(statusTimer);
       statusTimer = null;
     }
+  }
+
+  if(fetchBtn){
+    fetchBtn.addEventListener('click', async () => {
+      const domain = domainInput ? domainInput.value.trim() : '';
+      const source = sourceSel ? sourceSel.value : 'crtsh';
+      if(source !== 'local' && !domain) return;
+      const params = new URLSearchParams({source});
+      if(domain) params.set('domain', domain);
+      if(apiInput && apiInput.value.trim()) params.set('api_key', apiInput.value.trim());
+      startStatusPolling();
+      try{
+        const resp = await fetch('/subdomains', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
+        if(resp.ok){
+          tableData = await resp.json();
+          currentPage = 1;
+          render();
+        } else {
+          showStatus(await resp.text());
+        }
+      }catch(err){
+        console.error('import failed', err);
+      }
+    });
   }
 
 


### PR DESCRIPTION
## Summary
- allow importing subdomains from crt.sh, VirusTotal or local URLs
- wire up new input fields to `/subdomains` endpoint

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864260c4af8833296c08dc7ae2fe384