### PR TITLE
Fix domain sort counting and refresh

### DIFF
--- a/docs/project_overview_spec.md
+++ b/docs/project_overview_spec.md
@@ -6,6 +6,8 @@ This document outlines the new **Project Overview** feature. Each SQLite databas
 - Treat every loaded `.db` file as its own project.
 - Display counts for URLs, domains, screenshots, site zips, JWT cookies and notes.
 - Group subdomains by root domain similar to the URL results table.
+- Counts shown in overlays and trees are always the total number of records. When
+  filters are active the dashboard must indicate this state but still report true totals.
 - Allow each subdomain to be sent to other Retrorecon tools.
 
 ## Routes
@@ -19,4 +21,7 @@ The layout mirrors the search results page with a table for each domain. A summa
 No schema changes are required. Counts are derived from the existing `urls`, `domains`, `screenshots`, `sitezips`, `jwt_cookies` and `notes` tables.
 
 ## Implementation Notes
-The Flask blueprint `overview.py` collects table counts and domain lists. It is registered in `app.py` so the page is accessible once a database is loaded.
+The Flask blueprint `overview.py` collects table counts and domain lists using helpers
+shared with the `/domain_sort` overlay. After any import or delete operation the
+frontend should refresh these values by requesting `/overview.json` or `/domain_sort`.
+The blueprint is registered in `app.py` so the page is accessible once a database is loaded.

--- a/retrorecon/routes/domains.py
+++ b/retrorecon/routes/domains.py
@@ -332,15 +332,7 @@ def domain_sort_page():
                 except Exception:
                     pass
             # After inserting, rebuild using every subdomain and URL host
-            all_roots = defaultdict(set)
-            for row in subdomain_utils.list_all_subdomains():
-                if row['subdomain'] != row['domain']:
-                    all_roots[row['domain']].add(row['subdomain'])
-            for host in subdomain_utils.list_url_hosts():
-                root = _extract_root(host)
-                if host != root:
-                    all_roots[root].add(host)
-            roots = {k: sorted(v) for k, v in all_roots.items()}
+            roots = subdomain_utils.aggregate_root_domains()
         else:
             roots = uploaded
 
@@ -361,19 +353,9 @@ def domain_sort_page():
         return Response(output, mimetype='text/html')
 
     if app._db_loaded():
-        rows = subdomain_utils.list_all_subdomains()
-        url_hosts = subdomain_utils.list_url_hosts()
-        if rows or url_hosts:
-            roots = defaultdict(set)
-            for r in rows:
-                if r['subdomain'] != r['domain']:
-                    roots[r['domain']].add(r['subdomain'])
-            for host in url_hosts:
-                root = _extract_root(host)
-                if host != root:
-                    roots[root].add(host)
-            sorted_roots = {k: sorted(v) for k, v in roots.items()}
-            output = _render_domain_sort_output(sorted_roots)
+        roots = subdomain_utils.aggregate_root_domains()
+        if roots:
+            output = _render_domain_sort_output(roots)
             return dynamic_template('domain_sort.html', initial_output=output)
     return dynamic_template('domain_sort.html', initial_output="")
 

--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -23,6 +23,11 @@ function initDomainSort(){
     if(statusDiv) statusDiv.textContent = msg;
   }
 
+  async function refresh(){
+    const resp = await fetch('/domain_sort');
+    outputDiv.innerHTML = await resp.text();
+  }
+
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const formData = new FormData(form);
@@ -31,6 +36,7 @@ function initDomainSort(){
     const resp = await fetch('/domain_sort', {method:'POST', body: formData});
     outputDiv.innerHTML = await resp.text();
     setStatus(resp.ok ? 'List imported successfully.' : 'Upload failed.');
+    document.dispatchEvent(new Event('domainDataChanged'));
   });
 
   if(importBtn && importInput){
@@ -44,10 +50,14 @@ function initDomainSort(){
         await fetch('/subdomains', {method:'POST', body: params});
       }
       setStatus('Import complete.');
-      const listResp = await fetch('/domain_sort');
-      outputDiv.innerHTML = await listResp.text();
+      await refresh();
+      document.dispatchEvent(new Event('domainDataChanged'));
     });
   }
+
+  document.addEventListener('domainDataChanged', () => {
+    refresh();
+  });
 
   exportBtn.addEventListener('click', async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- deduplicate subdomain inserts and document counting logic
- standardize domain aggregation via `aggregate_root_domains`
- refresh domain_sort overlay after data changes
- keep overview counts in sync with domain sort
- clarify counting rules in project overview docs
- extend domain sort route tests

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648e5f18fc833292f469114e9d3b8a