### PR TITLE
feat(mcp): add memory, sequential-thinking, and time mcp modules with tool use UI indicator

### DIFF
--- a/static/chat.css
+++ b/static/chat.css
@@ -63,3 +63,16 @@
 .retrorecon-root .chat-overlay__input-field {
   flex: 1;
 }
+
+.retrorecon-root .tool-call {
+  background: rgba(var(--bg-rgb) / var(--panel-opacity, 0.95));
+  border: 1px solid var(--color-contrast);
+  border-radius: 4px;
+  padding: 0.25em 0.5em;
+  margin: 0.25em 0;
+}
+
+.retrorecon-root .tool-call__name {
+  font-weight: bold;
+  margin-bottom: 0.25em;
+}

--- a/static/chat.js
+++ b/static/chat.js
@@ -64,6 +64,9 @@ window.retroChat = (function() {
     const data = await resp.json();
     if (data.message) {
       appendMessage('LLM: ' + data.message);
+      if (Array.isArray(data.tools)) {
+        data.tools.forEach(t => appendToolCard(t));
+      }
     } else if (data.error) {
       const hint = data.hint ? '\n' + data.hint : '';
       appendMessage('Error: ' + data.error + hint);
@@ -76,6 +79,26 @@ window.retroChat = (function() {
     const pre = document.createElement('pre');
     pre.textContent = text;
     messages.appendChild(pre);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  function appendToolCard(tool) {
+    const card = document.createElement('div');
+    card.className = 'tool-call';
+    const header = document.createElement('div');
+    header.className = 'tool-call__name';
+    const params = tool.args && Object.keys(tool.args).length
+      ? ' ' + JSON.stringify(tool.args)
+      : '';
+    header.textContent = tool.name.replace('_', '/') + params;
+    const pre = document.createElement('pre');
+    const result = typeof tool.result === 'string'
+      ? tool.result
+      : JSON.stringify(tool.result, null, 2);
+    pre.textContent = result;
+    card.appendChild(header);
+    card.appendChild(pre);
+    messages.appendChild(card);
     messages.scrollTop = messages.scrollHeight;
   }
 

--- a/tests/test_mcp_chat.py
+++ b/tests/test_mcp_chat.py
@@ -61,7 +61,7 @@ def test_llm_request(monkeypatch, tmp_path):
 
     server = RetroReconMCPServer(config=cfg)
     resp = server.answer_question("What tables exist?")
-    assert resp == {"message": "hi there"}
+    assert resp.get("message") == "hi there"
     assert captured["url"] == "http://llm/chat/completions"
     assert captured["headers"]["Authorization"] == "Bearer key"
     assert captured["timeout"] == cfg.timeout


### PR DESCRIPTION
## Summary
- integrate memory, sequential-thinking, and time MCP modules
- surface tool usage via inline cards in chat UI
- mount configured MCP servers when starting the RetroRecon MCP server

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686807eb1d788332b71215c551607b1e