### PR TITLE
Fix chat overlay styling

### DIFF
--- a/static/chat.css
+++ b/static/chat.css
@@ -6,8 +6,8 @@
   width: 50vw;
   max-width: 90vw;
   min-width: 300px;
-  background: #000;
-  border-left: 1px solid #ccc;
+  background: rgba(var(--bg-rgb) / var(--panel-opacity, 0.95));
+  border-left: 1px solid var(--color-contrast);
   display: flex;
   flex-direction: column;
   transform: translateX(100%);
@@ -34,8 +34,8 @@
 .retrorecon-root .chat-overlay__header {
   display: flex;
   justify-content: flex-end;
-  border-bottom: 1px solid #ccc;
-  background: #000;
+  border-bottom: 1px solid var(--color-contrast);
+  background: var(--bg-color);
 }
 
 .retrorecon-root .chat-overlay__close {
@@ -57,7 +57,7 @@
 
 .retrorecon-root .chat-overlay__input {
   display: flex;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid var(--color-contrast);
 }
 
 .retrorecon-root .chat-overlay__input-field {

--- a/static/chat.js
+++ b/static/chat.js
@@ -62,7 +62,14 @@ window.retroChat = (function() {
       body: JSON.stringify({ message: text })
     });
     const data = await resp.json();
-    appendMessage(JSON.stringify(data, null, 2));
+    if (data.message) {
+      appendMessage('LLM: ' + data.message);
+    } else if (data.error) {
+      const hint = data.hint ? '\n' + data.hint : '';
+      appendMessage('Error: ' + data.error + hint);
+    } else {
+      appendMessage(JSON.stringify(data, null, 2));
+    }
   }
 
   function appendMessage(text) {

--- a/templates/chat_overlay.html
+++ b/templates/chat_overlay.html
@@ -1,13 +1,9 @@
-<div class="retrorecon-root">
-  <div class="chat-overlay hidden">
-    <div class="chat-overlay__resize"></div>
-    <div class="chat-overlay__header">
-      <button type="button" class="chat-overlay__close btn">×</button>
-    </div>
-    <div class="chat-overlay__messages"></div>
-    <div class="chat-overlay__input">
-      <input class="chat-overlay__input-field input" type="text" placeholder="Ask a question about your data" />
-      <button class="chat-overlay__send btn">Send</button>
-    </div>
+<div class="chat-overlay hidden" id="chat-overlay">
+  <div class="chat-overlay__resize"></div>
+  <button type="button" class="chat-overlay__close btn overlay-close-btn">×</button>
+  <div class="chat-overlay__messages"></div>
+  <div class="chat-overlay__input">
+    <input class="chat-overlay__input-field form-input" type="text" placeholder="Ask a question about your data" />
+    <button class="chat-overlay__send btn">Send</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- align chat overlay CSS with site theme using CSS variables
- apply global overlay close button styles
- use existing form input styling
- parse chat JSON responses for friendly display

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_6866ded9edac83329d4846e4072931aa