### PR TITLE
Add domain import field

### DIFF
--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -7,6 +7,8 @@ function initDomainSort(){
   const exportBtn = document.getElementById('domain-sort-export-btn');
   const closeBtn = document.getElementById('domain-sort-close-btn');
   const statusDiv = document.getElementById('domain-sort-status');
+  const importInput = document.getElementById('domain-import-input');
+  const importBtn = document.getElementById('domain-import-btn');
 
   outputDiv.addEventListener('click', (e) => {
     if(e.target.classList.contains('domain-sort-toggle')){
@@ -30,6 +32,25 @@ function initDomainSort(){
     outputDiv.innerHTML = await resp.text();
     setStatus(resp.ok ? 'List imported successfully.' : 'Upload failed.');
   });
+
+  if(importBtn && importInput){
+    importBtn.addEventListener('click', async () => {
+      const domain = importInput.value.trim().toLowerCase();
+      if(!domain) return;
+      importInput.value = '';
+      setStatus('Importing...');
+      for(const src of ['crtsh','virustotal']){
+        const params = new URLSearchParams({domain, source: src});
+        await fetch('/subdomains', {method:'POST', body: params});
+      }
+      const cdxData = new URLSearchParams({domain, ajax:'1'});
+      const resp = await fetch('/fetch_cdx', {method:'POST', body: cdxData});
+      const json = await resp.json().catch(() => ({}));
+      setStatus(json.message || (resp.ok ? 'Import complete.' : 'Import failed.'));
+      const listResp = await fetch('/domain_sort');
+      outputDiv.innerHTML = await listResp.text();
+    });
+  }
 
   exportBtn.addEventListener('click', async (e) => {
     e.preventDefault();

--- a/templates/domain_sort.html
+++ b/templates/domain_sort.html
@@ -3,6 +3,8 @@
   <form id="domain-sort-form" action="/domain_sort" method="post" enctype="multipart/form-data" class="mt-05 domain-sort-form">
     <label class="mr-05">Upload file: <input type="file" name="file"></label>
     <button type="submit" class="btn mr-05">Generate Tree</button>
+    <input type="text" id="domain-import-input" class="form-input subdomonster-domain-bar mr-05" placeholder="example.com" />
+    <button type="button" class="btn mr-05" id="domain-import-btn">Import</button>
     <button type="button" class="btn" id="domain-sort-export-btn">Export to MD</button>
     <input type="hidden" name="format" value="html" id="domain-sort-format">
   </form>


### PR DESCRIPTION
## Summary
- add import text input for the Domain Sort overlay
- wire up JS to pull subdomains from crt.sh and VirusTotal, then fetch CDX

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686468f0a48083328d658c7df6a87cb8