### PR TITLE
Fix autoload loop when missing db

### DIFF
--- a/static/index_page.js
+++ b/static/index_page.js
@@ -67,6 +67,15 @@ function autoloadLastDb(current){
   }
   const last = getLastDb();
   if(!last) return;
+  const selector = document.getElementById('load-saved-db-bar-select') ||
+                   document.getElementById('load-saved-db-select');
+  if(selector){
+    const found = Array.from(selector.options).some(opt => opt.value === last);
+    if(!found){
+      try{ localStorage.removeItem('retroLastDb'); }catch(e){}
+      return;
+    }
+  }
   const form = document.createElement('form');
   form.method = 'POST';
   form.action = '/load_saved_db';


### PR DESCRIPTION
## Summary
- avoid repeatedly reloading missing database by clearing `retroLastDb` if not found in dropdown

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864984394ec83329e7181f489598cdf