### PR TITLE
Dynamic MCP tool aggregation

### DIFF
--- a/docs/tools/mcp_setup_guide.md
+++ b/docs/tools/mcp_setup_guide.md
@@ -14,3 +14,12 @@ separate `mcp-server-sqlite` process is launched.
    entirely inside the application.
 4. Set `RETRORECON_LOG_LEVEL=DEBUG` before launching to view MCP debug output in
    the console.
+
+## Dynamic Tool Discovery
+
+The embedded server now aggregates tools from all configured MCP services at
+runtime. When a new service is mounted (locally or remotely), its tool list is
+queried during startup. Healthy services are mounted under their configuration
+name and their tools automatically become available to the LLM with the prefix
+`<name>_`. No manual code changes are required for additional modules—simply add
+an entry in the MCP configuration.

--- a/tests/test_mcp_dynamic.py
+++ b/tests/test_mcp_dynamic.py
@@ -1,0 +1,51 @@
+import pytest
+from retrorecon.mcp.server import RetroReconMCPServer
+from retrorecon.mcp.config import load_config
+from fastmcp import FastMCP
+from fastmcp.tools import FunctionTool
+from mcp.types import TextContent
+
+
+@pytest.fixture
+def base_server(tmp_path):
+    cfg = load_config()
+    cfg.db_path = str(tmp_path / "empty.db")
+    with open(cfg.db_path, "wb"):
+        pass
+    cfg.mcp_servers = None
+    return RetroReconMCPServer(config=cfg)
+
+
+def make_child():
+    child = FastMCP("child")
+
+    async def hi() -> TextContent:
+        return TextContent(type="text", text="hi")
+
+    child.add_tool(FunctionTool.from_function(hi, name="hi", description="say hi"))
+    return child
+
+
+def test_tools_include_mounted(base_server):
+    child = make_child()
+    base_server.server.mount(child, prefix="child")
+    tools = base_server._openai_tools()
+    names = {t["function"]["name"] for t in tools}
+    assert "child_hi" in names
+    assert "read_query" in names
+
+
+def test_routing_to_mounted(base_server):
+    child = make_child()
+    base_server.server.mount(child, prefix="child")
+    result = base_server._call_tool("child_hi", {})
+    assert result["type"] == "text"
+    assert "hi" in result["text"]
+
+
+def test_dynamic_addition(base_server):
+    initial = set(t["function"]["name"] for t in base_server._openai_tools())
+    child = make_child()
+    base_server.server.mount(child, prefix="child")
+    updated = set(t["function"]["name"] for t in base_server._openai_tools())
+    assert "child_hi" in updated - initial


### PR DESCRIPTION
## Summary
- gather tool specs from all mounted MCP services at runtime
- mount external MCP services under their config names with health checks
- route tool calls via a context to remote services
- document dynamic tool discovery for MCP modules
- add tests covering dynamic aggregation and routing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868206b78a88332827a9bafbf04de79