### PR TITLE
Refactor launch scripts to use config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ db/*.db
 !mcp_servers.json
 !frontend/package.json
 !frontend/.stylelintrc.json
+!launch_config.example.json
 frontend/node_modules/
 node_modules/
 frontend/package-lock.json

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Use `--help` to view available options for filtering, exporting, and source map 
 
 ## 🖥️ Running the Web Interface
 
-Launch the Flask UI with the provided scripts. The optional `-l` flag sets the listening address (default `127.0.0.1`).
+Launch the Flask UI with the provided scripts. Edit `launch_config.example.json` (copy to `launch_config.json`) to adjust the listening address or database path.
 
 ```bash
-./launch_app.sh -l 0.0.0.0   # Linux/macOS
-.\launch_app.bat -l 0.0.0.0  # Windows
+./launch_app.sh            # Linux/macOS
+.\launch_app.bat           # Windows
 ```
 
 These scripts export `RETRORECON_LISTEN` so `app.py` binds accordingly.

--- a/docs/mcp_troubleshooting.md
+++ b/docs/mcp_troubleshooting.md
@@ -161,7 +161,7 @@ First, you will need to modify the RetroRecon logging configuration to `DEBUG` l
 After modifying the logging level, run RetroRecon as usual and capture the console output:
 
 ```cmd
-.\launch_app.bat -l 0.0.0.0 > retrorecon_debug_log.txt 2>&1
+.\launch_app.bat > retrorecon_debug_log.txt 2>&1
 ```
 
 Then, please provide the `retrorecon_debug_log.txt` file.

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -1,19 +1,15 @@
 @echo off
 cd /d "%~dp0"
 
-set LISTEN_ADDR=127.0.0.1
-if "%1"=="-l" (
-    set LISTEN_ADDR=%2
-    shift
-    shift
-)
+set LISTEN_ADDR=
+set DB_PATH=
 
-REM Accept optional DB path as first argument after -l
-if "%1"=="" (
-    set DB_PATH=%cd%\db\waybax.db
-) else (
-    set DB_PATH=%1
-)
+REM Load options from launch_config.json if present
+for /f "usebackq tokens=*" %%A in (`powershell -NoProfile -Command "(Get-Content -Raw launch_config.json | ConvertFrom-Json).listen_addr" 2^>nul`) do set LISTEN_ADDR=%%A
+for /f "usebackq tokens=*" %%A in (`powershell -NoProfile -Command "(Get-Content -Raw launch_config.json | ConvertFrom-Json).db_path" 2^>nul`) do set DB_PATH=%%A
+
+if "%LISTEN_ADDR%"=="" set LISTEN_ADDR=127.0.0.1
+if "%DB_PATH%"=="" set DB_PATH=%cd%\db\waybax.db
 
 git pull
 

--- a/launch_app.sh
+++ b/launch_app.sh
@@ -4,23 +4,24 @@ cd "$(dirname "$0")"
 
 git pull
 
-LISTEN_ADDR="127.0.0.1"
-while getopts "l:" opt; do
-  case $opt in
-    l)
-      LISTEN_ADDR="$OPTARG"
-      ;;
-  esac
-done
+LISTEN_ADDR=""
+DB_PATH=""
 
-shift $((OPTIND -1))
-
-# Accept optional DB path after -l
-if [ -z "$1" ]; then
-  DB_PATH="$(pwd)/db/waybax.db"
-else
-  DB_PATH="$1"
+if [ -f launch_config.json ]; then
+  LISTEN_ADDR=$(python3 - <<'EOF'
+import json,sys
+print(json.load(open('launch_config.json')).get('listen_addr',''))
+EOF
+  )
+  DB_PATH=$(python3 - <<'EOF'
+import json,sys
+print(json.load(open('launch_config.json')).get('db_path',''))
+EOF
+  )
 fi
+
+[ -z "$LISTEN_ADDR" ] && LISTEN_ADDR="127.0.0.1"
+[ -z "$DB_PATH" ] && DB_PATH="$(pwd)/db/waybax.db"
 
 if [ ! -d venv ]; then
   python3 -m venv venv

--- a/launch_config.example.json
+++ b/launch_config.example.json
@@ -1,0 +1,4 @@
+{
+  "listen_addr": "127.0.0.1",
+  "db_path": "db\\waybax.db"
+}


### PR DESCRIPTION
## Summary
- refactor `launch_app.bat` to load options from `launch_config.json`
- refactor `launch_app.sh` with same logic
- document new config in README
- update troubleshooting docs
- add example config file
- track example config in `.gitignore`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4c350fd08332ae6839c7743273af