### PR TITLE
Improve MCP debug logging

### DIFF
--- a/docs/tools/mcp_setup_guide.md
+++ b/docs/tools/mcp_setup_guide.md
@@ -13,7 +13,9 @@ separate `mcp-server-sqlite` process is launched.
 3. There is no need to configure a port or connect LM Studio; the server runs
    entirely inside the application.
 4. Set `RETRORECON_LOG_LEVEL=DEBUG` before launching to view MCP debug output in
-   the console.
+   the console. Debug logs now include detailed information on which MCP servers
+   are mounted, any health check failures, and when alternate API bases are used
+   for fallback requests.
 
 ## Dynamic Tool Discovery
 


### PR DESCRIPTION
## Summary
- log transport details when creating MCP server transports
- add fallback reporting and retry support for alternate API bases
- capture server mounting details in debug logs
- improve tool invocation logging
- document new debug output in MCP setup guide

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686852e19ef08332884f257ed85288e0