### PR TITLE
Fix default MCP host

### DIFF
--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -10,7 +10,7 @@ class MCPConfig:
     """Configuration values for the MCP server."""
 
     db_path: Optional[str] = None
-    api_base: str = "http://localhost:1234/v1"
+    api_base: str = "http://192.168.1.98:1234/v1"
     model: str = "qwen2.5-coldbrew-aetheria-test2_tools"
     temperature: float = 0.1
     row_limit: int = 100
@@ -23,7 +23,7 @@ class MCPConfig:
 def load_config() -> MCPConfig:
     """Load MCP configuration from environment variables."""
     db_path = os.getenv("RETRORECON_MCP_DB")
-    api_base = os.getenv("RETRORECON_MCP_API_BASE", "http://localhost:1234/v1")
+    api_base = os.getenv("RETRORECON_MCP_API_BASE", "http://192.168.1.98:1234/v1")
     model = os.getenv("RETRORECON_MCP_MODEL", "qwen2.5-coldbrew-aetheria-test2_tools")
     try:
         temperature = float(os.getenv("RETRORECON_MCP_TEMPERATURE", "0.1"))

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -4,7 +4,7 @@
   "VIRUSTOTAL_API": "",
   "REGISTRY_USERNAME": "",
   "REGISTRY_PASSWORD": "",
-  "RETRORECON_MCP_API_BASE": "http://localhost:1234/v1",
+  "RETRORECON_MCP_API_BASE": "http://192.168.1.98:1234/v1",
   "RETRORECON_MCP_MODEL": "qwen2.5-coldbrew-aetheria-test2_tools",
   "RETRORECON_MCP_TEMPERATURE": 0.1,
   "RETRORECON_MCP_TIMEOUT": 60,


### PR DESCRIPTION
## Summary
- default to the lmstudio host for MCP
- update example secrets file

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687552e0c574833294e1d0ac2e0b953b