### PR TITLE
Add MCP fetch server integration

### DIFF
--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -5,5 +5,11 @@
     "command": ["basic-memory", "mcp", "--transport", "stdio"],
     "model": "memory",
     "description": "A memory server for storing and retrieving information."
+  },
+  {
+    "name": "fetch",
+    "transport": "stdio",
+    "command": ["python", "-m", "mcp_server_fetch"],
+    "description": "Fetch web content and convert to markdown."
   }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ zstandard
 fastmcp>=0.1.0
 a2wsgi
 tzdata
+mcp-server-fetch

--- a/tests/test_fetch_server_load.py
+++ b/tests/test_fetch_server_load.py
@@ -1,0 +1,57 @@
+import json
+import sys
+import asyncio
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import mcp_manager
+
+
+def test_fetch_server_started(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "mcp_servers.json"
+    cfg_file.write_text(json.dumps([
+        {
+            "name": "fetch",
+            "transport": "stdio",
+            "command": ["python", "-m", "mcp_server_fetch"],
+        }
+    ]))
+    monkeypatch.setenv("RETRORECON_MCP_SERVERS_FILE", str(cfg_file))
+
+    captured = {}
+
+    class DummyGroup:
+        async def __aenter__(self):
+            captured['entered'] = True
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            captured['exited'] = True
+
+        async def connect_to_server(self, params):
+            captured['command'] = params.command
+            captured['args'] = params.args
+
+        @property
+        def tools(self):
+            return {}
+
+    monkeypatch.setattr(mcp_manager, 'ClientSessionGroup', lambda: DummyGroup())
+
+    class DummyPortal:
+        def call(self, func, *args, **kwargs):
+            if asyncio.iscoroutinefunction(func):
+                return asyncio.run(func(*args, **kwargs))
+            return func(*args, **kwargs)
+
+        def stop(self):
+            captured['stopped'] = True
+
+    monkeypatch.setattr(mcp_manager, 'start_blocking_portal', lambda: DummyPortal())
+    mcp_manager.stop_mcp_sqlite()
+
+    mcp_manager.start_mcp_sqlite(str(tmp_path / "db.sqlite"))
+    assert captured['command'] == "python"
+    assert captured['args'] == ["-m", "mcp_server_fetch"]
+    mcp_manager.stop_mcp_sqlite()
+    monkeypatch.delenv("RETRORECON_MCP_SERVERS_FILE")


### PR DESCRIPTION
## Summary
- integrate MCP fetch server via stdio
- automatically launch fetch module alongside memory module
- provide tests ensuring fetch server configuration works
- install mcp-server-fetch dependency
- update MCP server configuration

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ada648708332ab5e00feb3ea2280