### PR TITLE
Unify MCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ rerun the launch script.
 For a quick walkthrough of the common workflow see
 [docs/new_user_guide.md](docs/new_user_guide.md).
 
+### MCP Server Configuration
+
+External MCP services are defined in a central `mcp_servers.json` file. The
+application loads this file from the project root by default or from the path
+specified by the `RETRORECON_MCP_SERVERS_FILE` environment variable. Each entry
+describes the server name, transport type and connection details. The built-in
+MCP manager starts any enabled services automatically when a database is loaded.
+
 ### Capture a Snap
 
 The **HTTPolaroid** tool can be triggered from the UI under `Tools → Active Recon`. It fetches a URL in a headless browser, follows redirects and saves the page, assets, headers and screenshot into a single zip file for download.

--- a/docs/mcp_troubleshooting.md
+++ b/docs/mcp_troubleshooting.md
@@ -10,7 +10,9 @@ Key observations from the codebase:
 
 *   **`RetroReconMCPServer`**: This class (in `retrorecon/mcp/server.py`) acts as RetroRecon's internal MCP server. It includes tools for `_query_sqlite`, `_get_current_datetime`, and `_fetch_url_content`.
 *   **`MCPConfig`**: Defined in `retrorecon/mcp/config.py`, this dataclass holds configuration for the MCP server, including `api_base`, `model`, `temperature`, `row_limit`, `api_key`, `timeout`, and `alt_api_bases`.
-*   **External Server Configuration**: Support for additional FastMCP servers has been removed, so the `mcp_servers` field is unused.
+*   **External Server Configuration**: Additional FastMCP servers are defined in
+    `mcp_servers.json` (or the file specified by
+    `RETRORECON_MCP_SERVERS_FILE`).
 
 
 ## 3. External Fetch Server

--- a/docs/tools/mcp_setup_guide.md
+++ b/docs/tools/mcp_setup_guide.md
@@ -28,8 +28,10 @@ an entry in the MCP configuration.
 
 ## MCP Server Configuration Example
 
-External servers can be defined in a YAML file such as `mcp_servers.yaml`.
-Each entry specifies how the server should be launched or contacted:
+External servers are defined in a single JSON or YAML file such as
+`mcp_servers.json`. Set the path with the `RETRORECON_MCP_SERVERS_FILE`
+environment variable if needed. Each entry specifies how the server should be
+launched or contacted:
 
 ```yaml
 - name: memory

--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -18,6 +18,7 @@ class MCPConfig:
     timeout: int = 60
     alt_api_bases: list[str] = field(default_factory=list)
     mcp_servers: List[Dict[str, object]] | None = None
+    servers_file: str | None = None
 
 
 def load_config() -> MCPConfig:
@@ -59,4 +60,5 @@ def load_config() -> MCPConfig:
         timeout=timeout,
         alt_api_bases=alt_api_bases,
         mcp_servers=servers_cfg,
+        servers_file=cfg_file,
     )

--- a/secrets.example.json
+++ b/secrets.example.json
@@ -10,5 +10,6 @@
   "RETRORECON_MCP_TIMEOUT": 60,
   "RETRORECON_MCP_ALT_API_BASES": [
     "http://192.168.1.98:1234/v1"
-  ]
+  ],
+  "RETRORECON_MCP_SERVERS_FILE": "mcp_servers.json"
 }


### PR DESCRIPTION
## Summary
- add `RETRORECON_MCP_SERVERS_FILE` example to secrets config
- document centralized MCP server config in README
- clarify server file in setup and troubleshooting docs
- expose `servers_file` in MCP config dataclass

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687587260d008332ac86d38b73c37da2