### PR TITLE
Enable built‑in MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,9 @@ These scripts export `RETRORECON_LISTEN` so `app.py` binds accordingly.
 
 `launch_app.sh` and `launch_app.bat` previously started the vendored Model
 Context Protocol server. This logic now lives inside the Flask application.
-Whenever a database is loaded or switched RetroRecon launches
-`mcp-server-sqlite` as a subprocess pointing at the active database. The
-server communicates over standard input/output and is terminated
-automatically when the app shuts down. No TCP port is exposed.
+Whenever a database is loaded or switched RetroRecon uses the built-in
+`RetroReconMCPServer` class pointing at the active database. No external
+process is launched; all communication happens directly in Python.
 
 You may mention in your system prompt that an MCP server is available within
 the application for executing safe SQL queries against the current database.

--- a/app.py
+++ b/app.py
@@ -154,7 +154,7 @@ def _create_temp_db() -> None:
     if os.path.exists(app.config['DATABASE']):
         os.remove(app.config['DATABASE'])
     init_db()
-    start_mcp_sqlite(app.config['DATABASE'])
+    app.mcp_server = start_mcp_sqlite(app.config['DATABASE'])
 
 
 if not env_db:
@@ -954,7 +954,7 @@ if __name__ == '__main__':
                 create_new_db(os.path.splitext(os.path.basename(env_db))[0])
             else:
                 ensure_schema()
-        start_mcp_sqlite(app.config['DATABASE'])
+        app.mcp_server = start_mcp_sqlite(app.config['DATABASE'])
     host = os.environ.get('RETRORECON_LISTEN', '127.0.0.1')
     port = int(os.environ.get('RETRORECON_PORT', '5000'))
     app.run(debug=True, host=host, port=port)

--- a/docs/mcp_setup_guide.md
+++ b/docs/mcp_setup_guide.md
@@ -1,20 +1,14 @@
 # RetroRecon MCP Setup Guide
 
-This guide explains how to ensure the bundled `mcp-server-sqlite` starts correctly.
-The server is launched automatically by the Flask application and communicates over
-standard input/output—no TCP port is exposed.
+This guide explains how RetroRecon's embedded MCP server works.
+The application now uses the `RetroReconMCPServer` class directly so no
+separate `mcp-server-sqlite` process is launched.
 
 ## Steps
 
-1. Run `launch_app.sh` (Linux/macOS) or `launch_app.bat` (Windows).
-   These scripts create a virtual environment under `external/mcp-sqlite` and
-   install the server in editable mode.
-2. The Flask app will spawn `mcp-server-sqlite` whenever a database is created or
-   loaded. If you see a "program not found" error, verify that the virtual
-   environment exists and contains the package:
-   ```bash
-   ls external/mcp-sqlite/.venv
-   ```
-   Re-run the launch script if necessary.
-3. There is no need to configure a port or connect LM Studio to this server. It
-   is an internal helper used solely by RetroRecon.
+1. Run `launch_app.sh` (Linux/macOS) or `launch_app.bat` (Windows) to install
+   the Python dependencies.
+2. The Flask app automatically instantiates `RetroReconMCPServer` whenever a
+   database is created or loaded. No separate background process is required.
+3. There is no need to configure a port or connect LM Studio; the server runs
+   entirely inside the application.

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -27,17 +27,6 @@ venv\Scripts\pip install -r requirements.txt
 set RETRORECON_LOG_LEVEL=DEBUG
 set RETRORECON_LISTEN=%LISTEN_ADDR%
 
-set MCP_DIR=external\mcp-sqlite
-if "%MCP_VENV%"=="" (
-    set MCP_VENV=%MCP_DIR%\.venv
-)
-if not exist %MCP_VENV% (
-    python -m venv %MCP_VENV%
-)
-
-%MCP_VENV%\Scripts\python -m pip install --upgrade pip
-%MCP_VENV%\Scripts\pip install -e %MCP_DIR%
-
 set RETRORECON_DB=%DB_PATH%
 
 venv\Scripts\python app.py

--- a/launch_app.sh
+++ b/launch_app.sh
@@ -33,16 +33,6 @@ export RETRORECON_LOG_LEVEL=DEBUG
 export RETRORECON_LISTEN="$LISTEN_ADDR"
 
 python_cmd="venv/bin/python"
-# Setup vendored MCP SQLite server
-MCP_DIR="external/mcp-sqlite"
-MCP_VENV="${MCP_VENV:-$MCP_DIR/.venv}"
-if [ ! -d "$MCP_VENV" ]; then
-  python3 -m venv "$MCP_VENV"
-fi
-
-"$MCP_VENV/bin/pip" install --upgrade pip
-"$MCP_VENV/bin/pip" install -e "$MCP_DIR"
-
 export RETRORECON_DB="$DB_PATH"
 if [ ! -f "$DB_PATH" ]; then
   echo "Database not found at $DB_PATH"

--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -1,40 +1,34 @@
-import os
-import sys
-import subprocess
 import atexit
 from typing import Optional
 
-# The server currently communicates over stdio only so no port is needed.
+from retrorecon.mcp import RetroReconMCPServer, load_config
 
