### PR TITLE
Fix MCP config path and logging

### DIFF
--- a/retrorecon/routes/mcp_config.py
+++ b/retrorecon/routes/mcp_config.py
@@ -14,7 +14,10 @@ bp = Blueprint('mcp_config', __name__, url_prefix='/api/mcp')
 def _get_config_file_path() -> str:
     """Get the path to the MCP configuration file."""
     config = load_config()
-    return config.servers_file or 'mcp_servers.json'
+    path = config.servers_file or 'mcp_servers.json'
+    if not os.path.isabs(path):
+        path = os.path.join(os.getcwd(), path)
+    return path
 
 
 def _validate_server_config(server: Dict[str, Any]) -> List[str]:
@@ -124,7 +127,7 @@ def get_config():
 def update_config():
     """Update the MCP configuration."""
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True)
         if not data:
             return jsonify({'error': 'No data provided'}), 400
         

--- a/tests/test_mcp_config_api.py
+++ b/tests/test_mcp_config_api.py
@@ -153,7 +153,7 @@ class TestMCPConfigHelpers:
         mock_load_config.return_value = mock_config
         
         path = _get_config_file_path()
-        assert path == 'mcp_servers.json'
+        assert os.path.basename(path) == 'mcp_servers.json'
     
     @patch('retrorecon.routes.mcp_config.load_config')
     def test_get_config_file_path_custom(self, mock_load_config):
@@ -163,4 +163,4 @@ class TestMCPConfigHelpers:
         mock_load_config.return_value = mock_config
         
         path = _get_config_file_path()
-        assert path == 'custom_servers.json'
+        assert os.path.basename(path) == 'custom_servers.json'

--- a/tests/test_mcp_config_secrets.py
+++ b/tests/test_mcp_config_secrets.py
@@ -33,3 +33,12 @@ def test_mcp_config_from_secrets_file(monkeypatch, tmp_path):
     assert cfg.alt_api_bases == ['http://alt1.example.com/v1', 'http://alt2.example.com/v1']
 
     monkeypatch.delenv('RETRORECON_SECRETS_FILE', raising=False)
+
+
+def test_alt_api_base_missing_protocol(monkeypatch):
+    monkeypatch.setenv('RETRORECON_MCP_ALT_API_BASES', 'alt1.example.com/v1')
+    from retrorecon.mcp.config import load_config
+
+    cfg = load_config()
+    assert cfg.alt_api_bases == ['http://alt1.example.com/v1']
+    monkeypatch.delenv('RETRORECON_MCP_ALT_API_BASES', raising=False)


### PR DESCRIPTION
## Summary
- handle missing protocol in `api_base` and `alt_api_bases`
- log and resolve MCP server config path
- use silent JSON parsing in MCP config API
- adjust tests for new path behaviour
- test protocol sanitisation

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759d4a1b4483328802589eed846144