### PR TITLE
Add tilde hotkey to toggle chat overlay

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -87,6 +87,12 @@ window.retroChat = (function() {
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && overlay.classList.contains('show')) {
       hide();
+    } else if (e.key === '~' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+      if (overlay.classList.contains('show')) {
+        hide();
+      } else {
+        show();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- allow pressing `~` to toggle the chat overlay open or closed

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68675d8f83988332832611ba0512a63a