### PR TITLE
Add escape key close and header styling to chat

### DIFF
--- a/static/chat.css
+++ b/static/chat.css
@@ -6,7 +6,7 @@
   width: 50vw;
   max-width: 600px;
   min-width: 300px;
-  background: var(--bg-color);
+  background: #000;
   border-left: 1px solid #ccc;
   display: flex;
   flex-direction: column;
@@ -35,6 +35,7 @@
   display: flex;
   justify-content: flex-end;
   border-bottom: 1px solid #ccc;
+  background: #000;
 }
 
 .retrorecon-root .chat-overlay__close {

--- a/static/chat.js
+++ b/static/chat.js
@@ -77,6 +77,11 @@ window.retroChat = (function() {
     if (e.key === 'Enter') sendMessage();
   });
   if (closeBtn) closeBtn.addEventListener('click', hide);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay.classList.contains('show')) {
+      hide();
+    }
+  });
 
   if (resizeHandle) resizeHandle.addEventListener('mousedown', startResize)
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- make chat overlay opaque so text is visible
- allow closing chat with `Esc`

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b667d5c8833294a9c7c2c8bd25f3