### PR TITLE
Fix MCP health check timeout context

### DIFF
--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -116,7 +116,7 @@ class RetroReconMCPServer:
                     proxy = FastMCP.as_proxy(client)
                     # perform simple health check
                     async def _check():
-                        async with anyio.fail_after(5):
+                        with anyio.fail_after(5):
                             await proxy._list_tools()
 
                     try:


### PR DESCRIPTION
## Summary
- fix health check to use sync `with anyio.fail_after`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > reports/report.json`


------
https://chatgpt.com/codex/tasks/task_e_6868264110608332b214ec1ee1ad36e8