### PR TITLE
Fix SimpleMDE style init

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1450,6 +1450,10 @@ body.bg-hidden {
 .retrorecon-root #markdown-editor-form {
   height: 100%;
 }
+
+.retrorecon-root #mdeditor-textarea {
+  min-height: 20em;
+}
 /* stylelint-disable selector-class-pattern */
 .retrorecon-root #markdown-editor-form .CodeMirror,
 .retrorecon-root #markdown-editor-form .editor-preview {

--- a/static/markdown_editor.js
+++ b/static/markdown_editor.js
@@ -84,6 +84,7 @@ function initMarkdownEditor(){
     });
   }
   window.loadMdFiles = loadFiles;
+  window.ensureMdEditor = ensureEditor;
 
   function refreshEditor(){
     if(simplemde){
@@ -132,9 +133,7 @@ function initMarkdownEditor(){
     }
   });
 
-  ensureEditor();
-  refreshEditor();
-  loadFiles();
+  // initialization is performed when the overlay becomes visible
 }
 
 if(document.readyState === 'loading'){

--- a/templates/index.html
+++ b/templates/index.html
@@ -1238,6 +1238,7 @@
         }
         ov.classList.remove('hidden');
         document.body.style.overflow = 'hidden';
+        if(window.ensureMdEditor) window.ensureMdEditor();
         if(window.loadMdFiles) window.loadMdFiles();
         if(window.refreshMdEditor) window.refreshMdEditor();
         if(!skipPush){


### PR DESCRIPTION
## Summary
- ensure SimpleMDE initializes after the overlay becomes visible
- expose `ensureMdEditor` for initialization
- set a default textarea height

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6865d1aa755c8332842d2c253d7ce883