### PR TITLE
Refactor MCP setup to use official SDK

### DIFF
--- a/tests/test_mcp_chat.py
+++ b/tests/test_mcp_chat.py
@@ -78,7 +78,7 @@ def test_time_fallback(monkeypatch, tmp_path):
     def fake_call(name, args):
         raise Exception("Unknown time zone")
 
-    monkeypatch.setattr(server.server, "_call_tool", fake_call)
+    monkeypatch.setattr(server.server, "call_tool", fake_call)
 
     resp = server._call_tool("time_now", {"timezone": "Pacific Standard Time"})
     assert resp["type"] == "text"
@@ -102,7 +102,7 @@ def test_windows_timezone_mapping(monkeypatch, tmp_path):
         captured["tz"] = args.get("timezone")
         return FakeResult()
 
-    monkeypatch.setattr(server.server, "_call_tool", fake_call)
+    monkeypatch.setattr(server.server, "call_tool", fake_call)
 
     resp = server._call_tool("time_now", {"timezone": "Pacific Standard Time"})
     assert captured["tz"] == "America/Los_Angeles"


### PR DESCRIPTION
## Summary
- wrap MCP memory module with `ClientSessionGroup`
- allow stdio, SSE and HTTP transports for MCP server connections
- update server tools to match FastMCP 2.0 API
- adjust chat tests for new call path

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/audit_css.py > reports/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6868baedea5c833288c03bd10d3cf4fc