### PR TITLE
Fix MCP server launch args

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,12 @@ These scripts export `RETRORECON_LISTEN` so `app.py` binds accordingly.
 `launch_app.sh` and `launch_app.bat` previously started the vendored Model
 Context Protocol server. This logic now lives inside the Flask application.
 Whenever a database is loaded or switched RetroRecon launches
-`mcp-server-sqlite` as a subprocess on port `12345` pointing at the active
-database. The server is terminated automatically when the app shuts down.
+`mcp-server-sqlite` as a subprocess pointing at the active database. The
+server communicates over standard input/output and is terminated
+automatically when the app shuts down. No TCP port is exposed.
 
-LLMs can connect to MCP at `127.0.0.1:12345`. Include a line such as:
-
-```
-You have access to the currently loaded retrorecon SQLite database via MCP at
-127.0.0.1:12345. Use this endpoint for SQL queries.
-```
-
-in your system prompt or tool configuration.
+You may mention in your system prompt that an MCP server is available within
+the application for executing safe SQL queries against the current database.
 
 If dependency installation fails, delete the virtual environment directory and
 rerun the launch script.

--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -9,14 +9,18 @@ _mcp_proc: Optional[subprocess.Popen] = None
 
 
 def start_mcp_sqlite(db_path: str, port: int = MCP_PORT) -> None:
-    """Start the mcp-sqlite server for *db_path* on the given port."""
+    """Start the mcp-sqlite server for *db_path*.
+
+    The vendored server currently communicates over standard input/output and
+    ignores the ``port`` argument. The parameter is kept for backward
+    compatibility with older documentation but no network listener is started.
+    """
     global _mcp_proc
     stop_mcp_sqlite()
     mcp_dir = os.path.join(os.path.dirname(__file__), 'external', 'mcp-sqlite')
     env = os.environ.copy()
     env.setdefault('PYTHONPATH', os.path.join(mcp_dir, 'src'))
-    cmd = [sys.executable, '-m', 'mcp_server_sqlite', '--db-path', db_path,
-           '--host', '127.0.0.1', '--port', str(port)]
+    cmd = [sys.executable, '-m', 'mcp_server_sqlite', '--db-path', db_path]
     _mcp_proc = subprocess.Popen(cmd, cwd=mcp_dir, env=env)
 
 


### PR DESCRIPTION
## Summary
- avoid passing nonexistent `--host`/`--port` flags when spawning mcp-server
- clarify README about MCP server running via stdio

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867150eaa8083328f98e98a1c0e9a7d