### PR TITLE
Implement CDX pagination support

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -33,10 +33,11 @@ curl -G --data-urlencode "q=url:example.com AND http:200" http://localhost:5000/
 ```
 
 ### `POST /fetch_cdx`
-Fetch Wayback Machine CDX records for a domain and insert any new URLs into the loaded database. The backend automatically queries `url=*.DOMAIN/*` so all subdomains are included.
+Fetch Wayback Machine CDX records for a domain and insert any new URLs into the loaded database. The backend automatically queries `url=*.DOMAIN/*` so all subdomains are included and follows pagination using the CDX `resumeKey`.
 
 Parameters:
 - `domain` – domain name to query.
+- `resume_key` – optional resume token for continuing a previous fetch.
 
 Example:
 ```

--- a/docs/new_user_guide.md
+++ b/docs/new_user_guide.md
@@ -6,7 +6,7 @@ This short guide walks through the typical workflow of exploring archived URLs.
    ```bash
    curl -X POST http://localhost:5000/fetch_cdx -d "domain=example.com"
    ```
-   This pulls Wayback Machine records for `example.com` **and all of its subdomains** into the local SQLite database. The server automatically queries `url=*.example.com/*`.
+   This pulls Wayback Machine records for `example.com` **and all of its subdomains** into the local SQLite database. The server automatically queries `url=*.example.com/*` and follows pagination until all pages are retrieved. You can resume a partial fetch by providing the `resume_key` form field.
 
 2. **Browse results**
    Visit `http://localhost:5000/` in your browser. Use the search box to filter

--- a/docs/status_state_machine.md
+++ b/docs/status_state_machine.md
@@ -8,6 +8,8 @@ Status events are retrieved via the `/status` API and shown in the UI.
 - `cdx_api_waiting` – waiting for a response from the Wayback CDX API.
 - `cdx_api_downloading` – currently downloading CDX records.
 - `cdx_api_download_complete` – finished downloading the CDX data.
+- `cdx_page_processed` – one page of CDX results has been inserted.
+- `cdx_resume_key` – emitted when a resume key is available for the next page.
 - `cdx_import_complete` – all CDX records processed and inserted.
 - `layerpeek_start` – layerpeek fetch initiated.
 - `layerpeek_fetch_manifest` – retrieving image manifest information.

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -24,6 +24,13 @@ paths:
   /fetch_cdx:
     post:
       summary: POST /fetch_cdx
+      parameters:
+        - in: formData
+          name: domain
+          type: string
+        - in: formData
+          name: resume_key
+          type: string
       responses:
         '200':
           description: Successful response

--- a/tests/test_fetch_cdx_pagination.py
+++ b/tests/test_fetch_cdx_pagination.py
@@ -1,0 +1,63 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+    @property
+    def text(self):
+        return json.dumps(self._data)
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    with app.app.app_context():
+        app.create_new_db("test")
+
+
+def test_fetch_cdx_pagination(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    page1 = [["original", "timestamp", "statuscode", "mimetype"],
+             ["http://a.example.com/", "202101", "200", "text/html"],
+             ["key123"]]
+    page2 = [["original", "timestamp", "statuscode", "mimetype"],
+             ["http://b.example.com/", "202102", "200", "text/html"]]
+
+    calls = []
+
+    def fake_get(url, timeout=20):
+        calls.append(url)
+        if "resumeKey=key123" in url:
+            return FakeResp(page2)
+        return FakeResp(page1)
+
+    monkeypatch.setattr(app.requests, "get", fake_get)
+
+    with app.app.test_client() as client:
+        resp = client.post("/fetch_cdx", data={"domain": "example.com"})
+        assert resp.status_code == 302
+
+    with app.app.app_context():
+        rows = app.query_db("SELECT url FROM urls ORDER BY id")
+        urls = [r["url"] for r in rows]
+
+    assert urls == ["http://a.example.com/", "http://b.example.com/"]
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- loop through CDX results using resumeKey
- emit progress status events for each page
- document resume_key parameter and new status codes
- update OpenAPI spec and user guide
- test CDX pagination logic

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864296d45408332969506ff1c12fffc