### PR TITLE
Add timeout config for MCP LLM requests

### DIFF
--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -12,6 +12,7 @@ class MCPConfig:
     temperature: float = 0.1
     row_limit: int = 100
     api_key: Optional[str] = None
+    timeout: int = 20
 
 
 def load_config() -> MCPConfig:
@@ -28,6 +29,10 @@ def load_config() -> MCPConfig:
         row_limit = int(os.getenv("RETRORECON_MCP_ROW_LIMIT", "100"))
     except ValueError:
         row_limit = 100
+    try:
+        timeout = int(os.getenv("RETRORECON_MCP_TIMEOUT", "20"))
+    except ValueError:
+        timeout = 20
     return MCPConfig(
         db_path=db_path,
         api_base=api_base,
@@ -35,4 +40,5 @@ def load_config() -> MCPConfig:
         temperature=temperature,
         row_limit=row_limit,
         api_key=api_key,
+        timeout=timeout,
     )

--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -32,6 +32,7 @@ class RetroReconMCPServer:
         self.temperature = self.config.temperature
         self.row_limit = self.config.row_limit
         self.api_key = self.config.api_key
+        self.timeout = self.config.timeout
         self.server = FastMCP("RetroRecon SQLite Explorer")
         self._setup_tools()
 
@@ -51,7 +52,7 @@ class RetroReconMCPServer:
         headers = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
-        resp = httpx.post(url, json=payload, headers=headers, timeout=20)
+        resp = httpx.post(url, json=payload, headers=headers, timeout=self.timeout)
         resp.raise_for_status()
         data = resp.json()
         try:

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -6,5 +6,6 @@
   "REGISTRY_PASSWORD": "",
   "RETRORECON_MCP_API_BASE": "http://localhost:1234/v1",
   "RETRORECON_MCP_MODEL": "qwen2.5-coldbrew-aetheria-test2_tools",
-  "RETRORECON_MCP_TEMPERATURE": 0.1
+  "RETRORECON_MCP_TEMPERATURE": 0.1,
+  "RETRORECON_MCP_TIMEOUT": 20
 }

--- a/tests/test_mcp_chat.py
+++ b/tests/test_mcp_chat.py
@@ -48,6 +48,7 @@ def test_llm_request(monkeypatch, tmp_path):
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers
+        captured["timeout"] = timeout
         class Resp:
             status_code = 200
             def raise_for_status(self):
@@ -63,3 +64,4 @@ def test_llm_request(monkeypatch, tmp_path):
     assert resp == {"message": "hi there"}
     assert captured["url"] == "http://llm/chat/completions"
     assert captured["headers"]["Authorization"] == "Bearer key"
+    assert captured["timeout"] == cfg.timeout

--- a/tests/test_mcp_config_secrets.py
+++ b/tests/test_mcp_config_secrets.py
@@ -13,7 +13,8 @@ def test_mcp_config_from_secrets_file(monkeypatch, tmp_path):
     secrets.write_text(json.dumps({
         'RETRORECON_MCP_MODEL': 'test-model',
         'RETRORECON_MCP_API_BASE': 'http://example.com/v1',
-        'RETRORECON_MCP_TEMPERATURE': 0.55
+        'RETRORECON_MCP_TEMPERATURE': 0.55,
+        'RETRORECON_MCP_TIMEOUT': 42
     }))
     monkeypatch.setenv('RETRORECON_SECRETS_FILE', str(secrets))
 
@@ -27,5 +28,6 @@ def test_mcp_config_from_secrets_file(monkeypatch, tmp_path):
     assert cfg.model == 'test-model'
     assert cfg.api_base == 'http://example.com/v1'
     assert cfg.temperature == 0.55
+    assert cfg.timeout == 42
 
     monkeypatch.delenv('RETRORECON_SECRETS_FILE', raising=False)


### PR DESCRIPTION
## Summary
- allow configuring MCP LLM request timeout via `RETRORECON_MCP_TIMEOUT`
- expose timeout value on `MCPConfig`
- use timeout when posting to the LLM
- update example secrets
- extend tests for new setting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675604401883328bd2e07bc6fd8041