### PR TITLE
Add MCP server status indicator

### DIFF
--- a/docs/api_routes.md
+++ b/docs/api_routes.md
@@ -67,6 +67,17 @@ Response:
 {"status": "done", "progress": 10, "total": 10, "detail": "Imported 10 records."}
 ```
 
+### `GET /chat/status`
+Check that the embedded MCP server is running and connected to the SQLite database.
+
+```
+curl http://localhost:5000/chat/status
+```
+Response:
+```json
+{"ok": true, "db": "retro.db"}
+```
+
 ### `POST /add_tag`
 Add a tag to a single URL entry.
 

--- a/retrorecon/routes/chat.py
+++ b/retrorecon/routes/chat.py
@@ -42,3 +42,20 @@ def handle_chat_message():
         return jsonify(result)
     except Exception as exc:
         return jsonify({'error': str(exc)})
+
+
+@bp.route('/status', methods=['GET'])
+def chat_status():
+    """Return health information for the MCP server."""
+    try:
+        server = _get_server()
+    except Exception as exc:  # pragma: no cover - unexpected init failure
+        return jsonify({'ok': False, 'error': str(exc)})
+
+    try:
+        with server.get_connection() as conn:
+            conn.execute('SELECT 1')
+        return jsonify({'ok': True, 'db': server.db_path})
+    except Exception as exc:
+        return jsonify({'ok': False, 'error': str(exc)})
+

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -58,6 +58,12 @@ paths:
       responses:
         '200':
           description: Successful response
+  /chat/status:
+    get:
+      summary: GET /chat/status
+      responses:
+        '200':
+          description: Successful response
   /add_tag:
     post:
       summary: POST /add_tag

--- a/templates/index.html
+++ b/templates/index.html
@@ -263,6 +263,10 @@
           <span id="import-progress-numbers-span"></span>
         </div>
       </div>
+      <div id="mcp-status-block" class="db-info ml-1">
+        <span class="ml-01"><strong>MCP:</strong></span>
+        <span id="mcp-status-text">checking…</span>
+      </div>
     </div>
   </nav>
 
@@ -870,6 +874,22 @@
     }
 
     pollStatus();
+
+    function checkMcp(){
+      const text = document.getElementById('mcp-status-text');
+      fetch('/chat/status')
+        .then(r => r.json())
+        .then(data => {
+          if(data.ok){
+            text.textContent = 'online';
+          } else {
+            text.textContent = 'error';
+          }
+        })
+        .catch(() => { text.textContent = 'error'; });
+    }
+
+    checkMcp();
 
     // Check once on load and show current status
       fetch('/import_progress')

--- a/tests/test_mcp_status_route.py
+++ b/tests/test_mcp_status_route.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import app
+
+
+def setup_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(app.app, "root_path", str(tmp_path))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "db").mkdir(exist_ok=True)
+    schema = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
+    (tmp_path / "db" / "schema.sql").write_text(schema.read_text())
+    monkeypatch.setitem(app.app.config, "DATABASE", str(tmp_path / "test.db"))
+    with app.app.app_context():
+        app.create_new_db("test")
+    if hasattr(app, "mcp_server"):
+        delattr(app, "mcp_server")
+
+
+def test_mcp_status_ok(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    with app.app.test_client() as client:
+        resp = client.get("/chat/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert "db" in data
+
+
+def test_mcp_status_failure(monkeypatch, tmp_path):
+    setup_tmp(monkeypatch, tmp_path)
+    monkeypatch.setitem(app.app.config, "DATABASE", None)
+    if hasattr(app, "mcp_server"):
+        delattr(app, "mcp_server")
+    with app.app.test_client() as client:
+        resp = client.get("/chat/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is False
+        assert "error" in data


### PR DESCRIPTION
## Summary
- show MCP server status in the navbar
- poll `/chat/status` endpoint on page load
- expose `/chat/status` route for health checks
- document new route and add OpenAPI entry
- test MCP status route

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866df2376548332bea3d357c4bd1ba4