### PR TITLE
Fix TextContent type in MCP

### DIFF
--- a/docs/SQLite MCP Server Integration Guide for RetroRecon.md
+++ b/docs/SQLite MCP Server Integration Guide for RetroRecon.md
@@ -292,15 +292,15 @@ async def handle_read_query(self, query: str, params: List[Any] = None) -> TextC
         
         # Format results for display
         if results['count'] == 0:
-            return TextContent(text="No results found for the query.")
+            return TextContent(type="text", text="No results found for the query.")
             
         # Create formatted table output
         formatted_output = self._format_query_results(results)
-        return TextContent(text=formatted_output)
+        return TextContent(type="text", text=formatted_output)
         
     except Exception as e:
         logging.error(f"Query execution failed: {e}")
-        return TextContent(text=f"Query execution failed: {str(e)}")
+        return TextContent(type="text", text=f"Query execution failed: {str(e)}")
 
 def _format_query_results(self, results: Dict[str, Any]) -> str:
     """Format query results for display."""

--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -281,12 +281,12 @@ class RetroReconMCPServer:
         try:
             results = self.execute_query(query, params)
             if results["count"] == 0:
-                return TextContent(text="No results found for the query.")
+                return TextContent(type="text", text="No results found for the query.")
             formatted = self._format_query_results(results)
-            return TextContent(text=formatted)
+            return TextContent(type="text", text=formatted)
         except Exception as exc:
             logger.error("Query execution failed: %s", exc)
-            return TextContent(text=f"Query execution failed: {exc}")
+            return TextContent(type="text", text=f"Query execution failed: {exc}")
 
     async def handle_list_tables(self) -> TextContent:
         logger.debug("handle_list_tables")
@@ -294,20 +294,20 @@ class RetroReconMCPServer:
             q = "SELECT name FROM sqlite_master WHERE type='table'"
             results = self.execute_query(q)
             tables = [r[0] for r in results["rows"]]
-            return TextContent(text="\n".join(tables))
+            return TextContent(type="text", text="\n".join(tables))
         except Exception as exc:
             logger.error("List tables failed: %s", exc)
-            return TextContent(text=f"Failed to list tables: {exc}")
+            return TextContent(type="text", text=f"Failed to list tables: {exc}")
 
     async def handle_describe_table(self, table: str) -> TextContent:
         logger.debug("handle_describe_table %s", table)
         try:
             q = f"PRAGMA table_info({table})"
             results = self.execute_query(q)
-            return TextContent(text=self._format_query_results(results))
+            return TextContent(type="text", text=self._format_query_results(results))
         except Exception as exc:
             logger.error("Describe table failed: %s", exc)
-            return TextContent(text=f"Failed to describe table: {exc}")
+            return TextContent(type="text", text=f"Failed to describe table: {exc}")
 
     # formatting helper
     def _format_query_results(self, results: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- ensure `TextContent` specifies its `type` field for FastMCP
- update MCP guide to match code

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_686778131b808332b2ee1a18b531c034