### PR TITLE
Fix initial tool status polling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -857,8 +857,13 @@
 
     function pollStatus(){
       fetch('/status')
-        .then(r => r.json())
+        .then(r => r.status === 204 ? null : r.json())
         .then(data => {
+          if(!data){
+            statusDelay = Math.min(statusDelay * 2, 30000);
+            statusTimer = setTimeout(pollStatus, statusDelay);
+            return;
+          }
           if(data.code){
             showStatus(data.message || data.code);
             statusDelay = 1000;


### PR DESCRIPTION
## Summary
- avoid 204 parsing errors in status poller

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68680bf940c08332a958c6b7246e2411