-_mcp_proc: Optional[subprocess.Popen] = None
+_mcp_server: Optional[RetroReconMCPServer] = None
 
 
-def start_mcp_sqlite(db_path: str) -> None:
-    """Start the mcp-sqlite server for *db_path*.
+def start_mcp_sqlite(db_path: str) -> RetroReconMCPServer:
+    """Initialize or update the embedded MCP server for *db_path*."""
+    global _mcp_server
+    if _mcp_server is None:
+        cfg = load_config()
+        cfg.db_path = db_path
+        _mcp_server = RetroReconMCPServer(config=cfg)
+    else:
+        _mcp_server.update_database_path(db_path)
+    return _mcp_server
 
-    The vendored server communicates over standard input/output. Earlier
-    versions exposed a ``port`` argument but no network listener is currently
-    started.
-    """
-    global _mcp_proc
-    stop_mcp_sqlite()
-    mcp_dir = os.path.join(os.path.dirname(__file__), 'external', 'mcp-sqlite')
-    env = os.environ.copy()
-    env.setdefault('PYTHONPATH', os.path.join(mcp_dir, 'src'))
-    cmd = [sys.executable, '-m', 'mcp_server_sqlite', '--db-path', db_path]
-    _mcp_proc = subprocess.Popen(cmd, cwd=mcp_dir, env=env)
+
+def get_mcp_server() -> Optional[RetroReconMCPServer]:
+    """Return the active MCP server instance, if any."""
+    return _mcp_server
 
 
 def stop_mcp_sqlite() -> None:
-    """Stop the running mcp-sqlite subprocess if active."""
-    global _mcp_proc
-    if _mcp_proc is not None and _mcp_proc.poll() is None:
-        _mcp_proc.terminate()
-        try:
-            _mcp_proc.wait(timeout=5)
-        except Exception:
-            _mcp_proc.kill()
-    _mcp_proc = None
+    """Cleanup the embedded MCP server instance."""
+    global _mcp_server
+    if _mcp_server is not None:
+        _mcp_server.cleanup()
+    _mcp_server = None
 
 
 atexit.register(stop_mcp_sqlite)

--- a/retrorecon/routes/chat.py
+++ b/retrorecon/routes/chat.py
@@ -1,7 +1,8 @@
 import app
 from flask import Blueprint, request, jsonify
 
-from retrorecon.mcp import RetroReconMCPServer, load_config
+from retrorecon.mcp import RetroReconMCPServer
+from mcp_manager import start_mcp_sqlite
 
 bp = Blueprint('chat', __name__, url_prefix='/chat')
 
@@ -10,9 +11,10 @@ def _get_server() -> RetroReconMCPServer:
     """Get or create the MCP server instance."""
     server = getattr(app, 'mcp_server', None)
     if server is None:
-        server = RetroReconMCPServer(config=load_config())
+        server = start_mcp_sqlite(app.app.config.get('DATABASE'))
         app.mcp_server = server
-    _ensure_db_path(server)
+    else:
+        _ensure_db_path(server)
     return server
 
 

--- a/retrorecon/routes/db.py
+++ b/retrorecon/routes/db.py
@@ -17,7 +17,7 @@ def new_db():
         os.remove(temp_path)
     try:
         db_name = app.create_new_db(safe)
-        app.start_mcp_sqlite(app.app.config['DATABASE'])
+        app.mcp_server = app.start_mcp_sqlite(app.app.config['DATABASE'])
         session['db_display_name'] = db_name
         flash('New database created.', 'success')
     except ValueError as e:
@@ -44,7 +44,7 @@ def load_db_route():
         file.save(db_path)
         app.app.config['DATABASE'] = db_path
         app.ensure_schema()
-        app.start_mcp_sqlite(app.app.config['DATABASE'])
+        app.mcp_server = app.start_mcp_sqlite(app.app.config['DATABASE'])
         session['db_display_name'] = filename
         flash("Database loaded.", "success")
     except Exception as e:
@@ -88,7 +88,7 @@ def rename_db():
         return redirect(url_for('index'))
     app.app.config['DATABASE'] = new_path
     app.ensure_schema()
-    app.start_mcp_sqlite(app.app.config['DATABASE'])
+    app.mcp_server = app.start_mcp_sqlite(app.app.config['DATABASE'])
     session['db_display_name'] = safe
     flash('Database renamed.', 'success')
     return redirect(url_for('index'))
@@ -113,7 +113,7 @@ def load_saved_db():
     try:
         app.app.config['DATABASE'] = path
         app.ensure_schema()
-        app.start_mcp_sqlite(app.app.config['DATABASE'])
+        app.mcp_server = app.start_mcp_sqlite(app.app.config['DATABASE'])
         session['db_display_name'] = safe
         flash('Database loaded.', 'success')
     except Exception as e:


### PR DESCRIPTION
## Summary
- use RetroReconMCPServer instead of spawning `mcp-server-sqlite`
- update database routes to refresh the server when DB changes
- simplify launch scripts
- document new MCP approach

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68674621011c8332a8100513e0ebd582