### PR TITLE
Fix MCP module startup cleanup

### DIFF
--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -118,7 +118,14 @@ def _start_memory_module(cfg) -> None:
             await group.connect_to_server(params)
             return group
 
-        group = portal.call(_initialize)
+        try:
+            group = portal.call(_initialize)
+        except Exception as exc:
+            if portal_ctx is not None:
+                portal_ctx.__exit__(None, None, None)
+            else:
+                portal.stop()
+            raise
         tools = list(group.tools.keys())
         _memory_group = group
         _memory_portal = portal
@@ -198,7 +205,14 @@ def _start_fetch_module(cfg) -> None:
             await group.connect_to_server(params)
             return group
 
-        group = portal.call(_initialize)
+        try:
+            group = portal.call(_initialize)
+        except Exception:
+            if portal_ctx is not None:
+                portal_ctx.__exit__(None, None, None)
+            else:
+                portal.stop()
+            raise
         tools = list(group.tools.keys())
         _fetch_group = group
         _fetch_portal = portal


### PR DESCRIPTION
## Summary
- handle errors when starting memory and fetch MCP modules

## Testing
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869e71b7404833286d085ed18b026bd