### PR TITLE
Add chat help message

### DIFF
--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -110,6 +110,15 @@ class RetroReconMCPServer:
 
         if lowered in {"hello", "hi"}:
             return {"message": "Hello! Ask me a database question."}
+        if lowered in {"help", "?"}:
+            db_info = self.db_path if self.db_path else "(no database loaded)"
+            return {
+                "message": (
+                    "RetroRecon chat is ready. "
+                    f"Database: {db_info}. Model: {self.model}. "
+                    "Ask about your data in plain English."
+                )
+            }
         if lowered == "prompt":
             return {"message": "Try asking about tables or data in plain English."}
 

--- a/tests/test_mcp_chat.py
+++ b/tests/test_mcp_chat.py
@@ -21,3 +21,14 @@ def test_answer_question_sql_rejected(tmp_path):
     server = RetroReconMCPServer(config=cfg)
     resp = server.answer_question("SELECT 1")
     assert resp.get("error") == "Direct SQL input is not supported in chat"
+
+
+def test_help_message(tmp_path):
+    cfg = load_config()
+    cfg.db_path = str(tmp_path / "empty.db")
+    with open(cfg.db_path, "wb"):
+        pass
+    server = RetroReconMCPServer(config=cfg)
+    resp = server.answer_question("help")
+    assert "RetroRecon chat is ready" in resp.get("message", "")
+    assert cfg.model in resp.get("message", "")


### PR DESCRIPTION
## Summary
- add a help response in `RetroReconMCPServer.answer_question`
- test that help includes model information

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cbd294308332a691d6756da98522