### PR TITLE
Enable basic MCP connectivity

### DIFF
--- a/app.py
+++ b/app.py
@@ -916,6 +916,7 @@ from retrorecon.routes import (
     overview_bp,
     help_bp,
     dynamic_bp,
+    chat_bp,
 )
 app.register_blueprint(notes_bp)
 app.register_blueprint(tools_bp)
@@ -932,6 +933,7 @@ app.register_blueprint(swagger_bp)
 app.register_blueprint(overview_bp)
 app.register_blueprint(help_bp)
 app.register_blueprint(dynamic_bp)
+app.register_blueprint(chat_bp)
 
 
 @app.after_request

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest
 requests
 tldextract
 zstandard
+fastmcp>=0.1.0

--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -1,0 +1,130 @@
+import os
+import sqlite3
+import logging
+from typing import Dict, Any, List, Optional
+
+from fastmcp import FastMCP
+from mcp.types import TextContent
+from fastmcp.tools import FunctionTool
+
+logger = logging.getLogger(__name__)
+
+
+class RetroReconMCPServer:
+    """Embedded MCP server for querying RetroRecon SQLite databases."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path
+        self.server = FastMCP("RetroRecon SQLite Explorer")
+        self._setup_tools()
+
+    # tool setup
+    def _setup_tools(self) -> None:
+        self.server.add_tool(self._create_read_query_tool())
+        self.server.add_tool(self._create_list_tables_tool())
+        self.server.add_tool(self._create_describe_table_tool())
+
+    def update_database_path(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    # tools
+    def _create_read_query_tool(self):
+        async def read_query(query: str, params: list[Any] | None = None) -> TextContent:
+            return await self.handle_read_query(query, params)
+
+        return FunctionTool.from_function(
+            read_query,
+            name="read_query",
+            description="Execute a SELECT query on the RetroRecon database",
+        )
+
+    def _create_list_tables_tool(self):
+        async def list_tables() -> TextContent:
+            return await self.handle_list_tables()
+
+        return FunctionTool.from_function(
+            list_tables,
+            name="list_tables",
+            description="List tables in the current database",
+        )
+
+    def _create_describe_table_tool(self):
+        async def describe_table(table: str) -> TextContent:
+            return await self.handle_describe_table(table)
+
+        return FunctionTool.from_function(
+            describe_table,
+            name="describe_table",
+            description="Describe table columns",
+        )
+
+    # connection helpers
+    def get_connection(self):
+        if not self.db_path:
+            raise ValueError("Database path not configured")
+        return sqlite3.connect(self.db_path)
+
+    # validation
+    def validate_query(self, query: str) -> bool:
+        query_upper = query.upper().strip()
+        if not query_upper.startswith("SELECT"):
+            return False
+        prohibited = ["INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER"]
+        return not any(k in query_upper for k in prohibited)
+
+    # query execution
+    def execute_query(self, query: str, params: Optional[List[Any]] = None) -> Dict[str, Any]:
+        if not self.validate_query(query):
+            raise ValueError("Query validation failed")
+        with self.get_connection() as conn:
+            c = conn.cursor()
+            if "LIMIT" not in query.upper():
+                query += " LIMIT 100"
+            c.execute(query, params or [])
+            rows = c.fetchall()
+            columns = [d[0] for d in c.description]
+            return {"columns": columns, "rows": rows, "count": len(rows)}
+
+    # handlers
+    async def handle_read_query(self, query: str, params: Optional[List[Any]] = None) -> TextContent:
+        try:
+            results = self.execute_query(query, params)
+            if results["count"] == 0:
+                return TextContent(text="No results found for the query.")
+            formatted = self._format_query_results(results)
+            return TextContent(text=formatted)
+        except Exception as exc:
+            logger.error("Query execution failed: %s", exc)
+            return TextContent(text=f"Query execution failed: {exc}")
+
+    async def handle_list_tables(self) -> TextContent:
+        try:
+            q = "SELECT name FROM sqlite_master WHERE type='table'"
+            results = self.execute_query(q)
+            tables = [r[0] for r in results["rows"]]
+            return TextContent(text="\n".join(tables))
+        except Exception as exc:
+            logger.error("List tables failed: %s", exc)
+            return TextContent(text=f"Failed to list tables: {exc}")
+
+    async def handle_describe_table(self, table: str) -> TextContent:
+        try:
+            q = f"PRAGMA table_info({table})"
+            results = self.execute_query(q)
+            return TextContent(text=self._format_query_results(results))
+        except Exception as exc:
+            logger.error("Describe table failed: %s", exc)
+            return TextContent(text=f"Failed to describe table: {exc}")
+
+    # formatting helper
+    def _format_query_results(self, results: Dict[str, Any]) -> str:
+        header = " | ".join(results["columns"])
+        separator = " | ".join("-" * len(c) for c in results["columns"])
+        rows = [
+            " | ".join(str(cell) if cell is not None else "" for cell in row)
+            for row in results["rows"]
+        ]
+        return "{}\n{}\n{}".format(header, separator, "\n".join(rows))
+
+    def cleanup(self) -> None:
+        pass

--- a/retrorecon/routes/__init__.py
+++ b/retrorecon/routes/__init__.py
@@ -13,5 +13,6 @@ from .swagger import bp as swagger_bp
 from .overview import bp as overview_bp
 from .help import bp as help_bp
 from .dynamic import bp as dynamic_bp
+from .chat import bp as chat_bp
 
-__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'oci_explorer_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'help_bp', 'dynamic_bp']
+__all__ = ['notes_bp', 'tools_bp', 'db_bp', 'settings_bp', 'domains_bp', 'docker_bp', 'oci_explorer_bp', 'dag_bp', 'oci_bp', 'dagdotdev_bp', 'urls_bp', 'swagger_bp', 'overview_bp', 'help_bp', 'dynamic_bp', 'chat_bp']

--- a/retrorecon/routes/chat.py
+++ b/retrorecon/routes/chat.py
@@ -1,0 +1,38 @@
+import app
+from flask import Blueprint, request, jsonify
+
+from retrorecon.mcp.server import RetroReconMCPServer
+
+bp = Blueprint('chat', __name__, url_prefix='/chat')
+
+
+def _get_server() -> RetroReconMCPServer:
+    """Get or create the MCP server instance."""
+    server = getattr(app, 'mcp_server', None)
+    if server is None:
+        server = RetroReconMCPServer()
+        app.mcp_server = server
+    _ensure_db_path(server)
+    return server
+
+
+def _ensure_db_path(server: RetroReconMCPServer) -> None:
+    db_path = app.app.config.get('DATABASE')
+    if db_path and server.db_path != db_path:
+        server.update_database_path(db_path)
+
+
+@bp.route('/message', methods=['POST'])
+def handle_chat_message():
+    """Process a chat message via MCP."""
+    data = request.get_json() or {}
+    message = data.get('message', '').strip()
+    if not message:
+        return jsonify({'error': 'Message content required'}), 400
+
+    server = _get_server()
+    try:
+        result = server.execute_query(message)
+        return jsonify(result)
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 400

--- a/static/chat.css
+++ b/static/chat.css
@@ -1,0 +1,26 @@
+.retrorecon-root .chat-overlay {
+  position: fixed;
+  top: var(--navbar-height);
+  right: 0;
+  width: 300px;
+  height: calc(100% - var(--navbar-height));
+  background: var(--bg-color);
+  border-left: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+}
+
+.retrorecon-root .chat-overlay__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5em;
+}
+
+.retrorecon-root .chat-overlay__input {
+  display: flex;
+  border-top: 1px solid #ccc;
+}
+
+.retrorecon-root .chat-overlay__input-field {
+  flex: 1;
+}

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,0 +1,32 @@
+window.retroChat = (function() {
+  const overlay = document.querySelector('.chat-overlay');
+  const messages = overlay.querySelector('.chat-overlay__messages');
+  const input = overlay.querySelector('.chat-overlay__input-field');
+  const sendBtn = overlay.querySelector('.chat-overlay__send');
+
+  async function sendMessage() {
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = '';
+    appendMessage('> ' + text);
+    const resp = await fetch('/chat/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text })
+    });
+    const data = await resp.json();
+    appendMessage(JSON.stringify(data, null, 2));
+  }
+
+  function appendMessage(text) {
+    const pre = document.createElement('pre');
+    pre.textContent = text;
+    messages.appendChild(pre);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  sendBtn.addEventListener('click', sendMessage);
+  input.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') sendMessage();
+  });
+})();

--- a/templates/chat_overlay.html
+++ b/templates/chat_overlay.html
@@ -1,0 +1,9 @@
+<div class="retrorecon-root">
+  <div class="chat-overlay hidden">
+    <div class="chat-overlay__messages"></div>
+    <div class="chat-overlay__input">
+      <input class="chat-overlay__input-field input" type="text" placeholder="SQL or question" />
+      <button class="chat-overlay__send btn">Send</button>
+    </div>
+  </div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}" />
   <link rel="stylesheet" href="{{ url_for('static', filename='tools.css') }}" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='chat.css') }}" />
   {% if current_theme %}
   {% if current_theme == 'terminal-sans-dark.css' %}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@latest" />
@@ -419,6 +420,8 @@
     </div>
     <div id="tags-list" class="notes-list mt-05"></div>
   </div>
+
+  {% include 'chat_overlay.html' %}
 
   <script>
     const totalResultsCount = {{ total_count }};
@@ -1791,6 +1794,7 @@
   </script>
 </div>
 <script src="{{ url_for('static', filename='col_resize.js') }}"></script>
+<script src="{{ url_for('static', filename='chat.js') }}"></script>
 <script src="{{ url_for('static', filename='index_page.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add FastMCP dependency
- implement RetroReconMCPServer and chat blueprint for SQL MCP access
- provide minimal chat overlay template, CSS and JS
- register new chat blueprint in Flask app

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662ff2e9188332867ff4fac96c05a9