### PR TITLE
Fix uvx stdio server config

### DIFF
--- a/retrorecon/mcp/server.py
+++ b/retrorecon/mcp/server.py
@@ -72,7 +72,7 @@ class RetroReconMCPServer:
             extra = srv.args[1:]
             transport = UvxStdioTransport(
                 tool_name=tool,
-                args=extra or None,
+                tool_args=extra or None,
                 project_directory=srv.cwd,
                 env_vars=srv.env or None,
             )


### PR DESCRIPTION
## Summary
- fix UvxStdioTransport keyword name in `_make_transport`

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6868593ab0d88332af305b133191b7c6