### PR TITLE
Fix MCP timeout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 - Fix CDX import to use HTTPS for more reliable requests.
 - Update CDX imports to refresh subdomain records after fetching.
+- Increase default MCP request timeout to 60 seconds.

--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -15,7 +15,7 @@ class MCPConfig:
     temperature: float = 0.1
     row_limit: int = 100
     api_key: Optional[str] = None
-    timeout: int = 20
+    timeout: int = 60
     alt_api_bases: list[str] = field(default_factory=list)
     mcp_servers: List[Dict[str, object]] | None = None
 
@@ -35,9 +35,9 @@ def load_config() -> MCPConfig:
     except ValueError:
         row_limit = 100
     try:
-        timeout = int(os.getenv("RETRORECON_MCP_TIMEOUT", "20"))
+        timeout = int(os.getenv("RETRORECON_MCP_TIMEOUT", "60"))
     except ValueError:
-        timeout = 20
+        timeout = 60
     alt_env = os.getenv("RETRORECON_MCP_ALT_API_BASES", "")
     alt_api_bases = [b.strip() for b in alt_env.split(",") if b.strip()]
 

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -7,7 +7,7 @@
   "RETRORECON_MCP_API_BASE": "http://localhost:1234/v1",
   "RETRORECON_MCP_MODEL": "qwen2.5-coldbrew-aetheria-test2_tools",
   "RETRORECON_MCP_TEMPERATURE": 0.1,
-  "RETRORECON_MCP_TIMEOUT": 20,
+  "RETRORECON_MCP_TIMEOUT": 60,
   "RETRORECON_MCP_ALT_API_BASES": [
     "http://192.168.1.98:1234/v1"
   ]


### PR DESCRIPTION
## Summary
- extend MCP server timeout to 60 seconds
- document increased timeout in secrets and changelog

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869cb2cfb148332b66e9ccd01ba2d7a