### PR TITLE
Fix broken Wayback dropdown links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -727,7 +727,7 @@
       let link = '';
       switch(val){
         case 'archive':
-          link = 'https://web.archive.org/web/*/' + encodeURIComponent(url);
+          link = 'https://web.archive.org/web/*/' + encodeURI(url);
           break;
         case 'shodan':
           link = 'https://www.shodan.io/search?query=' + encodeURIComponent(url);


### PR DESCRIPTION
## Summary
- fix URL encoding for Web Archive dropdown option so colon and slashes remain intact
- verify stylelint and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874e52663cc83328743ab05a6d43dd4