### PR TITLE
Centralize MCP module management

### DIFF
--- a/mcp_manager.py
+++ b/mcp_manager.py
@@ -1,7 +1,8 @@
 import atexit
 import logging
 import sys
-from typing import Optional, List, Any
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
 
 import anyio
 from mcp.client.session_group import (
@@ -16,29 +17,180 @@ from retrorecon.mcp import RetroReconMCPServer, load_config
 
 logger = logging.getLogger(__name__)
 
-_mcp_server: Optional[RetroReconMCPServer] = None
-# Active MCP server for memory module
-_memory_group: Optional[ClientSessionGroup] = None
-_memory_portal: Optional[BlockingPortal] = None
-# Optional context manager returned by ``start_blocking_portal``.
-_memory_portal_cm: Optional[Any] = None
 
-# Active MCP server for fetch module
-_fetch_group: Optional[ClientSessionGroup] = None
-_fetch_portal: Optional[BlockingPortal] = None
-# Optional context manager returned by ``start_blocking_portal`` for fetch module
-_fetch_portal_cm: Optional[Any] = None
+@dataclass
+class ModuleSpec:
+    name: str
+    transport: str = "stdio"
+    command: list[str] | None = None
+    url: str | None = None
+    headers: Dict[str, str] | None = None
+    timeout: int | None = None
+    sse_read_timeout: int | None = None
+    enabled: bool = True
+    lazy_start: bool = False
+    retry: Dict[str, Any] | None = None
+
+
+class MCPModuleManager:
+    """Manage multiple MCP module client connections."""
+
+    def __init__(self, cfg) -> None:
+        self.cfg = cfg
+        self.modules: Dict[str, ModuleSpec] = {}
+        for mod in cfg.mcp_servers or []:
+            try:
+                spec = ModuleSpec(**mod)
+            except TypeError:
+                spec = ModuleSpec(
+                    name=mod.get("name", ""),
+                    transport=mod.get("transport", "stdio"),
+                    command=mod.get("command"),
+                    url=mod.get("url"),
+                    headers=mod.get("headers"),
+                    timeout=mod.get("timeout"),
+                    sse_read_timeout=mod.get("sse_read_timeout"),
+                    enabled=mod.get("enabled", True),
+                    lazy_start=mod.get("lazy_start", False),
+                    retry=mod.get("retry"),
+                )
+            self.modules[spec.name] = spec
+        self.groups: Dict[str, Optional[ClientSessionGroup]] = {n: None for n in self.modules}
+        self.portals: Dict[str, Optional[BlockingPortal]] = {n: None for n in self.modules}
+        self.portal_cms: Dict[str, Optional[Any]] = {n: None for n in self.modules}
+
+    def start_all(self) -> None:
+        for name, spec in self.modules.items():
+            if spec.enabled and not spec.lazy_start:
+                self.start(name)
+
+    def start(self, name: str) -> None:
+        if self.groups.get(name) is not None:
+            return
+        spec = self.modules.get(name)
+        if not spec or not spec.enabled:
+            return
+        try:
+            params = self._create_params(spec)
+            portal_ctx = start_blocking_portal()
+            if hasattr(portal_ctx, "__enter__"):
+                portal = portal_ctx.__enter__()
+            else:
+                portal = portal_ctx
+                portal_ctx = None
+
+            async def _initialize() -> ClientSessionGroup:
+                group = ClientSessionGroup()
+                await group.__aenter__()
+                try:
+                    await group.connect_to_server(params)
+                except Exception:
+                    await group.__aexit__(*sys.exc_info())
+                    raise
+                return group
+
+            group = portal.call(_initialize)
+        except FileNotFoundError:
+            logger.error("MCP module command not found: %s", " ".join(spec.command or []))
+            try:
+                if portal_ctx is not None:
+                    portal_ctx.__exit__(None, None, None)
+                else:
+                    portal.stop()
+            except BaseException:
+                pass
+            return
+        except BaseException as exc:
+            try:
+                if portal_ctx is not None:
+                    portal_ctx.__exit__(None, None, None)
+                else:
+                    portal.stop()
+            except BaseException:
+                pass
+            logger.error("Failed to start %s MCP module: %s", spec.name, exc)
+            return
+        tools = list(group.tools.keys())
+        self.groups[name] = group
+        self.portals[name] = portal
+        self.portal_cms[name] = portal_ctx
+        target = " ".join(spec.command or []) if spec.transport == "stdio" else spec.url or ""
+        logger.debug("%s MCP module started: %s", spec.name.capitalize(), target)
+        if tools:
+            logger.debug("%s MCP tools: %s", spec.name.capitalize(), ", ".join(tools))
+
+    def stop(self, name: str) -> None:
+        group = self.groups.get(name)
+        portal = self.portals.get(name)
+        portal_ctx = self.portal_cms.get(name)
+        if group is None or portal is None:
+            return
+        try:
+            portal.call(group.__aexit__, None, None, None)
+        except BaseException:
+            pass
+        finally:
+            logger.debug("%s MCP module stopped", name.capitalize())
+            self.groups[name] = None
+            if portal_ctx is not None:
+                portal_ctx.__exit__(None, None, None)
+            elif portal is not None:
+                portal.stop()
+            self.portals[name] = None
+            self.portal_cms[name] = None
+
+    def stop_all(self) -> None:
+        for name in list(self.modules.keys()):
+            self.stop(name)
+
+    def get_group(self, name: str) -> Optional[ClientSessionGroup]:
+        group = self.groups.get(name)
+        spec = self.modules.get(name)
+        if group is None and spec and spec.enabled and spec.lazy_start:
+            self.start(name)
+            group = self.groups.get(name)
+        return group
+
+    @staticmethod
+    def _create_params(spec: ModuleSpec):
+        if spec.transport == "stdio":
+            cmd = spec.command or []
+            if not cmd:
+                raise FileNotFoundError()
+            if len(cmd) >= 3 and cmd[1] == "-m":
+                import importlib.util
+                if importlib.util.find_spec(cmd[2]) is None:
+                    raise FileNotFoundError(f"MCP module not installed: {cmd[2]}")
+            return StdioServerParameters(command=cmd[0], args=cmd[1:])
+        elif spec.transport == "sse":
+            return SseServerParameters(
+                url=spec.url or "",
+                headers=spec.headers,
+                timeout=spec.timeout or 5,
+                sse_read_timeout=spec.sse_read_timeout or 300,
+            )
+        else:
+            return StreamableHttpParameters(
+                url=spec.url or "",
+                headers=spec.headers,
+                timeout=spec.timeout or 30,
+                sse_read_timeout=spec.sse_read_timeout or 300,
+            )
+
+
+_mcp_server: Optional[RetroReconMCPServer] = None
+_module_manager: Optional[MCPModuleManager] = None
 
 
 def start_mcp_sqlite(db_path: str) -> RetroReconMCPServer:
     """Initialize or update the embedded MCP server for *db_path*."""
-    global _mcp_server
+    global _mcp_server, _module_manager
     if _mcp_server is None:
         cfg = load_config()
         cfg.db_path = db_path
         _mcp_server = RetroReconMCPServer(config=cfg)
-        _start_memory_module(cfg)
-        _start_fetch_module(cfg)
+        _module_manager = MCPModuleManager(cfg)
+        _module_manager.start_all()
     else:
         _mcp_server.update_database_path(db_path)
     return _mcp_server
@@ -49,229 +201,37 @@ def get_mcp_server() -> Optional[RetroReconMCPServer]:
     return _mcp_server
 
 
+def get_module_manager() -> Optional[MCPModuleManager]:
+    return _module_manager
+
+
 def get_memory_group() -> Optional[ClientSessionGroup]:
-    """Return the active MCP client session group for memory module."""
-    return _memory_group
+    manager = get_module_manager()
+    if manager is not None:
+        return manager.get_group("memory")
+    return None
 
 
 def get_fetch_group() -> Optional[ClientSessionGroup]:
-    """Return the active MCP client session group for fetch module."""
-    return _fetch_group
+    manager = get_module_manager()
+    if manager is not None:
+        return manager.get_group("fetch")
+    return None
 
 
 def stop_mcp_sqlite() -> None:
     """Cleanup the embedded MCP server instance."""
-    global _mcp_server
+    global _mcp_server, _module_manager
     if _mcp_server is not None:
         _mcp_server.cleanup()
     _mcp_server = None
-    _stop_memory_module()
-    _stop_fetch_module()
+    if _module_manager is not None:
+        _module_manager.stop_all()
+    _module_manager = None
 
 
-atexit.register(stop_mcp_sqlite)
+def _atexit_stop() -> None:
+    stop_mcp_sqlite()
 
 
-def _start_memory_module(cfg) -> None:
-    """Launch the memory MCP module if configured and announce its tools."""
-    global _memory_group, _memory_portal
-    if _memory_group is not None:
-        return
-    servers = cfg.mcp_servers or []
-    mem = next((s for s in servers if s.get("name") == "memory"), None)
-    if not mem:
-        return
-    transport = mem.get("transport", "stdio")
-    cmd: List[str] = mem.get("command") or []
-    try:
-        if transport == "stdio":
-            if not cmd:
-                return
-            if len(cmd) >= 3 and cmd[1] == "-m":
-                import importlib.util
-                if importlib.util.find_spec(cmd[2]) is None:
-                    logger.error("MCP module not installed: %s", cmd[2])
-                    return
-            params = StdioServerParameters(command=cmd[0], args=cmd[1:])
-        elif transport == "sse":
-            params = SseServerParameters(
-                url=mem.get("url", ""),
-                headers=mem.get("headers"),
-                timeout=mem.get("timeout", 5),
-                sse_read_timeout=mem.get("sse_read_timeout", 300),
-            )
-        else:
-            params = StreamableHttpParameters(
-                url=mem.get("url", ""),
-                headers=mem.get("headers"),
-                timeout=mem.get("timeout", 30),
-                sse_read_timeout=mem.get("sse_read_timeout", 300),
-            )
-
-        portal_ctx = start_blocking_portal()
-        # ``start_blocking_portal`` returns a context manager in normal usage.
-        # Test suites may monkeypatch it to return a plain portal instance, so
-        # handle both cases here.
-        if hasattr(portal_ctx, "__enter__"):
-            portal = portal_ctx.__enter__()
-        else:
-            portal = portal_ctx
-            portal_ctx = None
-
-        async def _initialize() -> ClientSessionGroup:
-            group = ClientSessionGroup()
-            await group.__aenter__()
-            try:
-                await group.connect_to_server(params)
-            except Exception:
-                await group.__aexit__(*sys.exc_info())
-                raise
-            return group
-
-        try:
-            group = portal.call(_initialize)
-        except BaseException as exc:
-            try:
-                if portal_ctx is not None:
-                    # Ensure the portal is closed cleanly without re-raising
-                    portal_ctx.__exit__(None, None, None)
-                else:
-                    portal.stop()
-            except BaseException:
-                pass
-            logger.error("Failed to start memory MCP module: %s", exc)
-            return
-        tools = list(group.tools.keys())
-        _memory_group = group
-        _memory_portal = portal
-        global _memory_portal_cm
-        _memory_portal_cm = portal_ctx
-        target = " ".join(cmd) if transport == "stdio" else mem.get("url", "")
-        logger.debug("Memory MCP module started: %s", target)
-        if tools:
-            logger.debug("Memory MCP tools: %s", ", ".join(tools))
-    except FileNotFoundError:
-        logger.error("Memory MCP command not found: %s", " ".join(cmd))
-    except Exception as exc:
-        logger.error("Failed to start memory MCP module: %s", exc)
-
-
-def _stop_memory_module() -> None:
-    """Terminate the memory MCP client if running."""
-    global _memory_group, _memory_portal, _memory_portal_cm
-    if _memory_group is None or _memory_portal is None:
-        return
-    try:
-        _memory_portal.call(_memory_group.__aexit__, None, None, None)
-    except BaseException:
-        pass
-    finally:
-        logger.debug("Memory MCP module stopped")
-        _memory_group = None
-        if _memory_portal_cm is not None:
-            _memory_portal_cm.__exit__(None, None, None)
-            _memory_portal_cm = None
-        elif _memory_portal is not None:
-            _memory_portal.stop()
-        _memory_portal = None
-
-
-def _start_fetch_module(cfg) -> None:
-    """Launch the fetch MCP module if configured and announce its tools."""
-    global _fetch_group, _fetch_portal
-    if _fetch_group is not None:
-        return
-    servers = cfg.mcp_servers or []
-    fetch = next((s for s in servers if s.get("name") == "fetch"), None)
-    if not fetch:
-        return
-    transport = fetch.get("transport", "stdio")
-    cmd: List[str] = fetch.get("command") or []
-    try:
-        if transport == "stdio":
-            if not cmd:
-                return
-            if len(cmd) >= 3 and cmd[1] == "-m":
-                import importlib.util
-                if importlib.util.find_spec(cmd[2]) is None:
-                    logger.error("MCP module not installed: %s", cmd[2])
-                    return
-            params = StdioServerParameters(command=cmd[0], args=cmd[1:])
-        elif transport == "sse":
-            params = SseServerParameters(
-                url=fetch.get("url", ""),
-                headers=fetch.get("headers"),
-                timeout=fetch.get("timeout", 5),
-                sse_read_timeout=fetch.get("sse_read_timeout", 300),
-            )
-        else:
-            params = StreamableHttpParameters(
-                url=fetch.get("url", ""),
-                headers=fetch.get("headers"),
-                timeout=fetch.get("timeout", 30),
-                sse_read_timeout=fetch.get("sse_read_timeout", 300),
-            )
-
-        portal_ctx = start_blocking_portal()
-        if hasattr(portal_ctx, "__enter__"):
-            portal = portal_ctx.__enter__()
-        else:
-            portal = portal_ctx
-            portal_ctx = None
-
-        async def _initialize() -> ClientSessionGroup:
-            group = ClientSessionGroup()
-            await group.__aenter__()
-            try:
-                await group.connect_to_server(params)
-            except Exception:
-                await group.__aexit__(*sys.exc_info())
-                raise
-            return group
-
-        try:
-            group = portal.call(_initialize)
-        except BaseException as exc:
-            try:
-                if portal_ctx is not None:
-                    # Clean shutdown of the portal avoids cancel-scope errors
-                    portal_ctx.__exit__(None, None, None)
-                else:
-                    portal.stop()
-            except BaseException:
-                pass
-            logger.error("Failed to start fetch MCP module: %s", exc)
-            return
-        tools = list(group.tools.keys())
-        _fetch_group = group
-        _fetch_portal = portal
-        global _fetch_portal_cm
-        _fetch_portal_cm = portal_ctx
-        target = " ".join(cmd) if transport == "stdio" else fetch.get("url", "")
-        logger.debug("Fetch MCP module started: %s", target)
-        if tools:
-            logger.debug("Fetch MCP tools: %s", ", ".join(tools))
-    except FileNotFoundError:
-        logger.error("Fetch MCP command not found: %s", " ".join(cmd))
-    except Exception as exc:
-        logger.error("Failed to start fetch MCP module: %s", exc)
-
-
-def _stop_fetch_module() -> None:
-    """Terminate the fetch MCP client if running."""
-    global _fetch_group, _fetch_portal, _fetch_portal_cm
-    if _fetch_group is None or _fetch_portal is None:
-        return
-    try:
-        _fetch_portal.call(_fetch_group.__aexit__, None, None, None)
-    except BaseException:
-        pass
-    finally:
-        logger.debug("Fetch MCP module stopped")
-        _fetch_group = None
-        if _fetch_portal_cm is not None:
-            _fetch_portal_cm.__exit__(None, None, None)
-            _fetch_portal_cm = None
-        elif _fetch_portal is not None:
-            _fetch_portal.stop()
-        _fetch_portal = None
+atexit.register(_atexit_stop)

--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -1,8 +1,17 @@
 [
   {
+    "name": "memory",
+    "enabled": true,
+    "transport": "stdio",
+    "command": ["basic-memory", "mcp", "--transport", "stdio"],
+    "lazy_start": false
+  },
+  {
     "name": "fetch",
+    "enabled": true,
     "transport": "sse",
     "url": "http://localhost:3000/sse",
+    "lazy_start": true,
     "description": "Fetch web content and convert to markdown."
   }
 ]


### PR DESCRIPTION
## Summary
- centralize MCP module management with `MCPModuleManager`
- update default `mcp_servers.json` with memory and fetch modules

## Testing
- `npm --prefix frontend run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756663ff4483328724803c88586e58