### PR TITLE
Add LLM config via secrets

### DIFF
--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -7,16 +7,29 @@ class MCPConfig:
     """Configuration values for the MCP server."""
 
     db_path: Optional[str] = None
-    model: str = "gpt-4o"
+    api_base: str = "http://localhost:1234/v1"
+    model: str = "qwen2.5-coldbrew-aetheria-test2_tools"
+    temperature: float = 0.1
     row_limit: int = 100
 
 
 def load_config() -> MCPConfig:
     """Load MCP configuration from environment variables."""
     db_path = os.getenv("RETRORECON_MCP_DB")
-    model = os.getenv("RETRORECON_MCP_MODEL", "gpt-4o")
+    api_base = os.getenv("RETRORECON_MCP_API_BASE", "http://localhost:1234/v1")
+    model = os.getenv("RETRORECON_MCP_MODEL", "qwen2.5-coldbrew-aetheria-test2_tools")
+    try:
+        temperature = float(os.getenv("RETRORECON_MCP_TEMPERATURE", "0.1"))
+    except ValueError:
+        temperature = 0.1
     try:
         row_limit = int(os.getenv("RETRORECON_MCP_ROW_LIMIT", "100"))
     except ValueError:
         row_limit = 100
-    return MCPConfig(db_path=db_path, model=model, row_limit=row_limit)
+    return MCPConfig(
+        db_path=db_path,
+        api_base=api_base,
+        model=model,
+        temperature=temperature,
+        row_limit=row_limit,
+    )

--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -17,6 +17,9 @@ class RetroReconMCPServer:
     def __init__(self, db_path: Optional[str] = None, config: MCPConfig | None = None) -> None:
         self.config = config or load_config()
         self.db_path = db_path or self.config.db_path
+        self.api_base = self.config.api_base
+        self.model = self.config.model
+        self.temperature = self.config.temperature
         self.row_limit = self.config.row_limit
         self.server = FastMCP("RetroRecon SQLite Explorer")
         self._setup_tools()

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -3,5 +3,8 @@
   "DOCKERHUB_API": "",
   "VIRUSTOTAL_API": "",
   "REGISTRY_USERNAME": "",
-  "REGISTRY_PASSWORD": ""
+  "REGISTRY_PASSWORD": "",
+  "RETRORECON_MCP_API_BASE": "http://localhost:1234/v1",
+  "RETRORECON_MCP_MODEL": "qwen2.5-coldbrew-aetheria-test2_tools",
+  "RETRORECON_MCP_TEMPERATURE": 0.1
 }

--- a/tests/test_mcp_config_secrets.py
+++ b/tests/test_mcp_config_secrets.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+
+def test_mcp_config_from_secrets_file(monkeypatch, tmp_path):
+    monkeypatch.delenv('RETRORECON_MCP_MODEL', raising=False)
+    monkeypatch.delenv('RETRORECON_MCP_API_BASE', raising=False)
+    monkeypatch.delenv('RETRORECON_MCP_TEMPERATURE', raising=False)
+
+    secrets = tmp_path / 'secrets.json'
+    secrets.write_text(json.dumps({
+        'RETRORECON_MCP_MODEL': 'test-model',
+        'RETRORECON_MCP_API_BASE': 'http://example.com/v1',
+        'RETRORECON_MCP_TEMPERATURE': 0.55
+    }))
+    monkeypatch.setenv('RETRORECON_SECRETS_FILE', str(secrets))
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import importlib
+    import config
+    importlib.reload(config)
+    from retrorecon.mcp.config import load_config
+
+    cfg = load_config()
+    assert cfg.model == 'test-model'
+    assert cfg.api_base == 'http://example.com/v1'
+    assert cfg.temperature == 0.55
+
+    monkeypatch.delenv('RETRORECON_SECRETS_FILE', raising=False)


### PR DESCRIPTION
## Summary
- extend MCPConfig to include `api_base`, `model` and `temperature`
- read these from environment variables so they can be stored in secrets.json
- expose these config options on the server class
- update `secrets.example.json` with default LM Studio settings
- add regression test for secrets-based MCP config

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bf17d37083329e8c618d044e3ee8