### PR TITLE
Add MCP configuration module

### DIFF
--- a/retrorecon/mcp/__init__.py
+++ b/retrorecon/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""SQLite MCP server integration package."""
+
+from .config import MCPConfig, load_config
+from .server import RetroReconMCPServer
+
+__all__ = ["MCPConfig", "load_config", "RetroReconMCPServer"]

--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -1,0 +1,22 @@
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class MCPConfig:
+    """Configuration values for the MCP server."""
+
+    db_path: Optional[str] = None
+    model: str = "gpt-4o"
+    row_limit: int = 100
+
+
+def load_config() -> MCPConfig:
+    """Load MCP configuration from environment variables."""
+    db_path = os.getenv("RETRORECON_MCP_DB")
+    model = os.getenv("RETRORECON_MCP_MODEL", "gpt-4o")
+    try:
+        row_limit = int(os.getenv("RETRORECON_MCP_ROW_LIMIT", "100"))
+    except ValueError:
+        row_limit = 100
+    return MCPConfig(db_path=db_path, model=model, row_limit=row_limit)

--- a/retrorecon/routes/chat.py
+++ b/retrorecon/routes/chat.py
@@ -1,7 +1,7 @@
 import app
 from flask import Blueprint, request, jsonify
 
-from retrorecon.mcp.server import RetroReconMCPServer
+from retrorecon.mcp import RetroReconMCPServer, load_config
 
 bp = Blueprint('chat', __name__, url_prefix='/chat')
 
@@ -10,7 +10,7 @@ def _get_server() -> RetroReconMCPServer:
     """Get or create the MCP server instance."""
     server = getattr(app, 'mcp_server', None)
     if server is None:
-        server = RetroReconMCPServer()
+        server = RetroReconMCPServer(config=load_config())
         app.mcp_server = server
     _ensure_db_path(server)
     return server


### PR DESCRIPTION
## Summary
- implement missing `mcp/config.py` for environment-based settings
- expose MCP utilities from `retrorecon.mcp`
- load MCP config when chat routes instantiate the server
- support row limit and db path in `RetroReconMCPServer`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866baa18bec83328d359c192fd7d14d