### PR TITLE
Fix MCP tool return structure

### DIFF
--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -161,14 +161,14 @@ class RetroReconMCPServer:
             query = args.get("query", "")
             params = args.get("params")
             content = anyio.run(self.handle_read_query, query, params)
-            return {"text": content.text}
+            return {"type": "text", "text": content.text}
         if name == "list_tables":
             content = anyio.run(self.handle_list_tables)
-            return {"text": content.text}
+            return {"type": "text", "text": content.text}
         if name == "describe_table":
             table = args.get("table", "")
             content = anyio.run(self.handle_describe_table, table)
-            return {"text": content.text}
+            return {"type": "text", "text": content.text}
         return {"error": f"Unknown tool: {name}"}
 
     # tools

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,13 @@
+from retrorecon.mcp.server import RetroReconMCPServer
+from retrorecon.mcp.config import load_config
+
+
+def test_call_tool_returns_type(tmp_path):
+    cfg = load_config()
+    cfg.db_path = str(tmp_path / "empty.db")
+    with open(cfg.db_path, "wb"):
+        pass
+    server = RetroReconMCPServer(config=cfg)
+    result = server._call_tool("list_tables", {})
+    assert result["type"] == "text"
+    assert "text" in result


### PR DESCRIPTION
## Summary
- include `type: text` in MCP `_call_tool` responses
- add regression test for return value

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_686779ad2aa88332bcd8109fc3419135