### PR TITLE
Add alternate MCP API base support

### DIFF
--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -1,5 +1,5 @@
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 @dataclass
@@ -13,6 +13,7 @@ class MCPConfig:
     row_limit: int = 100
     api_key: Optional[str] = None
     timeout: int = 20
+    alt_api_bases: list[str] = field(default_factory=list)
 
 
 def load_config() -> MCPConfig:
@@ -33,6 +34,8 @@ def load_config() -> MCPConfig:
         timeout = int(os.getenv("RETRORECON_MCP_TIMEOUT", "20"))
     except ValueError:
         timeout = 20
+    alt_env = os.getenv("RETRORECON_MCP_ALT_API_BASES", "")
+    alt_api_bases = [b.strip() for b in alt_env.split(",") if b.strip()]
     return MCPConfig(
         db_path=db_path,
         api_base=api_base,
@@ -41,4 +44,5 @@ def load_config() -> MCPConfig:
         row_limit=row_limit,
         api_key=api_key,
         timeout=timeout,
+        alt_api_bases=alt_api_bases,
     )

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -7,5 +7,8 @@
   "RETRORECON_MCP_API_BASE": "http://localhost:1234/v1",
   "RETRORECON_MCP_MODEL": "qwen2.5-coldbrew-aetheria-test2_tools",
   "RETRORECON_MCP_TEMPERATURE": 0.1,
-  "RETRORECON_MCP_TIMEOUT": 20
+  "RETRORECON_MCP_TIMEOUT": 20,
+  "RETRORECON_MCP_ALT_API_BASES": [
+    "http://192.168.1.98:1234/v1"
+  ]
 }

--- a/tests/test_mcp_config_secrets.py
+++ b/tests/test_mcp_config_secrets.py
@@ -14,7 +14,8 @@ def test_mcp_config_from_secrets_file(monkeypatch, tmp_path):
         'RETRORECON_MCP_MODEL': 'test-model',
         'RETRORECON_MCP_API_BASE': 'http://example.com/v1',
         'RETRORECON_MCP_TEMPERATURE': 0.55,
-        'RETRORECON_MCP_TIMEOUT': 42
+        'RETRORECON_MCP_TIMEOUT': 42,
+        'RETRORECON_MCP_ALT_API_BASES': 'http://alt1.example.com/v1,http://alt2.example.com/v1'
     }))
     monkeypatch.setenv('RETRORECON_SECRETS_FILE', str(secrets))
 
@@ -29,5 +30,6 @@ def test_mcp_config_from_secrets_file(monkeypatch, tmp_path):
     assert cfg.api_base == 'http://example.com/v1'
     assert cfg.temperature == 0.55
     assert cfg.timeout == 42
+    assert cfg.alt_api_bases == ['http://alt1.example.com/v1', 'http://alt2.example.com/v1']
 
     monkeypatch.delenv('RETRORECON_SECRETS_FILE', raising=False)


### PR DESCRIPTION
## Summary
- expand `secrets.example.json` with `RETRORECON_MCP_ALT_API_BASES`
- allow multiple API bases via new dataclass field `alt_api_bases`
- test loading alt API bases from secrets file

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_686781202e5c8332ba27098857168162