### PR TITLE
Fix domain sort UI refresh

### DIFF
--- a/static/domain_sort.js
+++ b/static/domain_sort.js
@@ -21,10 +21,11 @@ function initDomainSort(){
 
   function setStatus(msg){
     if(statusDiv) statusDiv.textContent = msg;
+    if(window.showStatus) window.showStatus(msg);
   }
 
   async function refresh(){
-    const resp = await fetch('/domain_sort');
+    const resp = await fetch('/domain_sort', {method:'POST'});
     outputDiv.innerHTML = await resp.text();
   }
 


### PR DESCRIPTION
## Summary
- call global status box from domain sort overlay
- fetch POST `/domain_sort` for overlay refresh

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874555044648332b3d6313e5a0eda5a