### PR TITLE
Fix domain extraction edge cases

### DIFF
--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -19,10 +19,11 @@ bp = Blueprint('domains', __name__)
 
 def _extract_root(domain: str) -> str:
     """Return the registered domain using a local suffix cache."""
-    ext = _EXTRACTOR(domain)
+    dom = domain.strip().lower()
+    ext = _EXTRACTOR(dom)
     if ext.domain and ext.suffix:
         return f"{ext.domain}.{ext.suffix}"
-    return domain
+    return dom
 
 
 def _build_tree(domains):


### PR DESCRIPTION
## Summary
- strip whitespace and lowercase before extracting root domain

## Testing
- `pytest -q`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68645a68a3c883328eed34caaed5a5e9