### PR TITLE
Show host counts in Domain Sort

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -92,7 +92,9 @@ def _render_domain_sort_output(roots: dict) -> str:
         "<table class='domain-sort-summary'><thead><tr><th>Domain</th><th>Subdomains</th><th>URLs</th></tr></thead>"
         "<tbody>" + ''.join(rows) + "</tbody></table>"
     )
-    output = table
+    total_hosts = len({h for v in roots.values() for h in v})
+    counts = f"<p class='domain-sort-counts'>{total_hosts} hosts across {len(roots)} root domains</p>"
+    output = counts + table
     for root in sorted(roots):
         tree = _build_tree(roots[root])
         top_level = [

--- a/static/tools.css
+++ b/static/tools.css
@@ -125,6 +125,10 @@
   border-collapse: collapse;
   margin-bottom: 1em;
 }
+.retrorecon-root .domain-sort-counts {
+  margin: 0.25em 0;
+  font-weight: bold;
+}
 /* stylelint-disable-next-line no-descending-specificity */
 .retrorecon-root .domain-sort-summary th,
 .retrorecon-root .domain-sort-summary td {


### PR DESCRIPTION
## Summary
- display total host count in Domain Sort overlay
- add small style for domain-sort-counts paragraph

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_686439d4abec8332adc2dcb6cd028c10