### PR TITLE
Load memory MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ db/*.db
 *.json
 !data/demo_data.json
 !secrets.example.json
+!mcp_servers.json
 !frontend/package.json
 !frontend/.stylelintrc.json
 frontend/node_modules/

--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -1,9 +1,14 @@
 import atexit
+import subprocess
+import logging
 from typing import Optional
 
 from retrorecon.mcp import RetroReconMCPServer, load_config
 
+logger = logging.getLogger(__name__)
+
 _mcp_server: Optional[RetroReconMCPServer] = None
+_memory_proc: Optional[subprocess.Popen] = None
 
 
 def start_mcp_sqlite(db_path: str) -> RetroReconMCPServer:
@@ -13,6 +18,7 @@ def start_mcp_sqlite(db_path: str) -> RetroReconMCPServer:
         cfg = load_config()
         cfg.db_path = db_path
         _mcp_server = RetroReconMCPServer(config=cfg)
+        _start_memory_module(cfg)
     else:
         _mcp_server.update_database_path(db_path)
     return _mcp_server
@@ -29,6 +35,44 @@ def stop_mcp_sqlite() -> None:
     if _mcp_server is not None:
         _mcp_server.cleanup()
     _mcp_server = None
+    _stop_memory_module()
 
 
 atexit.register(stop_mcp_sqlite)
+
+
+def _start_memory_module(cfg) -> None:
+    """Launch the memory MCP module if configured."""
+    global _memory_proc
+    if _memory_proc is not None:
+        return
+    servers = cfg.mcp_servers or []
+    mem = next((s for s in servers if s.get("name") == "memory"), None)
+    if not mem or mem.get("transport") != "stdio":
+        return
+    cmd = mem.get("command")
+    if not cmd:
+        return
+    try:
+        _memory_proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+        logger.debug("Memory MCP module started: %s", cmd)
+    except FileNotFoundError:
+        logger.error("Memory MCP command not found: %s", cmd)
+    except Exception as exc:
+        logger.error("Failed to start memory MCP module: %s", exc)
+
+
+def _stop_memory_module() -> None:
+    """Terminate the memory MCP process if running."""
+    global _memory_proc
+    if _memory_proc is None:
+        return
+    try:
+        _memory_proc.terminate()
+        _memory_proc.wait(timeout=5)
+    except Exception:
+        if _memory_proc.poll() is None:
+            _memory_proc.kill()
+    finally:
+        logger.debug("Memory MCP module stopped")
+        _memory_proc = None

--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "memory",
+    "transport": "stdio",
+    "command": ["npx", "@modelcontextprotocol/server-memory"],
+    "model": "memory",
+    "description": "A memory server for storing and retrieving information."
+  }
+]

--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -1,7 +1,10 @@
 import os
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, List, Dict
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 @dataclass
 class MCPConfig:
     """Configuration values for the MCP server."""
@@ -14,7 +17,7 @@ class MCPConfig:
     api_key: Optional[str] = None
     timeout: int = 20
     alt_api_bases: list[str] = field(default_factory=list)
-    mcp_servers: dict | None = None
+    mcp_servers: List[Dict[str, object]] | None = None
 
 
 def load_config() -> MCPConfig:
@@ -39,6 +42,13 @@ def load_config() -> MCPConfig:
     alt_api_bases = [b.strip() for b in alt_env.split(",") if b.strip()]
 
     servers_cfg = None
+    cfg_file = os.getenv("RETRORECON_MCP_SERVERS_FILE", "mcp_servers.json")
+    if os.path.exists(cfg_file):
+        try:
+            with open(cfg_file, "r", encoding="utf-8") as fh:
+                servers_cfg = json.load(fh)
+        except Exception as exc:
+            logger.error("Failed to load MCP server config: %s", exc)
     return MCPConfig(
         db_path=db_path,
         api_base=api_base,

--- a/tests/test_memory_server_load.py
+++ b/tests/test_memory_server_load.py
@@ -1,0 +1,36 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import mcp_manager
+
+
+def test_memory_server_started(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "mcp_servers.json"
+    cfg_file.write_text(json.dumps([
+        {
+            "name": "memory",
+            "transport": "stdio",
+            "command": ["echo", "memory"],
+        }
+    ]))
+    monkeypatch.setenv("RETRORECON_MCP_SERVERS_FILE", str(cfg_file))
+
+    popen_called = {}
+
+    class DummyProc:
+        def __init__(self, *args, **kwargs):
+            popen_called['cmd'] = args[0]
+        def terminate(self):
+            pass
+        def wait(self, timeout=None):
+            pass
+
+    monkeypatch.setattr(mcp_manager.subprocess, 'Popen', lambda *a, **k: DummyProc(*a, **k))
+    mcp_manager.stop_mcp_sqlite()
+
+    server = mcp_manager.start_mcp_sqlite(str(tmp_path / "db.sqlite"))
+    assert popen_called['cmd'] == ["echo", "memory"]
+    mcp_manager.stop_mcp_sqlite()
+    monkeypatch.delenv("RETRORECON_MCP_SERVERS_FILE")


### PR DESCRIPTION
## Summary
- start an external memory MCP module at startup
- allow memory configuration via `mcp_servers.json`
- stop the subprocess on shutdown
- test memory module startup logic

## Testing
- `pip install -r requirements.txt`
- `python -c "import fastmcp, sys; print(fastmcp.__version__)" && echo OK`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868872b957483328d239f0959aaaa38