### PR TITLE
Fix ensure_schema call under app context

### DIFF
--- a/app.py
+++ b/app.py
@@ -985,10 +985,11 @@ def add_no_cache_headers(response: Response) -> Response:
 
 if __name__ == '__main__':
     if env_db and app.config.get('DATABASE'):
-        if not os.path.exists(app.config['DATABASE']):
-            create_new_db(os.path.splitext(os.path.basename(env_db))[0])
-        else:
-            ensure_schema()
+        with app.app_context():
+            if not os.path.exists(app.config['DATABASE']):
+                create_new_db(os.path.splitext(os.path.basename(env_db))[0])
+            else:
+                ensure_schema()
     host = os.environ.get('RETRORECON_LISTEN', '127.0.0.1')
     port = int(os.environ.get('RETRORECON_PORT', '5000'))
     app.run(debug=True, host=host, port=port)


### PR DESCRIPTION
## Summary
- wrap ensure_schema/create_new_db in `app.app_context()` at startup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6866fec241308332a555a9b2e9afad83