### PR TITLE
Add basic-memory MCP

### DIFF
--- a/docs/mcp_troubleshooting.md
+++ b/docs/mcp_troubleshooting.md
@@ -70,7 +70,7 @@ The `mcp/fetch` server typically exposes a tool (or tools) that can take a URL a
                 {
                     "name": "memory",
                     "transport": "stdio", # New field
-                    "command": ["npx", "@modelcontextprotocol/server-memory"], # New field
+                    "command": ["basic-memory", "mcp", "--transport", "stdio"], # New field
                     "model": "memory",
                     "description": "A memory server for storing and retrieving information.",
                 },
@@ -148,10 +148,10 @@ By addressing the fundamental difference in communication mechanisms for STDIO v
 
 To help diagnose the `memory` and `sequential-thinking` server issues, please run the following commands in your Windows 11 Command Prompt or PowerShell and provide the output:
 
-### Verify `npx` Path:
+### Verify `basic-memory` Command:
 
 ```cmd
-where npx
+where basic-memory
 ```
 
 ### RetroRecon Debug Logging:

--- a/docs/tools/mcp_setup_guide.md
+++ b/docs/tools/mcp_setup_guide.md
@@ -34,7 +34,7 @@ Each entry specifies how the server should be launched or contacted:
 ```yaml
 - name: memory
   transport: stdio
-  command: ["npx", "@modelcontextprotocol/server-memory"]
+  command: ["basic-memory", "mcp", "--transport", "stdio"]
   model: memory
   description: A memory server for storing and retrieving information.
 ```
@@ -51,7 +51,7 @@ subprocess. A simplified example looks like this:
 import subprocess
 
 proc = subprocess.Popen(
-    ["npx", "@modelcontextprotocol/server-memory"],
+    ["basic-memory", "mcp", "--transport", "stdio"],
     stdin=subprocess.PIPE,
     stdout=subprocess.PIPE,
     text=True,

--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -2,7 +2,7 @@
   {
     "name": "memory",
     "transport": "stdio",
-    "command": ["npx", "@modelcontextprotocol/server-memory"],
+    "command": ["basic-memory", "mcp", "--transport", "stdio"],
     "model": "memory",
     "description": "A memory server for storing and retrieving information."
   }


### PR DESCRIPTION
## Summary
- integrate basic-memory python module via Stdio transport
- log tools from the memory module at startup
- update memory server config
- update docs for the new command
- adjust memory server test

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ad44fc748332af741e5fa1d4db02