### PR TITLE
Fix alt_api_bases parsing when env var uses Python list syntax

### DIFF
--- a/retrorecon/mcp/config.py
+++ b/retrorecon/mcp/config.py
@@ -53,7 +53,21 @@ def load_config() -> MCPConfig:
             else:
                 alt_api_bases = [str(parsed)]
         except json.JSONDecodeError:
-            alt_api_bases = [b.strip() for b in alt_env.split(",") if b.strip()]
+            # Handle improperly quoted Python-style list strings
+            cleaned = alt_env.strip()
+            if cleaned.startswith("[") and cleaned.endswith("]"):
+                try:
+                    cleaned = cleaned.replace("'", '"')
+                    parsed = json.loads(cleaned)
+                    if isinstance(parsed, list):
+                        alt_api_bases = [str(b) for b in parsed]
+                    else:
+                        alt_api_bases = [str(parsed)]
+                except json.JSONDecodeError:
+                    cleaned = cleaned.strip("[]")
+                    alt_api_bases = [b.strip(" '\"") for b in cleaned.split(",") if b.strip()]
+            else:
+                alt_api_bases = [b.strip(" '\"") for b in alt_env.split(",") if b.strip()]
 
     normalized: list[str] = []
     for base in alt_api_bases:

--- a/tests/test_mcp_config_secrets.py
+++ b/tests/test_mcp_config_secrets.py
@@ -57,3 +57,18 @@ def test_alt_api_base_json_list(monkeypatch):
         'http://alt2.example.com/v1',
     ]
     monkeypatch.delenv('RETRORECON_MCP_ALT_API_BASES', raising=False)
+
+
+def test_alt_api_base_python_list_string(monkeypatch):
+    monkeypatch.setenv(
+        'RETRORECON_MCP_ALT_API_BASES',
+        "['http://alt1.example.com/v1','http://alt2.example.com/v1']",
+    )
+    from retrorecon.mcp.config import load_config
+
+    cfg = load_config()
+    assert cfg.alt_api_bases == [
+        'http://alt1.example.com/v1',
+        'http://alt2.example.com/v1',
+    ]
+    monkeypatch.delenv('RETRORECON_MCP_ALT_API_BASES', raising=False)


### PR DESCRIPTION
## Summary
- handle alt API base strings formatted like a Python list
- test the new parsing logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875dbce2ab88332aacc2e125ed05c25