### PR TITLE
Fix notes overlay flicker on dashboard updates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -881,6 +881,9 @@
         tagsOverlay.classList.add('hidden');
         tagsOverlay.classList.remove('show');
       }
+      if(typeof notesOverlay !== 'undefined' && !notesOverlay.classList.contains('hidden')){
+        notesOverlay.classList.add('hidden');
+      }
       document.getElementById('search-form').submit();
     }
 
@@ -937,6 +940,13 @@
       if(box){
         box.value = '';
         box.focus();
+      }
+      if(typeof tagsOverlay !== 'undefined' && !tagsOverlay.classList.contains('hidden')){
+        tagsOverlay.classList.add('hidden');
+        tagsOverlay.classList.remove('show');
+      }
+      if(typeof notesOverlay !== 'undefined' && !notesOverlay.classList.contains('hidden')){
+        notesOverlay.classList.add('hidden');
       }
       document.getElementById('search-form').submit();
     });
@@ -1703,6 +1713,13 @@
     if(perPageInput){
       document.querySelectorAll('#results-per-page-select').forEach(sel => {
         sel.addEventListener('change', function(){
+          if(typeof tagsOverlay !== 'undefined' && !tagsOverlay.classList.contains('hidden')){
+            tagsOverlay.classList.add('hidden');
+            tagsOverlay.classList.remove('show');
+          }
+          if(typeof notesOverlay !== 'undefined' && !notesOverlay.classList.contains('hidden')){
+            notesOverlay.classList.add('hidden');
+          }
           perPageInput.value = this.value;
           document.getElementById('set-items-form').submit();
         });


### PR DESCRIPTION
## Summary
- close notes overlay when quick search is performed
- hide notes overlay when clearing the search field
- hide notes overlay when changing results-per-page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_68647489d0788332ae2d2518e9ca55c7