### PR TITLE
Implement safe database deletion

### DIFF
--- a/app.py
+++ b/app.py
@@ -501,6 +501,17 @@ def index() -> str:
         session['db_display_name'] = actual_name
     db_name = session['db_display_name']
 
+    if not _db_loaded() and db_name not in ('(none)', TEMP_DISPLAY_NAME):
+        missing_path = os.path.join(get_db_folder(), db_name)
+        if not os.path.exists(missing_path) and not session.get('missing_db_warned'):
+            flash(
+                f"\N{WARNING SIGN} Previously loaded database '{db_name}' not found. Please select another or import a fresh copy.",
+                'error'
+            )
+            session['missing_db_warned'] = True
+    elif _db_loaded():
+        session.pop('missing_db_warned', None)
+
     try:
         saved_dbs = sorted([
             f for f in os.listdir(get_db_folder())

--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -607,6 +607,13 @@ Switch to a database file stored under `db/`.
 curl -X POST -d "db_file=wabax.db" http://localhost:5000/load_saved_db
 ```
 
+### `POST /delete_db`
+Remove a database snapshot from the `db/` folder.
+
+```
+curl -X POST -d "db_file=old.db" http://localhost:5000/delete_db
+```
+
 ### `POST /set_items_per_page`
 Change how many results display on the search page.
 

--- a/retrorecon/routes/db.py
+++ b/retrorecon/routes/db.py
@@ -115,3 +115,22 @@ def load_saved_db():
     except Exception as e:
         flash(f'Error loading database: {e}', 'error')
     return redirect(url_for('index'))
+
+@bp.route('/delete_db', methods=['POST'])
+def delete_db_route():
+    """Delete a saved database file."""
+    filename = request.form.get('db_file', '').strip()
+    safe = app._sanitize_db_name(filename)
+    if not safe:
+        return ('invalid', 400)
+    current = os.path.basename(app.app.config.get('DATABASE') or '')
+    if current == safe:
+        return ('active', 400)
+    path = os.path.join(app.get_db_folder(), safe)
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        return ('not_found', 404)
+    except OSError:
+        return ('error', 500)
+    return ('', 204)

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -333,6 +333,12 @@ paths:
       responses:
         '200':
           description: Successful response
+  /delete_db:
+    post:
+      summary: POST /delete_db
+      responses:
+        '200':
+          description: Successful response
   /set_theme:
     post:
       summary: POST /set_theme

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,7 +91,7 @@
           <form method="GET" action="/save_db" class="menu-row" id="save-db-form">
             <button type="submit" class="menu-btn">Save Project As...</button>
           </form>
-          <form method="POST" action="/load_saved_db" class="menu-row" id="load-saved-db-form">
+         <form method="POST" action="/load_saved_db" class="menu-row" id="load-saved-db-form">
             <select name="db_file" id="load-saved-db-select" class="form-select menu-btn">
               <option value="">Open Project...</option>
               {% for db in saved_dbs %}
@@ -99,6 +99,15 @@
               {% endfor %}
             </select>
           </form>
+          <div class="menu-row"><input type="text" id="db-filter" class="form-input w-100" placeholder="Filter projects..."></div>
+          <div id="db-list">
+            {% for db in saved_dbs %}
+            <div class="menu-row db-entry" data-db="{{ db }}">
+              <span>{{ db }}</span>
+              <button type="button" class="menu-btn ml-05 delete-db-btn" data-db="{{ db }}" {% if db == db_name %}disabled title="Cannot delete while active."{% endif %}>Delete</button>
+            </div>
+            {% endfor %}
+          </div>
           <select id="url-export-formats" class="form-select menu-btn">
             <option value="" selected>Export As...</option>
             <option value="json">JSON</option>
@@ -1036,6 +1045,32 @@
         }
       });
     }
+
+    const dbFilter = document.getElementById('db-filter');
+    if (dbFilter) {
+      dbFilter.addEventListener('input', () => {
+        const val = dbFilter.value.toLowerCase();
+        document.querySelectorAll('#db-list .db-entry').forEach(div => {
+          div.classList.toggle('hidden', !div.dataset.db.toLowerCase().includes(val));
+        });
+      });
+    }
+    document.querySelectorAll('.delete-db-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const name = btn.dataset.db;
+        if (!confirm(`You're about to permanently delete '${name}'. This cannot be undone.`)) return;
+        const params = new URLSearchParams();
+        params.append('db_file', name);
+        const resp = await fetch('/delete_db', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params});
+        if (resp.ok) {
+          alert(`✅ '${name}' successfully deleted.`);
+          location.reload();
+        } else {
+          const text = await resp.text();
+          alert(`❌ Failed to delete '${name}': ${text}`);
+        }
+      });
+    });
 
     const importBtn = document.getElementById('import-file-btn');
     const importInput = document.getElementById('import-file-input');

--- a/tests/test_delete_db.py
+++ b/tests/test_delete_db.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    with app.app.app_context():
+        app.create_new_db("test")
+
+
+def test_delete_db(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    extra = tmp_path / "db" / "extra.db"
+    extra.write_text("x")
+    with app.app.test_client() as client:
+        resp = client.post("/delete_db", data={"db_file": "extra.db"})
+        assert resp.status_code == 204
+    assert not extra.exists()
+
+
+def test_delete_active_db(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    active = tmp_path / "db" / "test.db"
+    assert active.exists()
+    with app.app.test_client() as client:
+        resp = client.post("/delete_db", data={"db_file": "test.db"})
+        assert resp.status_code == 400
+    assert active.exists()


### PR DESCRIPTION
## Summary
- add `/delete_db` API endpoint
- warn user if last selected DB is missing
- expose database deletion controls with filtering on the index page
- document the new API route
- test removal of saved databases

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865a7300aac83328b980ba30d861471