### PR TITLE
Fix Windows timezone mapping for MCP time tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ RetroRecon digs through the internet’s attic to find forgotten, buried, or qui
 | HTTPolaroid Snapshots         | Capture a single URL with full headers, screenshot and assets into a zip |
 | Markdown Editor               | Edit and preview project docs with a resizable editor |
 | Domain Sort (Subdomain View)  | Recursively group hosts by root domain |
+| Time Zone Flexibility         | `mcp/time` understands IANA and Windows zone names |
 
 ---
 

--- a/retrorecon/windows_tz.py
+++ b/retrorecon/windows_tz.py
@@ -1,0 +1,30 @@
+"""Mapping between Windows and IANA timezone names."""
+
+# Subset of mappings from CLDR windowsZones
+WINDOWS_TO_IANA = {
+    "Dateline Standard Time": "Etc/GMT+12",
+    "UTC-11": "Etc/GMT+11",
+    "Hawaiian Standard Time": "Pacific/Honolulu",
+    "Alaskan Standard Time": "America/Anchorage",
+    "Pacific Standard Time": "America/Los_Angeles",
+    "Mountain Standard Time": "America/Denver",
+    "Central Standard Time": "America/Chicago",
+    "Eastern Standard Time": "America/New_York",
+    "Atlantic Standard Time": "America/Halifax",
+    "Greenwich Standard Time": "Etc/Greenwich",
+    "GMT Standard Time": "Europe/London",
+    "Central Europe Standard Time": "Europe/Budapest",
+    "Romance Standard Time": "Europe/Paris",
+    "W. Europe Standard Time": "Europe/Berlin",
+    "E. Europe Standard Time": "Europe/Bucharest",
+    "Russian Standard Time": "Europe/Moscow",
+    "China Standard Time": "Asia/Shanghai",
+    "Tokyo Standard Time": "Asia/Tokyo",
+    "Korea Standard Time": "Asia/Seoul",
+    "India Standard Time": "Asia/Kolkata",
+}
+
+
+def to_iana(tz_name: str) -> str | None:
+    """Return the IANA zone for a Windows time zone name, if known."""
+    return WINDOWS_TO_IANA.get(tz_name)


### PR DESCRIPTION
## Summary
- add `windows_tz` helper mapping Windows timezone names to IANA names
- map timezone names before calling the `mcp/time` server and fallback to UTC if unknown
- support Windows timezones in fallback logic
- add unit test exercising Windows timezone mapping
- document timezone support in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681b702c98833288238d3f5b78c08f