### PR TITLE
Fix JSON alt_api_bases parsing

### DIFF
--- a/tests/test_mcp_config_secrets.py
+++ b/tests/test_mcp_config_secrets.py
@@ -42,3 +42,18 @@ def test_alt_api_base_missing_protocol(monkeypatch):
     cfg = load_config()
     assert cfg.alt_api_bases == ['http://alt1.example.com/v1']
     monkeypatch.delenv('RETRORECON_MCP_ALT_API_BASES', raising=False)
+
+
+def test_alt_api_base_json_list(monkeypatch):
+    monkeypatch.setenv(
+        'RETRORECON_MCP_ALT_API_BASES',
+        '["http://alt1.example.com/v1", "http://alt2.example.com/v1"]',
+    )
+    from retrorecon.mcp.config import load_config
+
+    cfg = load_config()
+    assert cfg.alt_api_bases == [
+        'http://alt1.example.com/v1',
+        'http://alt2.example.com/v1',
+    ]
+    monkeypatch.delenv('RETRORECON_MCP_ALT_API_BASES', raising=False)


### PR DESCRIPTION
## Summary
- support alt_api_bases configured via JSON
- test JSON env var for alt_api_bases

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix frontend install`
- `npm --prefix frontend run lint`
- `python scripts/audit_css.py > /tmp/report.json`

------
https://chatgpt.com/codex/tasks/task_e_6875c027dcac8332bae8af33cace1ece