### PR TITLE
Fix unhandled async generator cleanup

### DIFF
--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -1,5 +1,6 @@
 import atexit
 import logging
+import sys
 from typing import Optional, List, Any
 
 import anyio
@@ -115,7 +116,11 @@ def _start_memory_module(cfg) -> None:
         async def _initialize() -> ClientSessionGroup:
             group = ClientSessionGroup()
             await group.__aenter__()
-            await group.connect_to_server(params)
+            try:
+                await group.connect_to_server(params)
+            except Exception:
+                await group.__aexit__(*sys.exc_info())
+                raise
             return group
 
         try:
@@ -202,7 +207,11 @@ def _start_fetch_module(cfg) -> None:
         async def _initialize() -> ClientSessionGroup:
             group = ClientSessionGroup()
             await group.__aenter__()
-            await group.connect_to_server(params)
+            try:
+                await group.connect_to_server(params)
+            except Exception:
+                await group.__aexit__(*sys.exc_info())
+                raise
             return group
 
         try:


### PR DESCRIPTION
## Summary
- handle exceptions during `ClientSessionGroup` startup
- ensure cleanup happens if connecting to a server fails

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e88e2ee083328100538070254259