### PR TITLE
Integrate vendored MCP SQLite server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.db
 db/*.db
 *.zip
 *.sqlite
@@ -19,4 +20,6 @@ logs/
 *.log
 .vscode/
 venv/
+.venv/
+*/.venv/
 !schemas/*.json

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Launch the Flask UI with the provided scripts. The optional `-l` flag sets the l
 These scripts export `RETRORECON_LISTEN` so `app.py` binds accordingly.
 **Never expose the app publicly without proper hardening.**
 
+### Vendored MCP SQLite Server
+
+`launch_app.sh` and `launch_app.bat` also manage a local Model Context Protocol
+server located in `external/mcp-sqlite`. On first run they create a virtual
+environment under that folder, install its dependencies with `pip install -e .`,
+and start the server in the background before launching RetroRecon. The server
+uses the same database path as the main app (from `RETRORECON_DB` or
+`db/waybax.db`). When the app exits the MCP server is terminated automatically.
+
+If dependency installation fails, delete `external/mcp-sqlite/.venv` and rerun
+the launch script.
+
 For a quick walkthrough of the common workflow see
 [docs/new_user_guide.md](docs/new_user_guide.md).
 

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -18,4 +18,22 @@ venv\Scripts\pip install -r requirements.txt
 set RETRORECON_LOG_LEVEL=DEBUG
 set RETRORECON_LISTEN=%LISTEN_ADDR%
 
+set MCP_DIR=external\mcp-sqlite
+if not exist %MCP_DIR%\.venv (
+    python -m venv %MCP_DIR%\.venv
+)
+
+%MCP_DIR%\.venv\Scripts\python -m pip install --upgrade pip
+%MCP_DIR%\.venv\Scripts\pip install -e %MCP_DIR%
+
+if "%RETRORECON_DB%"=="" (
+    set DB_PATH=%cd%\db\waybax.db
+) else (
+    set DB_PATH=%RETRORECON_DB%
+)
+
+for /f %%p in ('powershell -NoProfile -Command "($p=Start-Process -FilePath '%MCP_DIR%\.venv\Scripts\python.exe' -ArgumentList '-m mcp_server_sqlite --db-path \"%DB_PATH%\"' -PassThru); $p.Id"') do set MCP_PID=%%p
+
 venv\Scripts\python app.py
+
+powershell -NoProfile -Command "Stop-Process -Id %MCP_PID%"

--- a/launch_app.sh
+++ b/launch_app.sh
@@ -24,5 +24,24 @@ export RETRORECON_LOG_LEVEL=DEBUG
 export RETRORECON_LISTEN="$LISTEN_ADDR"
 
 python_cmd="venv/bin/python"
+# Setup vendored MCP SQLite server
+MCP_DIR="external/mcp-sqlite"
+if [ ! -d "$MCP_DIR/.venv" ]; then
+  python3 -m venv "$MCP_DIR/.venv"
+fi
+"$MCP_DIR/.venv/bin/pip" install --upgrade pip
+"$MCP_DIR/.venv/bin/pip" install -e "$MCP_DIR"
+
+# Resolve database path for MCP server
+DB_PATH="${RETRORECON_DB:-$(pwd)/db/waybax.db}"
+if [ ! -f "$DB_PATH" ]; then
+  echo "Database not found at $DB_PATH"
+fi
+
+# Start MCP server in background and ensure cleanup
+"$MCP_DIR/.venv/bin/python" -m mcp_server_sqlite --db-path "$DB_PATH" &
+MCP_PID=$!
+trap 'kill $MCP_PID' EXIT
+
 # On WSL, using win32 path may create issues; always use the venv python
 "$python_cmd" app.py


### PR DESCRIPTION
## Summary
- ignore database files and Python virtual envs
- automatically start vendored MCP SQLite server when launching RetroRecon
- document MCP server setup in README
- remove leftover test DB

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dbb39e748332aa093f7e7b354ac0