### PR TITLE
Remove CDX fetch from subdomain tool

### DIFF
--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -43,10 +43,7 @@ function initDomainSort(){
         const params = new URLSearchParams({domain, source: src});
         await fetch('/subdomains', {method:'POST', body: params});
       }
-      const cdxData = new URLSearchParams({domain, ajax:'1'});
-      const resp = await fetch('/fetch_cdx', {method:'POST', body: cdxData});
-      const json = await resp.json().catch(() => ({}));
-      setStatus(json.message || (resp.ok ? 'Import complete.' : 'Import failed.'));
+      setStatus('Import complete.');
       const listResp = await fetch('/domain_sort');
       outputDiv.innerHTML = await listResp.text();
     });


### PR DESCRIPTION
## Summary
- stop domain sort overlay from fetching CDX records

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648101041c8332a8335f973c5e32a0