### PR TITLE
Refactor MCP module startup

### DIFF
--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -112,9 +112,13 @@ def _start_memory_module(cfg) -> None:
             portal = portal_ctx
             portal_ctx = None
 
-        group = ClientSessionGroup()
-        portal.call(group.__aenter__)
-        portal.call(group.connect_to_server, params)
+        async def _initialize() -> ClientSessionGroup:
+            group = ClientSessionGroup()
+            await group.__aenter__()
+            await group.connect_to_server(params)
+            return group
+
+        group = portal.call(_initialize)
         tools = list(group.tools.keys())
         _memory_group = group
         _memory_portal = portal
@@ -188,9 +192,13 @@ def _start_fetch_module(cfg) -> None:
             portal = portal_ctx
             portal_ctx = None
 
-        group = ClientSessionGroup()
-        portal.call(group.__aenter__)
-        portal.call(group.connect_to_server, params)
+        async def _initialize() -> ClientSessionGroup:
+            group = ClientSessionGroup()
+            await group.__aenter__()
+            await group.connect_to_server(params)
+            return group
+
+        group = portal.call(_initialize)
         tools = list(group.tools.keys())
         _fetch_group = group
         _fetch_portal = portal


### PR DESCRIPTION
## Summary
- initialize MCP modules in a single async call
- keep fetch and memory modules symmetric

## Testing
- `pytest tests/test_memory_server_load.py::test_memory_server_started -q`
- `pytest tests/test_fetch_server_load.py::test_fetch_server_started -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b2b413c88332bcd48e08f036c72e