### PR TITLE
Fix memory module loader

### DIFF
--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -61,11 +61,11 @@ def _start_memory_module(cfg) -> None:
         client = Client(transport)
 
         async def _init_client() -> tuple[Client, List[str]]:
-            async with anyio.fail_after(10):
+            with anyio.fail_after(10):
                 await client._connect()
             tools: List[str] = []
             try:
-                async with anyio.fail_after(5):
+                with anyio.fail_after(5):
                     result = await client.list_tools_mcp()
                     tools = [t.name for t in result.tools]
             except Exception as exc:
@@ -89,7 +89,7 @@ def _stop_memory_module() -> None:
         return
     try:
         async def _disconnect() -> None:
-            async with anyio.fail_after(5):
+            with anyio.fail_after(5):
                 await _memory_client._disconnect()
 
         anyio.run(_disconnect)

--- a/tests/test_memory_server_load.py
+++ b/tests/test_memory_server_load.py
@@ -38,10 +38,10 @@ def test_memory_server_started(monkeypatch, tmp_path):
     monkeypatch.setattr(mcp_manager, 'StdioTransport', DummyTransport)
     monkeypatch.setattr(mcp_manager, 'Client', DummyClient)
 
-    from contextlib import asynccontextmanager
+    from contextlib import contextmanager
 
-    @asynccontextmanager
-    async def DummyFailAfter(*args, **kwargs):
+    @contextmanager
+    def DummyFailAfter(*args, **kwargs):
         yield
 
     monkeypatch.setattr(mcp_manager.anyio, 'run', lambda func: asyncio.run(func()))


### PR DESCRIPTION
## Summary
- fix usage of `anyio.fail_after` in `mcp_manager`
- adjust test to patch new synchronous context manager

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868b92f382083329445837ff21f6c66