### PR TITLE
Fix MCP subprocess handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,20 @@ These scripts export `RETRORECON_LISTEN` so `app.py` binds accordingly.
 
 ### Vendored MCP SQLite Server
 
-`launch_app.sh` and `launch_app.bat` also manage a local Model Context Protocol
-server located in `external/mcp-sqlite`. They create a dedicated virtual
-environment for the server (defaulting to `external/mcp-sqlite/.venv` but
-overridable via the `MCP_VENV` variable), install dependencies with
-`pip install -e .`, and start the server in the background before launching
-RetroRecon. The server uses the same database path as the main app (from
-`RETRORECON_DB` or `db/waybax.db`). When the app exits the MCP server is
-terminated automatically.
+`launch_app.sh` and `launch_app.bat` previously started the vendored Model
+Context Protocol server. This logic now lives inside the Flask application.
+Whenever a database is loaded or switched RetroRecon launches
+`mcp-server-sqlite` as a subprocess on port `12345` pointing at the active
+database. The server is terminated automatically when the app shuts down.
+
+LLMs can connect to MCP at `127.0.0.1:12345`. Include a line such as:
+
+```
+You have access to the currently loaded retrorecon SQLite database via MCP at
+127.0.0.1:12345. Use this endpoint for SQL queries.
+```
+
+in your system prompt or tool configuration.
 
 If dependency installation fails, delete the virtual environment directory and
 rerun the launch script.

--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import subprocess
+import atexit
+from typing import Optional
+
+MCP_PORT = 12345
+_mcp_proc: Optional[subprocess.Popen] = None
+
+
+def start_mcp_sqlite(db_path: str, port: int = MCP_PORT) -> None:
+    """Start the mcp-sqlite server for *db_path* on the given port."""
+    global _mcp_proc
+    stop_mcp_sqlite()
+    mcp_dir = os.path.join(os.path.dirname(__file__), 'external', 'mcp-sqlite')
+    env = os.environ.copy()
+    env.setdefault('PYTHONPATH', os.path.join(mcp_dir, 'src'))
+    cmd = [sys.executable, '-m', 'mcp_server_sqlite', '--db-path', db_path,
+           '--host', '127.0.0.1', '--port', str(port)]
+    _mcp_proc = subprocess.Popen(cmd, cwd=mcp_dir, env=env)
+
+
+def stop_mcp_sqlite() -> None:
+    """Stop the running mcp-sqlite subprocess if active."""
+    global _mcp_proc
+    if _mcp_proc is not None and _mcp_proc.poll() is None:
+        _mcp_proc.terminate()
+        try:
+            _mcp_proc.wait(timeout=5)
+        except Exception:
+            _mcp_proc.kill()
+    _mcp_proc = None
+
+
+atexit.register(stop_mcp_sqlite)

--- a/retrorecon/routes/db.py
+++ b/retrorecon/routes/db.py
@@ -17,6 +17,7 @@ def new_db():
         os.remove(temp_path)
     try:
         db_name = app.create_new_db(safe)
+        app.start_mcp_sqlite(app.app.config['DATABASE'], app.MCP_PORT)
         session['db_display_name'] = db_name
         flash('New database created.', 'success')
     except ValueError as e:
@@ -43,6 +44,7 @@ def load_db_route():
         file.save(db_path)
         app.app.config['DATABASE'] = db_path
         app.ensure_schema()
+        app.start_mcp_sqlite(app.app.config['DATABASE'], app.MCP_PORT)
         session['db_display_name'] = filename
         flash("Database loaded.", "success")
     except Exception as e:
@@ -86,6 +88,7 @@ def rename_db():
         return redirect(url_for('index'))
     app.app.config['DATABASE'] = new_path
     app.ensure_schema()
+    app.start_mcp_sqlite(app.app.config['DATABASE'], app.MCP_PORT)
     session['db_display_name'] = safe
     flash('Database renamed.', 'success')
     return redirect(url_for('index'))
@@ -110,6 +113,7 @@ def load_saved_db():
     try:
         app.app.config['DATABASE'] = path
         app.ensure_schema()
+        app.start_mcp_sqlite(app.app.config['DATABASE'], app.MCP_PORT)
         session['db_display_name'] = safe
         flash('Database loaded.', 'success')
     except Exception as e:


### PR DESCRIPTION
## Summary
- spawn `mcp-server-sqlite` as a subprocess via new `mcp_manager` module
- launch and restart MCP when databases change
- remove old FastMCP middleware
- document MCP endpoint in README

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68670a4755d08332ad407c31c2b2c42a