### PR TITLE
Fix module execution for mcp_server_sqlite

### DIFF
--- a/external/mcp-sqlite/src/mcp_server_sqlite/__main__.py
+++ b/external/mcp-sqlite/src/mcp_server_sqlite/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `python -m mcp_server_sqlite` to work by adding `__main__.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686711dee25c8332a2d2515413320f6e