### PR TITLE
Switch to fetch-mcp SSE server

### DIFF
--- a/docs/mcp-gotchas.md
+++ b/docs/mcp-gotchas.md
@@ -10,10 +10,6 @@ This document summarizes issues discovered when working with the Model Context P
 
 If the configured STDIO command references a module that is not installed (for example `basic-memory`) the memory module fails to start. The startup code now checks for the module using `importlib.util.find_spec` and logs `"MCP module not installed"` instead of raising an exception.
 
-## 3. Fetch server warnings
-
-When starting the fetch MCP server a warning `Could not fetch resources: Method not found` may appear. This does not prevent usage of the `fetch` tool, but it is noisy. It originates from the MCP client library when optional endpoints are missing.
-
 ***
 
 During development each major test run is noted below.

--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -1,8 +1,8 @@
 [
   {
     "name": "fetch",
-    "transport": "stdio",
-    "command": ["python", "-m", "mcp_server_fetch"],
+    "transport": "sse",
+    "url": "http://localhost:3000/sse",
     "description": "Fetch web content and convert to markdown."
   }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ zstandard
 fastmcp>=0.1.0
 a2wsgi
 tzdata
-mcp-server-fetch

--- a/tests/test_fetch_server_load.py
+++ b/tests/test_fetch_server_load.py
@@ -12,8 +12,8 @@ def test_fetch_server_started(monkeypatch, tmp_path):
     cfg_file.write_text(json.dumps([
         {
             "name": "fetch",
-            "transport": "stdio",
-            "command": ["python", "-m", "mcp_server_fetch"],
+            "transport": "sse",
+            "url": "http://localhost:3000/sse"
         }
     ]))
     monkeypatch.setenv("RETRORECON_MCP_SERVERS_FILE", str(cfg_file))
@@ -29,8 +29,7 @@ def test_fetch_server_started(monkeypatch, tmp_path):
             captured['exited'] = True
 
         async def connect_to_server(self, params):
-            captured['command'] = params.command
-            captured['args'] = params.args
+            captured['url'] = params.url
 
         @property
         def tools(self):
@@ -51,7 +50,6 @@ def test_fetch_server_started(monkeypatch, tmp_path):
     mcp_manager.stop_mcp_sqlite()
 
     mcp_manager.start_mcp_sqlite(str(tmp_path / "db.sqlite"))
-    assert captured['command'] == "python"
-    assert captured['args'] == ["-m", "mcp_server_fetch"]
+    assert captured['url'] == "http://localhost:3000/sse"
     mcp_manager.stop_mcp_sqlite()
     monkeypatch.delenv("RETRORECON_MCP_SERVERS_FILE")


### PR DESCRIPTION
## Summary
- remove legacy Python fetch server references
- connect to the `fetch-mcp` SSE service
- adjust tests for the new config
- prune outdated documentation

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875421ef58c8332b45fcd7789ff2d9d